### PR TITLE
chore(deps): add dependabot for gomod and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Keeps dependencies current so upgrades arrive as small, reviewable PRs
+# instead of one large jump.
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+  # The workflows pin action versions, so they need updating too.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
Weekly Dependabot updates for the two ecosystems this repo has:

- `gomod` — currently only `gopkg.in/yaml.v3`, but the catalogs make this repo long-lived
- `github-actions` — the workflows pin action versions, so they drift too

Commit prefixes follow the conventional-commit style used here (`chore(deps)`, `chore(ci)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)