### PR TITLE
feat(action): ship a GitHub Action so the linter is one uses: line

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# The action image builds with the repository root as its context, so keep the
+# things that are not needed to compile the binary out of it.
+.git
+.github
+bin/
+dist/
+coverage.txt
+# The fixtures are read from the mounted workspace when a workflow points
+# schema-location at them, never from inside the image.
+testdata/

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -1,0 +1,119 @@
+name: action
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  action:
+    # The action is used the way a consumer would use it, so a broken
+    # action.yml, Dockerfile or entrypoint fails here rather than in somebody
+    # else's workflow.
+    #
+    # Every step points schema-location at the committed fixture, for the same
+    # reason the self-lint job does: a pull request has to be checked against
+    # the schemas it carries, not against another repository's current state.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Lint the valid examples
+        id: valid
+        uses: ./
+        with:
+          files: testdata/valid
+          collector-version: v0.157.0
+          schema-location: testdata/schemas
+
+      - name: A passing run reports zero failures
+        run: |
+          test "${{ steps.valid.outputs.exit-code }}" = "0"
+          test "${{ steps.valid.outputs.valid }}" = "1"
+          test "${{ steps.valid.outputs.invalid }}" = "0"
+          test "${{ steps.valid.outputs.errors }}" = "0"
+
+      - name: Lint the invalid examples
+        id: invalid
+        continue-on-error: true
+        uses: ./
+        with:
+          files: testdata/invalid
+          collector-version: v0.157.0
+          schema-location: testdata/schemas
+          # Text, not annotations: these files are meant to be broken, and
+          # annotating them would put red marks on every pull request.
+          output: text
+
+      - name: A failing run fails the step and reports the counts
+        run: |
+          test "${{ steps.invalid.outcome }}" = "failure"
+          test "${{ steps.invalid.outputs.exit-code }}" = "1"
+          test "${{ steps.invalid.outputs.invalid }}" = "2"
+          test "${{ steps.invalid.outputs.valid }}" = "0"
+
+      - name: A rule that is turned off is not reported
+        id: disabled
+        uses: ./
+        with:
+          files: testdata/invalid/pipeline.yaml
+          collector-version: v0.157.0
+          schema-location: testdata/schemas
+          output: text
+          # Everything pipeline.yaml is invalid for, so it comes back clean.
+          disable: connector-wiring,invalid-pipeline-key,empty-pipeline
+          min-severity: error
+
+      - name: Turning the rules off makes the run pass
+        run: test "${{ steps.disabled.outputs.exit-code }}" = "0"
+
+      - name: The distribution decides what a component means
+        id: distribution
+        continue-on-error: true
+        uses: ./
+        with:
+          files: testdata/valid
+          collector-version: v0.157.0
+          # The same file, against a binary that does not carry batch,
+          # memory_limiter, debug or zpages: valid on contrib, invalid here.
+          distribution: otlp
+          schema-location: testdata/schemas
+          output: text
+
+      - name: Changing the distribution changes the verdict
+        run: |
+          test "${{ steps.distribution.outputs.exit-code }}" = "1"
+          test "${{ steps.distribution.outputs.invalid }}" = "1"
+
+      - name: A bad input is a usage error, not a lint failure
+        id: usage
+        continue-on-error: true
+        uses: ./
+        with:
+          files: testdata/valid
+          schema-location: testdata/schemas
+          disable: no-such-rule
+
+      - name: A usage error exits 2
+        run: |
+          test "${{ steps.usage.outcome }}" = "failure"
+          test "${{ steps.usage.outputs.exit-code }}" = "2"
+
+      - name: An unknown output format is a usage error as well
+        id: bad-output
+        continue-on-error: true
+        uses: ./
+        with:
+          files: testdata/valid
+          schema-location: testdata/schemas
+          output: xml
+
+      - name: A format the linter does not know exits 2
+        run: |
+          test "${{ steps.bad-output.outcome }}" = "failure"
+          test "${{ steps.bad-output.outputs.exit-code }}" = "2"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,3 +71,23 @@ jobs:
 
           echo "Creating multi-arch manifest: ${MANIFEST_TAG}"
           docker buildx imagetools create -t "${MANIFEST_TAG}" "${AMD64_IMAGE}" "${ARM64_IMAGE}"
+
+  major-tag:
+    # Actions convention: `uses: minuk-dev/otelcol-config-lint@v1` has to follow
+    # the newest v1.x.y, so the major tag is moved once the release succeeded.
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Move the major tag to this release
+        run: |
+          major="${GITHUB_REF_NAME%%.*}"
+          echo "Moving ${major} to ${GITHUB_REF_NAME}"
+          git tag -f "${major}" "${GITHUB_REF_NAME}"
+          git push -f origin "refs/tags/${major}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# The image behind action.yml. It sits at the repository root because a
+# container action builds with the Dockerfile's own directory as the context,
+# and this build needs the whole source tree; build/docker/Dockerfile is the
+# separate distroless image that releases publish.
+#
+# Unlike that one this image needs a shell, so the entrypoint can turn the
+# action's inputs into flags and report the counts back as step outputs.
+FROM golang:1.25-alpine AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /out/otelcol-config-lint ./cmd/otelcol-config-lint
+
+FROM alpine:3.22
+
+# bash for the entrypoint's arrays, jq to read the summary out of the report,
+# and the CA bundle because schemas are fetched from the published registry
+# over HTTPS unless the workflow points schema-location somewhere local.
+RUN apk add --no-cache bash jq ca-certificates
+
+COPY --from=build /out/otelcol-config-lint /usr/local/bin/otelcol-config-lint
+COPY build/docker/action-entrypoint.sh /usr/local/bin/action-entrypoint
+
+WORKDIR /github/workspace
+
+ENTRYPOINT ["/usr/local/bin/action-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,50 @@ docker run --rm -v "$PWD:/workspace" \
 Tagged releases publish binaries for Linux, macOS and Windows on amd64 and
 arm64, plus a multi-arch image on ghcr.io.
 
+## GitHub Action
+
+In a workflow it is one `uses:` line — no Go toolchain, no install step:
+
+```yaml
+- uses: minuk-dev/otelcol-config-lint@v1
+  with:
+    files: ./configs
+    collector-version: v0.157.0
+    strict: true
+```
+
+Findings land as inline pull-request annotations, because the action defaults to
+`--output github`. The step passes when everything is valid, fails when a file
+is invalid, and reports a usage error — a rule that does not exist, an unreadable
+settings file — distinctly, with exit code 2.
+
+Every input is the `run` flag of the same name, so the flag table below is the
+whole reference: `files` (default `.`, whitespace-separated, globs allowed),
+`collector-version`, `distribution`, `schema-location` (one per line to search
+several in order), `strict`, `ignore-missing-schemas`, `min-severity`,
+`fail-on`, `disable`, `severity`, `exclude`, `output` (default `github`),
+`config`, `summary` (default `true`), `verbose` and `exit-on-error`. Only `-n`
+and `--no-color` are left out: a runner gains nothing from either.
+
+The counts come back as outputs — `exit-code`, `valid`, `invalid`, `errors`,
+`skipped`, `warnings` and `infos` — so a later step can decide what to do with
+them:
+
+```yaml
+- uses: minuk-dev/otelcol-config-lint@v1
+  id: lint
+  continue-on-error: true
+  with:
+    files: ./configs
+    fail-on: warning
+- run: echo "${{ steps.lint.outputs.invalid }} file(s) failed"
+```
+
+`@v1` follows the newest v1 release. Pin a full tag such as `@v1.2.3` to hold a
+workflow to one revision of the linter. The schemas are a separate registry that
+tracks its own main, so pin `schema-location` as well — at a vendored directory,
+or at a tagged URL — for a run that cannot change underneath a workflow.
+
 ## Usage
 
 ```
@@ -259,6 +303,7 @@ pkg/schema/                   schema types, version resolution and location look
 pkg/rule/                     the rules and the registry
 pkg/lint/                     the engine and the output formatters
 pkg/diag/                     diagnostics, severities and positions
+action.yml                    the GitHub Action; Dockerfile is the image it runs
 ```
 
 ## Development
@@ -272,5 +317,6 @@ make schemas VERSIONS=v0.158.0
 ```
 
 CI runs the tests with coverage reported on the pull request, builds every
-release target, lints this repository's own example configs, and publishes
-binaries and container images from tags.
+release target, lints this repository's own example configs, exercises the
+action against `testdata/`, and publishes binaries and container images from
+tags.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,121 @@
+name: otelcol-config-lint
+description: >-
+  Lint OpenTelemetry Collector config files against a specific collector
+  release, with findings as inline pull-request annotations.
+author: minuk-dev
+
+branding:
+  icon: check-square
+  color: purple
+
+# Every input maps onto the "run" flag of the same name, so there is nothing new
+# to learn: the CLI documentation is the action documentation. Only -n and
+# --no-color are left out; a runner has nothing to gain from either.
+inputs:
+  files:
+    description: Files, directories or globs to check, separated by spaces or newlines.
+    required: false
+    default: "."
+  collector-version:
+    description: Collector release to validate against, e.g. v0.157.0.
+    required: false
+    default: latest
+  distribution:
+    description: "Collector distribution to validate against: core, contrib, k8s or otlp."
+    required: false
+    default: contrib
+  schema-location:
+    description: >-
+      Where to find schemas: a registry directory or URL, a {{.Version}} /
+      {{.Distribution}} template, or "default". One per line to search several
+      in order.
+    required: false
+    default: ""
+  strict:
+    description: Report unknown component settings as errors.
+    required: false
+    default: "false"
+  ignore-missing-schemas:
+    description: Do not fail on components missing from the schema.
+    required: false
+    default: "false"
+  min-severity:
+    description: "Lowest severity to report: error, warning or info."
+    required: false
+    default: info
+  fail-on:
+    description: "Severity that makes a file invalid: error, warning or info."
+    required: false
+    default: error
+  disable:
+    description: Comma-separated rules to turn off.
+    required: false
+    default: ""
+  severity:
+    description: Comma-separated rule=level overrides, e.g. missing-batch=warning.
+    required: false
+    default: ""
+  exclude:
+    description: Comma-separated glob patterns to skip when walking directories.
+    required: false
+    default: ""
+  output:
+    description: "Output format: text, json, junit, tap or github."
+    required: false
+    default: github
+  config:
+    description: Settings file to read (default .otelcol-config-lint.yaml if present).
+    required: false
+    default: ""
+  summary:
+    description: Append a count of the outcomes to the output.
+    required: false
+    default: "true"
+  verbose:
+    description: Also report the files that passed.
+    required: false
+    default: "false"
+  exit-on-error:
+    description: Stop at the first file that fails.
+    required: false
+    default: "false"
+
+outputs:
+  exit-code:
+    description: "0 every file passed, 1 at least one file failed, 2 the command could not run."
+  valid:
+    description: Number of files that passed.
+  invalid:
+    description: Number of files that failed.
+  errors:
+    description: Number of files that could not be read or parsed.
+  skipped:
+    description: Number of files that were skipped.
+  warnings:
+    description: Number of warnings reported.
+  infos:
+    description: Number of infos reported.
+
+# The image is built from this repository, so the action and the linter it runs
+# are always the same revision: a workflow pinned to @v1 cannot drift.
+runs:
+  using: docker
+  image: Dockerfile
+  # Passed as --name=value so the entrypoint does not depend on their order.
+  args:
+    - --files=${{ inputs.files }}
+    - --collector-version=${{ inputs.collector-version }}
+    - --distribution=${{ inputs.distribution }}
+    - --schema-location=${{ inputs.schema-location }}
+    - --strict=${{ inputs.strict }}
+    - --ignore-missing-schemas=${{ inputs.ignore-missing-schemas }}
+    - --min-severity=${{ inputs.min-severity }}
+    - --fail-on=${{ inputs.fail-on }}
+    - --disable=${{ inputs.disable }}
+    - --severity=${{ inputs.severity }}
+    - --exclude=${{ inputs.exclude }}
+    - --output=${{ inputs.output }}
+    - --config=${{ inputs.config }}
+    - --summary=${{ inputs.summary }}
+    - --verbose=${{ inputs.verbose }}
+    - --exit-on-error=${{ inputs.exit-on-error }}

--- a/build/docker/action-entrypoint.sh
+++ b/build/docker/action-entrypoint.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# Entrypoint for the otelcol-config-lint GitHub Action.
+#
+# Turns the action's inputs into "otelcol-config-lint run" flags, publishes the
+# summary counts as step outputs, and exits with the linter's own exit code so
+# the step fails on 1 and reports a usage error distinctly on 2.
+
+set -euo pipefail
+
+in_files="."
+in_collector_version=""
+in_distribution=""
+in_schema_location=""
+in_strict="false"
+in_ignore_missing_schemas="false"
+in_min_severity=""
+in_fail_on=""
+in_disable=""
+in_severity=""
+in_exclude=""
+in_output="github"
+in_config=""
+in_summary="true"
+in_verbose="false"
+in_exit_on_error="false"
+
+# Inputs arrive as --name=value, one per input declared in action.yml, so the
+# script does not depend on the order action.yml lists them in.
+for arg in "$@"; do
+  if [ "${arg#*=}" = "${arg}" ]; then
+    echo "::error title=otelcol-config-lint::unexpected argument ${arg}"
+    exit 2
+  fi
+
+  name="${arg%%=*}"
+  value="${arg#*=}"
+
+  case "${name}" in
+    --files) in_files="${value:-.}" ;;
+    --collector-version) in_collector_version="${value}" ;;
+    --distribution) in_distribution="${value}" ;;
+    --schema-location) in_schema_location="${value}" ;;
+    --strict) in_strict="${value}" ;;
+    --ignore-missing-schemas) in_ignore_missing_schemas="${value}" ;;
+    --min-severity) in_min_severity="${value}" ;;
+    --fail-on) in_fail_on="${value}" ;;
+    --disable) in_disable="${value}" ;;
+    --severity) in_severity="${value}" ;;
+    --exclude) in_exclude="${value}" ;;
+    --output) in_output="${value:-github}" ;;
+    --config) in_config="${value}" ;;
+    --summary) in_summary="${value}" ;;
+    --verbose) in_verbose="${value}" ;;
+    --exit-on-error) in_exit_on_error="${value}" ;;
+    *)
+      echo "::error title=otelcol-config-lint::unexpected argument ${arg}"
+      exit 2
+      ;;
+  esac
+done
+
+flags=()
+
+# value <flag> <input>: pass the flag only when the input was given, so the
+# linter's own defaults stay in charge of everything left blank.
+value() {
+  if [ -n "$2" ]; then
+    flags+=("--$1" "$2")
+  fi
+}
+
+# toggle <flag> <input>: boolean inputs arrive as the strings true and false.
+toggle() {
+  if [ "$2" = "true" ]; then
+    flags+=("--$1")
+  fi
+}
+
+value collector-version "${in_collector_version}"
+value distribution "${in_distribution}"
+value min-severity "${in_min_severity}"
+value fail-on "${in_fail_on}"
+value disable "${in_disable}"
+value severity "${in_severity}"
+value exclude "${in_exclude}"
+value config "${in_config}"
+toggle strict "${in_strict}"
+toggle ignore-missing-schemas "${in_ignore_missing_schemas}"
+toggle verbose "${in_verbose}"
+toggle exit-on-error "${in_exit_on_error}"
+
+# --schema-location is repeatable: one location per line, searched in order.
+while IFS= read -r location; do
+  location="${location#"${location%%[![:space:]]*}"}"
+  location="${location%"${location##*[![:space:]]}"}"
+
+  if [ -n "${location}" ]; then
+    flags+=(--schema-location "${location}")
+  fi
+done <<<"${in_schema_location}"
+
+# Deliberately unquoted: files are separated by whitespace, and a glob such as
+# configs/*.yaml is expanded here, against the workspace.
+# shellcheck disable=SC2206
+files=(${in_files})
+if [ ${#files[@]} -eq 0 ]; then
+  files=(.)
+fi
+
+# The counts come from the JSON report whatever format the caller asked for, so
+# it is written to a file first and the requested format rendered afterwards.
+# The second pass re-reads the schema, from the registry over the network when
+# no --schema-location is given; one schema for one release is a small download,
+# and it buys the same numbers whichever format was asked for.
+report="${TMPDIR:-/tmp}/otelcol-config-lint.json"
+
+code=0
+otelcol-config-lint run "${flags[@]}" --output json "${files[@]}" >"${report}" || code=$?
+
+# A run that never produced a report -- a usage error -- still has to report a
+# number, so anything unreadable counts as zero.
+count() {
+  local n
+  n="$(jq -r ".summary.$1 // 0" "${report}" 2>/dev/null || true)"
+
+  if [ -z "${n}" ] || [ "${n}" = "null" ]; then
+    n=0
+  fi
+
+  printf '%s\n' "${n}"
+}
+
+emit_outputs() {
+  if [ -z "${GITHUB_OUTPUT:-}" ]; then
+    return
+  fi
+
+  {
+    echo "exit-code=$1"
+    echo "valid=$(count valid)"
+    echo "invalid=$(count invalid)"
+    echo "errors=$(count errors)"
+    echo "skipped=$(count skipped)"
+    echo "warnings=$(count warnings)"
+    echo "infos=$(count infos)"
+  } >>"${GITHUB_OUTPUT}"
+}
+
+# Exit code 2 means the run never happened -- the linter has already said why on
+# stderr, and rendering it a second time would only repeat the message.
+if [ "${code}" -eq 2 ]; then
+  emit_outputs 2
+  echo "::error title=otelcol-config-lint::the command could not run; check the action's inputs"
+  exit 2
+fi
+
+if [ "${in_output}" = "json" ]; then
+  emit_outputs "${code}"
+  cat "${report}"
+  exit "${code}"
+fi
+
+if [ "${in_summary}" = "true" ]; then
+  flags+=(--summary)
+fi
+
+# The findings themselves. Only a usage error can differ from the pass above --
+# an output format the linter does not know -- and that has to fail the step
+# rather than be swallowed, or "output: xml" would silently report nothing.
+render=0
+otelcol-config-lint run "${flags[@]}" --output "${in_output}" "${files[@]}" || render=$?
+
+if [ "${render}" -eq 2 ]; then
+  emit_outputs 2
+  echo "::error title=otelcol-config-lint::the command could not run; check the action's inputs"
+  exit 2
+fi
+
+emit_outputs "${code}"
+
+exit "${code}"


### PR DESCRIPTION
Closes #7.

A workflow that lints collector configs is now one `uses:` line:

```yaml
- uses: minuk-dev/otelcol-config-lint@v1
  with:
    files: ./configs
    collector-version: v0.157.0
    distribution: contrib
    strict: true
```

## What is here

- **`action.yml`** — one input per `run` flag (`files`, `collector-version`, `distribution`, `schema-location`, `strict`, `ignore-missing-schemas`, `min-severity`, `fail-on`, `disable`, `severity`, `exclude`, `output`, `config`, `summary`, `verbose`, `exit-on-error`), each defaulting to the CLI default, so the flag table in the README is the whole reference. Only `-n` and `--no-color` are left out: a runner gains nothing from either. `output` defaults to `github`, so annotations appear with no configuration.
- **Outputs** — `exit-code`, `valid`, `invalid`, `errors`, `skipped`, `warnings`, `infos`, read from the JSON report so they are the same numbers whatever format was rendered.
- **Exit codes** — 0 passes, 1 fails the step, 2 fails it with `::error::the command could not run; check the action's inputs`, so a typo in `disable:` does not read as a broken config.
- **`Dockerfile` + `build/docker/action-entrypoint.sh`** — the image the action runs. The entrypoint turns inputs into flags, writes the outputs and exits with the linter's own code.
- **`.github/workflows/action.yaml`** — the action used the way a consumer uses it: `testdata/valid` (1 valid, exit 0), `testdata/invalid` (the step fails with 2 invalid), the same valid file under `distribution: otlp` (invalid, because that binary carries none of its processors), `testdata/invalid/pipeline.yaml` with those rules disabled (a pass), a bad `disable:` value and an unknown `output:` (both exit 2). The invalid runs use `output: text` so broken-on-purpose fixtures do not put red annotations on every PR.
- **`release.yaml`** — moves `v1` to the newest `v1.x.y` after a successful release, per the Actions convention.

## Rebased onto main

The CLI moved under a `run` subcommand with cobra long flags while this sat open, and catalogs became schemas, so the action was rewritten to match rather than merely merged:

- `otelcol-config-lint <flags>` → `otelcol-config-lint run --<flags>`.
- `catalog-location` → `schema-location`.
- `distribution` is now an input. It was left out originally because the flag did not exist; #33 landed it, so the README's "every input is the flag of the same name" is true again. CI asserts it takes effect rather than merely parsing: `testdata/valid/agent.yaml` is valid on contrib and invalid on otlp.
- `verbose` and `exit-on-error` are exposed for the same reason.

Two things the rebase exposed, fixed here:

- **The image needs a CA bundle.** Schemas are fetched from the published registry over HTTPS now, not embedded, and `apk add bash jq` on alpine does not guarantee one.
- **An unknown `output:` was swallowed.** The entrypoint runs the linter twice — JSON for the counts, then the requested format — and the second run's failure was discarded with `|| true`, so `output: xml` would have passed the step having printed nothing. It now reports exit 2 like any other usage error.

CI also points `schema-location` at the committed `testdata/schemas`, matching the self-lint job: a pull request has to be checked against the schemas it carries, not against another repository's current state.

## Two decisions worth review

**The image is built from the repository, not pulled from ghcr.io.** The issue proposed a Docker action against the published image. There are still no tags, so no `:v1` or `:latest` exists to pin to — and a `docker://` action cannot map inputs to flags or write outputs, because the release image is distroless and has no shell. Building from source keeps the action and the linter it runs on the same revision, which is the property the issue wanted from pinning: `@v1` cannot silently change behaviour. The cost is a build on the runner (Go build of one package, layer-cached). Switching the builder stage to `FROM ghcr.io/minuk-dev/otelcol-config-lint:<tag>` once a release exists is a follow-up — filed separately.

The Dockerfile sits at the repository root because a container action builds with the Dockerfile's own directory as its build context, and this build needs the source tree. `build/docker/Dockerfile` is untouched and remains the distroless image releases publish.

**`@v1` does not pin the schemas.** The registry tracks its own main by design, so a tag pins the linter but not what it validates against. The README now says so, and points at `schema-location` for a workflow that needs a run that cannot change underneath it.

## Not in this PR

Marketplace publishing and creating the first `v1` tag are release actions, not code.

## Verified

`go test ./...` passes. The entrypoint was exercised locally against `testdata/` for every path — pass, fail, `distribution: otlp`, disabled rules, an unknown rule, an unknown output format, JSON output, multi-line `schema-location`, a globbed `files`, an empty `files` — checking the step outputs each time. Docker was not available locally, so the image build and the annotations are first checked by this PR's own `action` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
