### PR TITLE
refactor: add pkg/sets and pkg/scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,10 @@ between releases. Components without an overlay are simply not field-checked.
 ## Layout
 
 ```
-cmd/otelcol-config-lint/  the entry point
-pkg/cmd/otelcol-config-lint/  the cobra command: flags, file discovery, settings files
+cmd/otelcol-config-lint/      the entry point
+pkg/cmd/otelcol-config-lint/  the cobra command: flags, settings files, reporting
+pkg/scanner/              expands the given paths into the files to lint
+pkg/sets/                 a set built on a map, in the shape of k8s.io/apimachinery
 pkg/config/               YAML parsing that keeps positions, so findings have line numbers
 pkg/catalog/              catalog types, version resolution and location lookup
 pkg/rule/                 the rules and the registry

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -251,7 +251,7 @@ func (o *Options) runLint(cmd *cobra.Command, paths []string) error {
 		return err
 	}
 
-	if len(files) == 0 {
+	if files.Len() == 0 {
 		return fmt.Errorf("%w in %s", ErrNoYAMLFiles, strings.Join(paths, ", "))
 	}
 
@@ -277,37 +277,33 @@ func (o *Options) runLint(cmd *cobra.Command, paths []string) error {
 	return nil
 }
 
-// lintAll checks every file and reports the results in argument order,
-// returning ErrFilesInvalid when the gate was not met.
+// stdinMarker is the argument that asks for the config on standard input.
+const stdinMarker = "-"
+
+// lintAll checks every file and reports the results in path order, returning
+// ErrFilesInvalid when the gate was not met.
 func (o *Options) lintAll(
 	cmd *cobra.Command,
 	linter *lint.Linter,
 	formatter lint.Formatter,
-	files []string,
+	files sets.Set[string],
 ) error {
 	var summary lint.Summary
 
-	// Results are buffered so output stays in file order even though the files
+	// Results are buffered so output stays in path order even though the files
 	// are checked concurrently.
-	results := make(map[string]lint.Result, len(files))
+	results := make(map[string]lint.Result, files.Len())
 
-	var toLint []string
-
-	for _, f := range files {
-		if f == "-" {
-			results[f] = linter.LintReader("stdin", cmd.InOrStdin())
-
-			continue
-		}
-
-		toLint = append(toLint, f)
+	if files.Has(stdinMarker) {
+		results[stdinMarker] = linter.LintReader("stdin", cmd.InOrStdin())
 	}
 
-	for r := range linter.LintAll(toLint, o.workers) {
+	onDisk := sets.List(files.Difference(sets.New(stdinMarker)))
+	for r := range linter.LintAll(onDisk, o.workers) {
 		results[r.Path] = r
 	}
 
-	for _, f := range files {
+	for _, f := range sets.List(files) {
 		r := results[f]
 
 		summary.Add(r)
@@ -579,23 +575,16 @@ func isConfigExt(ext string) bool {
 	return ext == ".yaml" || ext == ".yml"
 }
 
-// collect expands the command line arguments into a list of files to lint.
-// Directories are walked recursively; "-" is kept as a marker for stdin.
-func collect(args []string, exclude []string) ([]string, error) {
-	var out []string
-
-	// The same file can be named twice, or named and also walked into. Keep
-	// the first mention, so the report follows the order of the arguments.
-	seen := sets.New[string]()
-	add := func(p string) {
-		if seen.InsertNew(p) {
-			out = append(out, p)
-		}
-	}
+// collect expands the command line arguments into the files to lint.
+// Directories are walked recursively; "-" is kept as a marker for stdin. The
+// same file can be named twice, or named and also walked into, so the result
+// is a set. It carries no order: that is the reporting side's decision.
+func collect(args []string, exclude []string) (sets.Set[string], error) {
+	files := sets.New[string]()
 
 	for _, arg := range args {
-		if arg == "-" {
-			add("-")
+		if arg == stdinMarker {
+			files.Insert(stdinMarker)
 
 			continue
 		}
@@ -608,7 +597,7 @@ func collect(args []string, exclude []string) ([]string, error) {
 		if !info.IsDir() {
 			// An explicitly named file is linted even if it would be excluded
 			// by a directory walk, matching how other linters behave.
-			add(filepath.Clean(arg))
+			files.Insert(filepath.Clean(arg))
 
 			continue
 		}
@@ -635,7 +624,7 @@ func collect(args []string, exclude []string) ([]string, error) {
 				return nil
 			}
 
-			add(filepath.Clean(path))
+			files.Insert(filepath.Clean(path))
 
 			return nil
 		})
@@ -644,7 +633,7 @@ func collect(args []string, exclude []string) ([]string, error) {
 		}
 	}
 
-	return out, nil
+	return files, nil
 }
 
 // excluded reports whether a path matches any exclude pattern. Patterns are

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/lint"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
 )
 
 // Version is the linter's own version.
@@ -566,7 +566,7 @@ func (o *Options) applySettings(s *settings, changed func(name string) bool) {
 
 	if len(s.Severity) > 0 {
 		pairs := make([]string, 0, len(s.Severity))
-		for _, name := range sortedKeys(s.Severity) {
+		for _, name := range sets.List(sets.KeySet(s.Severity)) {
 			pairs = append(pairs, name+"="+s.Severity[name])
 		}
 		// Later pairs win, so file overrides are listed first.
@@ -584,10 +584,11 @@ func isConfigExt(ext string) bool {
 func collect(args []string, exclude []string) ([]string, error) {
 	var out []string
 
-	seen := map[string]bool{}
+	// The same file can be named twice, or named and also walked into. Keep
+	// the first mention, so the report follows the order of the arguments.
+	seen := sets.New[string]()
 	add := func(p string) {
-		if !seen[p] {
-			seen[p] = true
+		if seen.InsertNew(p) {
 			out = append(out, p)
 		}
 	}
@@ -712,17 +713,6 @@ func joinList(a, b string) string {
 	default:
 		return a + "," + b
 	}
-}
-
-func sortedKeys[V any](m map[string]V) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-
-	sort.Strings(out)
-
-	return out
 }
 
 func defaultWorkers() int {

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"text/tabwriter"
@@ -22,6 +21,7 @@ import (
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/lint"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/scanner"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
 )
 
@@ -246,9 +246,9 @@ func (o *Options) Run(cmd *cobra.Command, args []string) error {
 
 // runLint resolves what to check and how to report it, then does the work.
 func (o *Options) runLint(cmd *cobra.Command, paths []string) error {
-	files, err := collect(paths, splitList(o.exclude))
+	files, err := scanner.New(splitList(o.exclude)).Scan(paths)
 	if err != nil {
-		return err
+		return fmt.Errorf("collect files: %w", err)
 	}
 
 	if files.Len() == 0 {
@@ -277,9 +277,6 @@ func (o *Options) runLint(cmd *cobra.Command, paths []string) error {
 	return nil
 }
 
-// stdinMarker is the argument that asks for the config on standard input.
-const stdinMarker = "-"
-
 // lintAll checks every file and reports the results in path order, returning
 // ErrFilesInvalid when the gate was not met.
 func (o *Options) lintAll(
@@ -294,11 +291,11 @@ func (o *Options) lintAll(
 	// are checked concurrently.
 	results := make(map[string]lint.Result, files.Len())
 
-	if files.Has(stdinMarker) {
-		results[stdinMarker] = linter.LintReader("stdin", cmd.InOrStdin())
+	if files.Has(scanner.StdinMarker) {
+		results[scanner.StdinMarker] = linter.LintReader("stdin", cmd.InOrStdin())
 	}
 
-	onDisk := sets.List(files.Difference(sets.New(stdinMarker)))
+	onDisk := sets.List(files.Difference(sets.New(scanner.StdinMarker)))
 	for r := range linter.LintAll(onDisk, o.workers) {
 		results[r.Path] = r
 	}
@@ -568,93 +565,6 @@ func (o *Options) applySettings(s *settings, changed func(name string) bool) {
 		// Later pairs win, so file overrides are listed first.
 		o.severity = joinList(strings.Join(pairs, ","), o.severity)
 	}
-}
-
-// isConfigExt reports whether a file extension is one a directory walk picks up.
-func isConfigExt(ext string) bool {
-	return ext == ".yaml" || ext == ".yml"
-}
-
-// collect expands the command line arguments into the files to lint.
-// Directories are walked recursively; "-" is kept as a marker for stdin. The
-// same file can be named twice, or named and also walked into, so the result
-// is a set. It carries no order: that is the reporting side's decision.
-func collect(args []string, exclude []string) (sets.Set[string], error) {
-	files := sets.New[string]()
-
-	for _, arg := range args {
-		if arg == stdinMarker {
-			files.Insert(stdinMarker)
-
-			continue
-		}
-
-		info, err := os.Stat(arg)
-		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", arg, err)
-		}
-
-		if !info.IsDir() {
-			// An explicitly named file is linted even if it would be excluded
-			// by a directory walk, matching how other linters behave.
-			files.Insert(filepath.Clean(arg))
-
-			continue
-		}
-
-		err = filepath.WalkDir(arg, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-
-			name := d.Name()
-			if d.IsDir() {
-				if path != arg && (strings.HasPrefix(name, ".") || name == "vendor" || name == "node_modules") {
-					return fs.SkipDir
-				}
-
-				return nil
-			}
-
-			if !isConfigExt(strings.ToLower(filepath.Ext(name))) {
-				return nil
-			}
-
-			if excluded(path, exclude) {
-				return nil
-			}
-
-			files.Insert(filepath.Clean(path))
-
-			return nil
-		})
-		if err != nil {
-			return nil, fmt.Errorf("walk %s: %w", arg, err)
-		}
-	}
-
-	return files, nil
-}
-
-// excluded reports whether a path matches any exclude pattern. Patterns are
-// matched against both the full path and the base name.
-func excluded(path string, patterns []string) bool {
-	base := filepath.Base(path)
-	for _, p := range patterns {
-		if ok, _ := filepath.Match(p, base); ok {
-			return true
-		}
-
-		if ok, _ := filepath.Match(p, path); ok {
-			return true
-		}
-
-		if strings.Contains(path, strings.Trim(p, "*")) && strings.Contains(p, "*") {
-			return true
-		}
-	}
-
-	return false
 }
 
 // columns renders aligned help output for --list-rules and --list-versions.

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -14,8 +15,9 @@ import (
 )
 
 const (
-	validConfig = "../../../testdata/valid"
-	badConfig   = "../../../testdata/invalid/typos.yaml"
+	validConfig   = "../../../testdata/valid"
+	badConfig     = "../../../testdata/invalid/typos.yaml"
+	invalidConfig = "../../../testdata/invalid"
 )
 
 // run executes the command and returns its exit code and streams. The wiring
@@ -489,5 +491,44 @@ func TestSummaryCountsFiles(t *testing.T) {
 	_, out, _ := run(t, "", "--summary", "--min-severity", "error", validConfig, badConfig)
 	if !strings.Contains(out, "2 file(s) checked, 1 valid, 1 invalid") {
 		t.Errorf("unexpected summary:\n%s", out)
+	}
+}
+
+// TestAFileNamedTwiceIsCheckedOnce pins that naming a file directly and also
+// walking into the directory holding it does not check it twice.
+func TestAFileNamedTwiceIsCheckedOnce(t *testing.T) {
+	t.Parallel()
+
+	_, out, _ := run(t, "", "--summary", "--min-severity", "error",
+		validConfig, filepath.Join(validConfig, "agent.yaml"))
+	if !strings.Contains(out, "1 file(s) checked") {
+		t.Errorf("the file should have been de-duplicated:\n%s", out)
+	}
+}
+
+// TestReportOrderDoesNotDependOnArgumentOrder pins that results come out in
+// path order, so the same set of files reads the same however it was named.
+func TestReportOrderDoesNotDependOnArgumentOrder(t *testing.T) {
+	t.Parallel()
+
+	_, forwards, _ := run(t, "", "--output", "tap", validConfig, invalidConfig)
+	_, backwards, _ := run(t, "", "--output", "tap", invalidConfig, validConfig)
+
+	if forwards != backwards {
+		t.Errorf("argument order changed the report:\n%s\nvs\n%s", forwards, backwards)
+	}
+
+	// The paths themselves must be sorted, not merely stable.
+	var got []string
+
+	for line := range strings.SplitSeq(forwards, "\n") {
+		_, path, found := strings.Cut(line, " - ")
+		if found {
+			got = append(got, path)
+		}
+	}
+
+	if !slices.IsSorted(got) {
+		t.Errorf("results are not in path order: %v", got)
 	}
 }

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,0 +1,141 @@
+// Package scanner expands the paths named on a command line into the set of
+// config files to lint.
+package scanner
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
+)
+
+// StdinMarker is the path that asks for the config on standard input. A Scanner
+// passes it through untouched, for the caller to recognise.
+const StdinMarker = "-"
+
+// Scanner turns paths into the files to lint.
+type Scanner struct {
+	// Exclude are glob patterns skipped during a directory walk, matched
+	// against both the full path and the base name. A pattern containing "*"
+	// also matches anywhere in the path.
+	Exclude []string
+	// Extensions are the file extensions a directory walk picks up, compared
+	// in lower case and including the dot.
+	Extensions []string
+	// SkipDirs are directory names a walk does not descend into. Directories
+	// whose name starts with a dot are always skipped.
+	SkipDirs []string
+}
+
+// New builds a Scanner that picks up YAML files, does not descend into the
+// usual vendored directories, and skips anything matching exclude.
+func New(exclude []string) *Scanner {
+	return &Scanner{
+		Exclude:    exclude,
+		Extensions: []string{".yaml", ".yml"},
+		SkipDirs:   []string{"vendor", "node_modules"},
+	}
+}
+
+// Scan expands paths into the files to lint. Directories are walked
+// recursively and StdinMarker is passed through. The same file can be named
+// twice, or named and also walked into, so the result is a set: it holds each
+// file once and carries no order.
+func (s *Scanner) Scan(paths []string) (sets.Set[string], error) {
+	files := sets.New[string]()
+
+	for _, path := range paths {
+		if path == StdinMarker {
+			files.Insert(StdinMarker)
+
+			continue
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+
+		if !info.IsDir() {
+			// An explicitly named file is linted even if it would be excluded
+			// by a directory walk, matching how other linters behave.
+			files.Insert(filepath.Clean(path))
+
+			continue
+		}
+
+		err = s.walk(path, files)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return files, nil
+}
+
+// walk adds every config file under root to files.
+func (s *Scanner) walk(root string, files sets.Set[string]) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if path != root && s.skipDir(d.Name()) {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
+		if !s.wanted(d.Name()) || s.excluded(path) {
+			return nil
+		}
+
+		files.Insert(filepath.Clean(path))
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walk %s: %w", root, err)
+	}
+
+	return nil
+}
+
+// skipDir reports whether a walk should stay out of a directory.
+func (s *Scanner) skipDir(name string) bool {
+	return strings.HasPrefix(name, ".") || slices.Contains(s.SkipDirs, name)
+}
+
+// wanted reports whether a file name has an extension the walk picks up.
+func (s *Scanner) wanted(name string) bool {
+	return slices.Contains(s.Extensions, strings.ToLower(filepath.Ext(name)))
+}
+
+// excluded reports whether a path matches any exclude pattern. Patterns are
+// matched against both the full path and the base name.
+func (s *Scanner) excluded(path string) bool {
+	base := filepath.Base(path)
+	for _, pattern := range s.Exclude {
+		if ok, _ := filepath.Match(pattern, base); ok {
+			return true
+		}
+
+		if ok, _ := filepath.Match(pattern, path); ok {
+			return true
+		}
+
+		// A pattern with a star also matches anywhere in the path, so
+		// "*generated*" reaches files a plain glob would not.
+		if strings.Contains(pattern, "*") && strings.Contains(path, strings.Trim(pattern, "*")) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -1,0 +1,313 @@
+package scanner_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/scanner"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
+)
+
+// tree writes each named file under a fresh temporary directory and returns it.
+func tree(t *testing.T, names ...string) string {
+	t.Helper()
+
+	root := t.TempDir()
+
+	for _, name := range names {
+		path := filepath.Join(root, filepath.FromSlash(name))
+
+		err := os.MkdirAll(filepath.Dir(path), 0o750)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = os.WriteFile(path, []byte("receivers:\n"), 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return root
+}
+
+// relative turns the scan result back into slash-separated paths under root, so
+// the assertions read like the tree that was written.
+func relative(t *testing.T, root string, files sets.Set[string]) []string {
+	t.Helper()
+
+	out := make([]string, 0, files.Len())
+
+	for _, path := range sets.List(files) {
+		if path == scanner.StdinMarker {
+			out = append(out, path)
+
+			continue
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out = append(out, filepath.ToSlash(rel))
+	}
+
+	return out
+}
+
+func TestScanWalksADirectory(t *testing.T) {
+	t.Parallel()
+
+	root := tree(t, "a.yaml", "b.yml", "nested/c.yaml", "notes.txt", "no-extension")
+
+	files, err := scanner.New(nil).Scan([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := relative(t, root, files)
+	if want := []string{"a.yaml", "b.yml", "nested/c.yaml"}; !slices.Equal(got, want) {
+		t.Errorf("Scan() = %v, want %v", got, want)
+	}
+}
+
+func TestScanIsCaseInsensitiveAboutExtensions(t *testing.T) {
+	t.Parallel()
+
+	root := tree(t, "loud.YAML", "mixed.Yml")
+
+	files, err := scanner.New(nil).Scan([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if files.Len() != 2 {
+		t.Errorf("Scan() found %v, want both files", relative(t, root, files))
+	}
+}
+
+func TestScanSkipsDotAndVendorDirectories(t *testing.T) {
+	t.Parallel()
+
+	root := tree(t,
+		"keep.yaml",
+		".git/config.yaml",
+		"vendor/dep.yaml",
+		"node_modules/pkg.yaml",
+		"nested/.hidden/deep.yaml",
+	)
+
+	files, err := scanner.New(nil).Scan([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := relative(t, root, files)
+	if want := []string{"keep.yaml"}; !slices.Equal(got, want) {
+		t.Errorf("Scan() = %v, want %v", got, want)
+	}
+}
+
+// TestScanEntersADotDirectoryNamedDirectly pins that the skip applies to what a
+// walk descends into, not to the root the caller asked for.
+func TestScanEntersADotDirectoryNamedDirectly(t *testing.T) {
+	t.Parallel()
+
+	root := tree(t, ".config/app.yaml")
+
+	files, err := scanner.New(nil).Scan([]string{filepath.Join(root, ".config")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := relative(t, root, files)
+	if want := []string{".config/app.yaml"}; !slices.Equal(got, want) {
+		t.Errorf("Scan() = %v, want %v", got, want)
+	}
+}
+
+func TestScanExcludePatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		exclude []string
+		want    []string
+	}{
+		"nothing excluded": {
+			exclude: nil,
+			want:    []string{"agent.yaml", "gen/agent.generated.yaml", "keep.yaml"},
+		},
+		"by base name": {
+			exclude: []string{"agent.yaml"},
+			want:    []string{"gen/agent.generated.yaml", "keep.yaml"},
+		},
+		"by glob on the base name": {
+			exclude: []string{"*.generated.yaml"},
+			want:    []string{"agent.yaml", "keep.yaml"},
+		},
+		"a starred pattern matches anywhere in the path": {
+			exclude: []string{"*generated*"},
+			want:    []string{"agent.yaml", "keep.yaml"},
+		},
+		// The stars are stripped and what is left is matched as a substring,
+		// so a short pattern reaches further than it looks: "gen" is inside
+		// "agent". Surprising, but it is what the flag has always done.
+		"a starred pattern matches on a bare substring": {
+			exclude: []string{"*gen*"},
+			want:    []string{"keep.yaml"},
+		},
+		"several patterns": {
+			exclude: []string{"agent.yaml", "*.generated.yaml"},
+			want:    []string{"keep.yaml"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			root := tree(t, "agent.yaml", "keep.yaml", "gen/agent.generated.yaml")
+
+			files, err := scanner.New(tt.exclude).Scan([]string{root})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got := relative(t, root, files); !slices.Equal(got, tt.want) {
+				t.Errorf("Scan() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestScanKeepsAnExplicitlyNamedFile pins that naming a file wins over the
+// exclude patterns, which only govern directory walks.
+func TestScanKeepsAnExplicitlyNamedFile(t *testing.T) {
+	t.Parallel()
+
+	root := tree(t, "agent.yaml")
+	path := filepath.Join(root, "agent.yaml")
+
+	files, err := scanner.New([]string{"agent.yaml"}).Scan([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !files.Has(path) {
+		t.Errorf("an explicitly named file should be kept, got %v", sets.List(files))
+	}
+}
+
+// TestScanKeepsAnExplicitlyNamedFileWhateverItsExtension pins that the
+// extension filter also only governs directory walks.
+func TestScanKeepsAnExplicitlyNamedFileWhateverItsExtension(t *testing.T) {
+	t.Parallel()
+
+	root := tree(t, "config.txt")
+	path := filepath.Join(root, "config.txt")
+
+	files, err := scanner.New(nil).Scan([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !files.Has(path) {
+		t.Errorf("an explicitly named file should be kept, got %v", sets.List(files))
+	}
+}
+
+func TestScanDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	root := tree(t, "agent.yaml")
+	path := filepath.Join(root, "agent.yaml")
+
+	// Named through the walk, named directly, and named directly again with a
+	// path that needs cleaning.
+	unclean := filepath.Join(root, ".", "agent.yaml")
+
+	files, err := scanner.New(nil).Scan([]string{root, path, unclean})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if files.Len() != 1 {
+		t.Errorf("Scan() = %v, want one file", sets.List(files))
+	}
+}
+
+func TestScanPassesStdinThrough(t *testing.T) {
+	t.Parallel()
+
+	root := tree(t, "agent.yaml")
+
+	files, err := scanner.New(nil).Scan([]string{scanner.StdinMarker, root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !files.Has(scanner.StdinMarker) {
+		t.Errorf("the stdin marker should survive, got %v", sets.List(files))
+	}
+
+	if files.Len() != 2 {
+		t.Errorf("Scan() = %v, want the marker and the file", relative(t, root, files))
+	}
+}
+
+func TestScanReportsAMissingPath(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "nope.yaml")
+
+	_, err := scanner.New(nil).Scan([]string{missing})
+	if err == nil {
+		t.Fatal("want an error for a path that does not exist")
+	}
+
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("the cause should survive wrapping, got %v", err)
+	}
+}
+
+func TestScanOfNothingIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	files, err := scanner.New(nil).Scan(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if files.Len() != 0 {
+		t.Errorf("Scan(nil) = %v, want an empty set", sets.List(files))
+	}
+}
+
+// TestScannerFieldsAreHonoured pins that the defaults New picks are only
+// defaults, not something the walk hard-codes.
+func TestScannerFieldsAreHonoured(t *testing.T) {
+	t.Parallel()
+
+	root := tree(t, "a.json", "b.yaml", "skipme/c.json")
+
+	s := &scanner.Scanner{
+		Exclude:    nil,
+		Extensions: []string{".json"},
+		SkipDirs:   []string{"skipme"},
+	}
+
+	files, err := s.Scan([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := relative(t, root, files)
+	if want := []string{"a.json"}; !slices.Equal(got, want) {
+		t.Errorf("Scan() = %v, want %v", got, want)
+	}
+}

--- a/pkg/sets/sets.go
+++ b/pkg/sets/sets.go
@@ -1,0 +1,172 @@
+// Package sets provides a set built on a map, in the shape of
+// k8s.io/apimachinery/pkg/util/sets. That package predates generics and spells
+// its sets out per element type; this one is generic over any comparable type,
+// the way upstream's own Set[T] now is.
+package sets
+
+import (
+	"cmp"
+	"maps"
+	"slices"
+)
+
+// Empty is the zero-width map value, so a set costs only its keys.
+type Empty struct{}
+
+// Set holds each element at most once. The zero value is not usable; build one
+// with New or KeySet.
+type Set[T comparable] map[T]Empty
+
+// New builds a set holding items.
+func New[T comparable](items ...T) Set[T] {
+	s := make(Set[T], len(items))
+
+	return s.Insert(items...)
+}
+
+// KeySet builds a set of the keys of source.
+func KeySet[K comparable, V any](source map[K]V) Set[K] {
+	s := make(Set[K], len(source))
+	for key := range source {
+		s[key] = Empty{}
+	}
+
+	return s
+}
+
+// Insert adds items to the set and returns it, so calls can be chained.
+func (s Set[T]) Insert(items ...T) Set[T] {
+	for _, item := range items {
+		s[item] = Empty{}
+	}
+
+	return s
+}
+
+// InsertNew adds item and reports whether it was absent before, which is what
+// de-duplicating a stream while keeping first-seen order needs.
+func (s Set[T]) InsertNew(item T) bool {
+	if _, ok := s[item]; ok {
+		return false
+	}
+
+	s[item] = Empty{}
+
+	return true
+}
+
+// Delete removes items from the set and returns it, so calls can be chained.
+// Items that are not present are ignored.
+func (s Set[T]) Delete(items ...T) Set[T] {
+	for _, item := range items {
+		delete(s, item)
+	}
+
+	return s
+}
+
+// Has reports whether item is in the set.
+func (s Set[T]) Has(item T) bool {
+	_, ok := s[item]
+
+	return ok
+}
+
+// HasAll reports whether every one of items is in the set. It is true for no
+// items at all.
+func (s Set[T]) HasAll(items ...T) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// HasAny reports whether at least one of items is in the set.
+func (s Set[T]) HasAny(items ...T) bool {
+	return slices.ContainsFunc(items, s.Has)
+}
+
+// Len reports how many elements the set holds.
+func (s Set[T]) Len() int {
+	return len(s)
+}
+
+// Clone returns a copy that can be changed without touching the original.
+func (s Set[T]) Clone() Set[T] {
+	return maps.Clone(s)
+}
+
+// Union returns the elements in either set.
+func (s Set[T]) Union(other Set[T]) Set[T] {
+	out := make(Set[T], len(s)+len(other))
+	maps.Copy(out, s)
+	maps.Copy(out, other)
+
+	return out
+}
+
+// Intersection returns the elements in both sets.
+func (s Set[T]) Intersection(other Set[T]) Set[T] {
+	// Walking the smaller side keeps this proportional to it.
+	small, large := s, other
+	if len(other) < len(s) {
+		small, large = other, s
+	}
+
+	out := make(Set[T], len(small))
+
+	for item := range small {
+		if large.Has(item) {
+			out[item] = Empty{}
+		}
+	}
+
+	return out
+}
+
+// Difference returns the elements in s that are not in other.
+func (s Set[T]) Difference(other Set[T]) Set[T] {
+	out := make(Set[T], len(s))
+
+	for item := range s {
+		if !other.Has(item) {
+			out[item] = Empty{}
+		}
+	}
+
+	return out
+}
+
+// IsSuperset reports whether every element of other is in s.
+func (s Set[T]) IsSuperset(other Set[T]) bool {
+	for item := range other {
+		if !s.Has(item) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Equal reports whether both sets hold exactly the same elements.
+func (s Set[T]) Equal(other Set[T]) bool {
+	return len(s) == len(other) && s.IsSuperset(other)
+}
+
+// UnsortedList returns the elements in map order, which is deliberately
+// unspecified. Use List when the order matters.
+func (s Set[T]) UnsortedList() []T {
+	return slices.Collect(maps.Keys(s))
+}
+
+// List returns the elements in sorted order. It is a function rather than a
+// method because only orderable sets can be sorted.
+func List[T cmp.Ordered](s Set[T]) []T {
+	out := s.UnsortedList()
+	slices.Sort(out)
+
+	return out
+}

--- a/pkg/sets/sets.go
+++ b/pkg/sets/sets.go
@@ -43,18 +43,6 @@ func (s Set[T]) Insert(items ...T) Set[T] {
 	return s
 }
 
-// InsertNew adds item and reports whether it was absent before, which is what
-// de-duplicating a stream while keeping first-seen order needs.
-func (s Set[T]) InsertNew(item T) bool {
-	if _, ok := s[item]; ok {
-		return false
-	}
-
-	s[item] = Empty{}
-
-	return true
-}
-
 // Delete removes items from the set and returns it, so calls can be chained.
 // Items that are not present are ignored.
 func (s Set[T]) Delete(items ...T) Set[T] {

--- a/pkg/sets/sets_test.go
+++ b/pkg/sets/sets_test.go
@@ -45,24 +45,6 @@ func TestKeySet(t *testing.T) {
 	}
 }
 
-func TestInsertNewReportsNovelty(t *testing.T) {
-	t.Parallel()
-
-	s := sets.New[string]()
-
-	if !s.InsertNew("a") {
-		t.Error("the first insert should report the element as new")
-	}
-
-	if s.InsertNew("a") {
-		t.Error("the second insert should report the element as already present")
-	}
-
-	if s.Len() != 1 {
-		t.Errorf("Len() = %d, want 1", s.Len())
-	}
-}
-
 func TestInsertAndDeleteChain(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/sets/sets_test.go
+++ b/pkg/sets/sets_test.go
@@ -1,0 +1,191 @@
+package sets_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
+)
+
+func TestNewDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	s := sets.New("a", "b", "a")
+	if s.Len() != 2 {
+		t.Errorf("Len() = %d, want 2", s.Len())
+	}
+
+	if !s.HasAll("a", "b") {
+		t.Errorf("want both elements, got %v", sets.List(s))
+	}
+}
+
+func TestNewWithNoItems(t *testing.T) {
+	t.Parallel()
+
+	s := sets.New[string]()
+	if s.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", s.Len())
+	}
+
+	// An empty set must still be usable.
+	s.Insert("a")
+
+	if !s.Has("a") {
+		t.Error("Insert on an empty set did not take")
+	}
+}
+
+func TestKeySet(t *testing.T) {
+	t.Parallel()
+
+	s := sets.KeySet(map[string]int{"b": 2, "a": 1})
+	if got, want := sets.List(s), []string{"a", "b"}; !slices.Equal(got, want) {
+		t.Errorf("List() = %v, want %v", got, want)
+	}
+}
+
+func TestInsertNewReportsNovelty(t *testing.T) {
+	t.Parallel()
+
+	s := sets.New[string]()
+
+	if !s.InsertNew("a") {
+		t.Error("the first insert should report the element as new")
+	}
+
+	if s.InsertNew("a") {
+		t.Error("the second insert should report the element as already present")
+	}
+
+	if s.Len() != 1 {
+		t.Errorf("Len() = %d, want 1", s.Len())
+	}
+}
+
+func TestInsertAndDeleteChain(t *testing.T) {
+	t.Parallel()
+
+	s := sets.New("a").Insert("b", "c").Delete("a", "absent")
+	if got, want := sets.List(s), []string{"b", "c"}; !slices.Equal(got, want) {
+		t.Errorf("List() = %v, want %v", got, want)
+	}
+}
+
+func TestHasAllAndHasAny(t *testing.T) {
+	t.Parallel()
+
+	s := sets.New("a", "b")
+
+	if !s.HasAll() {
+		t.Error("HasAll() with no items should be true")
+	}
+
+	if s.HasAny() {
+		t.Error("HasAny() with no items should be false")
+	}
+
+	if !s.HasAll("a", "b") || s.HasAll("a", "z") {
+		t.Error("HasAll is wrong")
+	}
+
+	if !s.HasAny("z", "b") || s.HasAny("y", "z") {
+		t.Error("HasAny is wrong")
+	}
+}
+
+func TestUnionIntersectionDifference(t *testing.T) {
+	t.Parallel()
+
+	a := sets.New("a", "b", "c")
+	b := sets.New("c", "d")
+
+	tests := map[string]struct {
+		got  []string
+		want []string
+	}{
+		"union":                 {got: sets.List(a.Union(b)), want: []string{"a", "b", "c", "d"}},
+		"union is symmetric":    {got: sets.List(b.Union(a)), want: []string{"a", "b", "c", "d"}},
+		"intersection":          {got: sets.List(a.Intersection(b)), want: []string{"c"}},
+		"intersection reversed": {got: sets.List(b.Intersection(a)), want: []string{"c"}},
+		"difference":            {got: sets.List(a.Difference(b)), want: []string{"a", "b"}},
+		"difference reversed":   {got: sets.List(b.Difference(a)), want: []string{"d"}},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if !slices.Equal(tt.got, tt.want) {
+				t.Errorf("got %v, want %v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOperationsLeaveTheOperandsAlone(t *testing.T) {
+	t.Parallel()
+
+	a := sets.New("a", "b")
+	b := sets.New("b", "c")
+
+	a.Union(b)
+	a.Intersection(b)
+	a.Difference(b)
+
+	if got, want := sets.List(a), []string{"a", "b"}; !slices.Equal(got, want) {
+		t.Errorf("a changed: got %v, want %v", got, want)
+	}
+
+	if got, want := sets.List(b), []string{"b", "c"}; !slices.Equal(got, want) {
+		t.Errorf("b changed: got %v, want %v", got, want)
+	}
+}
+
+func TestEqualAndIsSuperset(t *testing.T) {
+	t.Parallel()
+
+	a := sets.New("a", "b")
+
+	if !a.Equal(sets.New("b", "a")) {
+		t.Error("order must not matter for Equal")
+	}
+
+	if a.Equal(sets.New("a")) || a.Equal(sets.New("a", "b", "c")) {
+		t.Error("sets of different sizes must not be equal")
+	}
+
+	if !a.IsSuperset(sets.New("a")) || !a.IsSuperset(sets.New[string]()) {
+		t.Error("IsSuperset should hold for subsets and the empty set")
+	}
+
+	if a.IsSuperset(sets.New("a", "z")) {
+		t.Error("IsSuperset should not hold for a set with an extra element")
+	}
+}
+
+func TestCloneIsIndependent(t *testing.T) {
+	t.Parallel()
+
+	original := sets.New("a")
+
+	clone := original.Clone()
+	clone.Insert("b")
+
+	if original.Has("b") {
+		t.Error("changing the clone must not touch the original")
+	}
+}
+
+func TestUnsortedListHoldsEveryElement(t *testing.T) {
+	t.Parallel()
+
+	s := sets.New(3, 1, 2)
+
+	got := s.UnsortedList()
+	slices.Sort(got)
+
+	if want := []int{1, 2, 3}; !slices.Equal(got, want) {
+		t.Errorf("UnsortedList() = %v, want %v once sorted", got, want)
+	}
+}


### PR DESCRIPTION
`collect` de-duplicates paths with a `map[string]bool`, a parallel slice and a closure, in the middle of the command package:

```go
var out []string

seen := map[string]bool{}
add := func(p string) {
	if !seen[p] {
		seen[p] = true
		out = append(out, p)
	}
}
```

All of that exists to keep first-seen order while de-duplicating. Nothing needs argument order, so the mechanism goes, and the walk moves out of the command package entirely.

## pkg/scanner

`collect`, `excluded` and `isConfigExt` have nothing to do with flags or reporting, and sitting in the command package meant they could only be reached through the whole CLI. They become a `Scanner`:

```go
type Scanner struct {
	Exclude    []string
	Extensions []string
	SkipDirs   []string
}

func New(exclude []string) *Scanner
func (s *Scanner) Scan(paths []string) (sets.Set[string], error)
```

The walk is configurable rather than hard-coded; `New` fills in the YAML defaults. The command calls `scanner.New(exclude).Scan(paths)`, and the stdin marker becomes `scanner.StdinMarker` instead of a bare `"-"` in three places.

`Scan` returns a set: the same file can be named twice, or named and also walked into, so the result holds each file once and carries no order.

### Two behaviours the new tests turned up

The walk had no direct tests before; it has 13 now. Two record behaviour that was previously unexamined, both pre-existing and left alone here:

- a dot-directory named directly on the command line **is** entered, since the skip only applies to what a walk descends into
- an `--exclude` pattern containing a star is matched as a bare substring with the stars stripped, so `*gen*` also drops `agent.yaml` — "gen" is inside "agent"

The second one is a sharp edge. Worth a separate look, but changing it would change what CI runs already skip.

## pkg/sets

Modelled on `k8s.io/apimachinery/pkg/util/sets`, generic over any comparable type rather than spelled out per element type the way `sets.String` is. That package predates generics; upstream's own `Set[T]` now works this way, and this repo is already on Go 1.25.

`New`, `KeySet`, `Insert`, `Delete`, `Has`, `HasAll`, `HasAny`, `Len`, `Clone`, `Union`, `Intersection`, `Difference`, `Equal`, `IsSuperset`, `UnsortedList`, and `List` as a function since only orderable sets can be sorted. `Union`, `Intersection` and `Difference` return new sets and leave both operands alone, which has a test.

`sortedKeys` in the command package is gone, replaced by `sets.List(sets.KeySet(...))` at its single call site in `applySettings`, which also drops the `sort` import.

## Behaviour change

Results now come out in path order rather than argument order. `otelcol-config-lint b.yaml a.yaml` reports `a.yaml` first.

That seems the better property for a linter: the same set of files reads the same however it was named, and inside a directory walk the two orders already agreed, so this only shows up when several paths are passed out of order. `--exit-on-error` still stops at the first failure, now meaning first in path order.

De-duplication and order were both untested before; there are now tests for each.

## Checks

`go build ./...`, `go test -race ./...` and `golangci-lint run` (0 issues) pass. `pkg/sets` is at 100% statement coverage, `pkg/scanner` at 88%.

Splitting the package also gave `wrapcheck` something real to check: the `Scan` error now crosses a package boundary, so it is wrapped at the call site.

## Follow-up

- #22 — use afero (or `fs.FS`) instead of touching the filesystem directly, now that the walk is isolated in one package

🤖 Generated with [Claude Code](https://claude.com/claude-code)