### PR TITLE
refactor: move isTerminal into pkg/termutil

### DIFF
--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -23,6 +23,7 @@ import (
 	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/scanner"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/termutil"
 )
 
 // Version is the linter's own version.
@@ -263,7 +264,7 @@ func (o *Options) runLint(cmd *cobra.Command, paths []string) error {
 	formatter, err := lint.NewFormatter(o.output, cmd.OutOrStdout(), lint.FormatterOptions{
 		Verbose: o.verbose,
 		Summary: o.summary,
-		Color:   !o.noColor && o.output == "text" && isTerminal(cmd.OutOrStdout()),
+		Color:   !o.noColor && o.output == "text" && termutil.IsTerminal(cmd.OutOrStdout()),
 	})
 	if err != nil {
 		return fmt.Errorf("create formatter: %w", err)
@@ -620,17 +621,4 @@ func defaultWorkers() int {
 	}
 
 	return maxDefaultWorkers
-}
-
-// isTerminal reports whether w is a character device, so colour is only used
-// when a human is watching.
-func isTerminal(w io.Writer) bool {
-	f, ok := w.(*os.File)
-	if !ok {
-		return false
-	}
-
-	info, err := f.Stat()
-
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }

--- a/pkg/termutil/terminal.go
+++ b/pkg/termutil/terminal.go
@@ -1,0 +1,21 @@
+// Package termutil holds stateless helpers for the terminal the command
+// writes to.
+package termutil
+
+import (
+	"io"
+	"os"
+)
+
+// IsTerminal reports whether w is a character device, so colour is only used
+// when a human is watching.
+func IsTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+
+	info, err := f.Stat()
+
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}

--- a/pkg/termutil/terminal_test.go
+++ b/pkg/termutil/terminal_test.go
@@ -1,0 +1,54 @@
+package termutil_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/termutil"
+)
+
+func TestIsTerminalNonFile(t *testing.T) {
+	t.Parallel()
+
+	if termutil.IsTerminal(&bytes.Buffer{}) {
+		t.Error("a buffer is not a terminal")
+	}
+}
+
+func TestIsTerminalRegularFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "out.txt")
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = f.Close()
+	})
+
+	if termutil.IsTerminal(f) {
+		t.Error("a regular file is not a terminal")
+	}
+}
+
+func TestIsTerminalCharDevice(t *testing.T) {
+	t.Parallel()
+
+	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = f.Close()
+	})
+
+	if !termutil.IsTerminal(f) {
+		t.Errorf("%s is a character device", os.DevNull)
+	}
+}


### PR DESCRIPTION
## Summary

`otelcol-config-lint.go` was carrying a file-mode check that has nothing to do with flag parsing, file discovery or reporting. It moves out to `pkg/termutil` as `termutil.IsTerminal`, leaving the command package to just call it when deciding whether to colour its output.

Naming follows the `<domain>util` convention for packages that hold only stateless helpers — a bare `util` would be a grab-bag.

## Test plan

- `pkg/termutil/terminal_test.go` covers the three cases that matter: a non-file writer (`*bytes.Buffer`), a regular file, and a character device (`os.DevNull`).
- `go build ./...`, `go test ./...` and `golangci-lint run` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)