### PR TITLE
feat(cli): add a "version" subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ arm64, plus a multi-arch image on ghcr.io.
 
 ```
 otelcol-config-lint [flags] <file|dir|->...
+otelcol-config-lint version
 ```
+
+| Command | Meaning |
+| --- | --- |
+| `version` | print the linter version (also available as `--version`) |
 
 | Flag | Meaning |
 | --- | --- |
@@ -58,7 +63,7 @@ otelcol-config-lint [flags] <file|dir|->...
 | `--exclude` | glob patterns to skip when walking directories |
 | `-n` | files checked in parallel |
 | `--summary`, `--verbose`, `--no-color`, `--exit-on-error` | output control |
-| `--list-rules`, `--list-versions`, `--version` | print and exit |
+| `--list-rules`, `--list-versions` | print and exit |
 
 Exit codes: `0` everything passed, `1` at least one file failed, `2` the command
 could not run.

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -26,11 +26,6 @@ import (
 	"github.com/minuk-dev/otelcol-config-lint/pkg/termutil"
 )
 
-// Version is the linter's own version.
-//
-//nolint:gochecknoglobals // injected at build time with -ldflags
-var Version = "dev"
-
 // Errors reported for bad flag values.
 var (
 	// ErrUnknownRule names a rule that does not exist.
@@ -102,7 +97,6 @@ type Options struct {
 	exitOnError      bool
 	listRules        bool
 	listVersions     bool
-	showVersion      bool
 
 	// internal state
 	store catalog.Store
@@ -116,8 +110,9 @@ func NewCommand(opts *Options) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
-		Use:   "otelcol-config-lint [flags] <file|dir|->...",
-		Short: "Validate OpenTelemetry Collector config files against a specific collector release",
+		Use:     "otelcol-config-lint [flags] <file|dir|->...",
+		Short:   "Validate OpenTelemetry Collector config files against a specific collector release",
+		Version: Version,
 		Example: `  otelcol-config-lint config.yaml
   otelcol-config-lint --collector-version v0.157.0 --summary ./configs
   cat config.yaml | otelcol-config-lint -
@@ -143,6 +138,12 @@ func NewCommand(opts *Options) *cobra.Command {
 			return nil
 		},
 	}
+
+	// Setting Version above gives the root command a built-in --version flag;
+	// this keeps it printing what the "version" subcommand prints.
+	cmd.SetVersionTemplate(versionTemplate)
+
+	cmd.AddCommand(newVersionCommand())
 
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		cmd.PrintErr(cmd.UsageString())
@@ -190,7 +191,6 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 	flags.BoolVar(&o.exitOnError, "exit-on-error", false, "stop at the first file that fails")
 	flags.BoolVar(&o.listRules, "list-rules", false, "print the rules and their default severities, then exit")
 	flags.BoolVar(&o.listVersions, "list-versions", false, "print the available catalog versions, then exit")
-	flags.BoolVar(&o.showVersion, "version", false, "print the linter version, then exit")
 }
 
 // Prepare folds the settings file into the parsed flags and builds the catalog
@@ -211,10 +211,6 @@ func (o *Options) Prepare(cmd *cobra.Command) error {
 // Run dispatches to whichever mode the flags asked for.
 func (o *Options) Run(cmd *cobra.Command, args []string) error {
 	switch {
-	case o.showVersion:
-		cmd.Printf("otelcol-config-lint %s\n", Version)
-
-		return nil
 	case o.listVersions:
 		err := o.runListVersions(cmd)
 		if err != nil {

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -443,12 +443,30 @@ func TestListRulesAndVersions(t *testing.T) {
 	}
 }
 
+// TestVersion pins that the subcommand and the built-in flag agree, so neither
+// can drift into printing something different.
 func TestVersion(t *testing.T) {
 	t.Parallel()
 
-	code, out, _ := run(t, "", "--version")
-	if code != 0 || !strings.Contains(out, "otelcol-config-lint ") {
-		t.Errorf("--version output looks wrong (exit %d):\n%s", code, out)
+	code, out, errOut := run(t, "", "version")
+	if code != 0 || !strings.HasPrefix(out, "otelcol-config-lint ") {
+		t.Errorf("version output looks wrong (exit %d): %q %q", code, out, errOut)
+	}
+
+	code, flagOut, _ := run(t, "", "--version")
+	if code != 0 || flagOut != out {
+		t.Errorf("--version should match the subcommand (exit %d): %q vs %q", code, flagOut, out)
+	}
+}
+
+// TestVersionTakesNoArguments keeps the subcommand from silently swallowing a
+// path the user meant to lint.
+func TestVersionTakesNoArguments(t *testing.T) {
+	t.Parallel()
+
+	code, _, errOut := run(t, "", "version", validConfig)
+	if code != 2 || !strings.Contains(errOut, validConfig) {
+		t.Errorf("want the stray argument reported on exit 2, got %d: %s", code, errOut)
 	}
 }
 

--- a/pkg/cmd/otelcol-config-lint/version.go
+++ b/pkg/cmd/otelcol-config-lint/version.go
@@ -1,0 +1,26 @@
+package otelcolconfiglint
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Version is the linter's own version.
+//
+//nolint:gochecknoglobals // injected at build time with -ldflags
+var Version = "dev"
+
+// versionTemplate renders the built-in --version flag the same way the
+// "version" subcommand prints it, so the two never drift apart.
+const versionTemplate = "otelcol-config-lint {{.Version}}\n"
+
+// newVersionCommand builds the "version" subcommand.
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+		Use:   "version",
+		Short: "Print the linter version",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			cmd.Printf("otelcol-config-lint %s\n", Version)
+		},
+	}
+}


### PR DESCRIPTION
Part of #19.

`--version` was a print-and-exit bool flag dispatched from the switch in `Run`. As #19 notes, that means `--help` advertises `--output`, `--strict` and everything else next to it, and the mode has nowhere of its own to live.

## What changed

- `otelcol-config-lint version` is a real subcommand, in its own `version.go`, with `Args: cobra.NoArgs`.
- The root sets cobra's `Version` field, so the built-in `--version` flag keeps working. The break #19 weighs is not needed for this one.
- A shared version template keeps the flag and the subcommand printing the same line (`otelcol-config-lint <version>`), and the test asserts they match rather than checking each in isolation.
- The `showVersion` field and its case in the `Run` switch are gone.

## Not in this PR

`--list-rules` and `--list-versions` — they share a `list` parent command and land together in a follow-up.

## Verification

`go test ./...` and `golangci-lint run` are clean. Checked by hand:

```
$ otelcol-config-lint version
otelcol-config-lint dev
$ otelcol-config-lint --version
otelcol-config-lint dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)