### PR TITLE
feat(cli): add "list rules" and "list versions" subcommands

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
           go-version: 1.25
       - name: Check the catalogs are readable and consistent
         run: |
-          go run ./cmd/otelcol-config-lint --list-versions
+          go run ./cmd/otelcol-config-lint list versions
           for f in catalogs/*.yaml; do
             version="$(basename "${f}" .yaml)"
             go run ./cmd/otelcol-config-lint \

--- a/README.md
+++ b/README.md
@@ -42,11 +42,15 @@ arm64, plus a multi-arch image on ghcr.io.
 
 ```
 otelcol-config-lint [flags] <file|dir|->...
+otelcol-config-lint list rules
+otelcol-config-lint list versions
 otelcol-config-lint version
 ```
 
 | Command | Meaning |
 | --- | --- |
+| `list rules` | the rules and their default severities, `--disable`/`--severity` applied |
+| `list versions` | the catalog versions available, honouring `--catalog-location` |
 | `version` | print the linter version (also available as `--version`) |
 
 | Flag | Meaning |
@@ -63,7 +67,6 @@ otelcol-config-lint version
 | `--exclude` | glob patterns to skip when walking directories |
 | `-n` | files checked in parallel |
 | `--summary`, `--verbose`, `--no-color`, `--exit-on-error` | output control |
-| `--list-rules`, `--list-versions` | print and exit |
 
 Exit codes: `0` everything passed, `1` at least one file failed, `2` the command
 could not run.
@@ -100,7 +103,7 @@ catalogLocations:
 
 ## What it checks
 
-`otelcol-config-lint --list-rules` prints the current set with default severities.
+`otelcol-config-lint list rules` prints the current set with default severities.
 
 **Structure** — `unknown-top-level-key`, `service-required`,
 `unknown-service-key`, `invalid-pipeline-key`, `empty-pipeline`,

--- a/pkg/cmd/otelcol-config-lint/list.go
+++ b/pkg/cmd/otelcol-config-lint/list.go
@@ -1,0 +1,163 @@
+package otelcolconfiglint
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+)
+
+// newListCommand builds "list" and its subcommands. Each one carries only the
+// flags that change what it prints, so their help stays short.
+func newListCommand(opts *Options) *cobra.Command {
+	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+		Use:   "list",
+		Short: "Print what the linter knows about",
+		Example: `  otelcol-config-lint list rules
+  otelcol-config-lint list versions`,
+	}
+
+	// Children inherit the root's usage template, whose exit-code footer talks
+	// about files passing and failing. A listing does neither.
+	cmd.SetUsageTemplate(defaultUsageTemplate())
+
+	cmd.AddCommand(opts.newListRulesCommand(), opts.newListVersionsCommand())
+
+	return cmd
+}
+
+// defaultUsageTemplate is cobra's own, before the root command appends to it.
+func defaultUsageTemplate() string {
+	return new(cobra.Command).UsageTemplate()
+}
+
+// newListRulesCommand builds "list rules". The severity flags apply because
+// they decide the severity the rules will actually run at.
+func (o *Options) newListRulesCommand() *cobra.Command {
+	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+		Use:   "rules",
+		Short: "Print the rules and their default severities",
+		Long: "Print the rules and their default severities.\n\n" +
+			"A severity changed by --disable, --severity or the settings file is\n" +
+			"marked as overridden.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := o.Prepare(cmd)
+			if err != nil {
+				return err
+			}
+
+			return o.runListRules(cmd)
+		},
+	}
+
+	o.registerSettingsFlag(cmd)
+	o.registerRuleFlags(cmd)
+
+	return cmd
+}
+
+// newListVersionsCommand builds "list versions". --collector-version is
+// deliberately absent: this is the command that says which ones exist.
+func (o *Options) newListVersionsCommand() *cobra.Command {
+	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+		Use:   "versions",
+		Short: "Print the available catalog versions",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := o.Prepare(cmd)
+			if err != nil {
+				return err
+			}
+
+			return o.runListVersions(cmd)
+		},
+	}
+
+	o.registerSettingsFlag(cmd)
+	o.registerCatalogLocationFlag(cmd)
+
+	return cmd
+}
+
+func (o *Options) runListRules(cmd *cobra.Command) error {
+	overrides, err := o.severityOverrides()
+	if err != nil {
+		return err
+	}
+
+	w := newColumns(cmd.OutOrStdout())
+
+	for _, r := range rule.All() {
+		sev := r.Severity()
+
+		note := ""
+		if s, ok := overrides[r.Name()]; ok && s != sev {
+			sev, note = s, " (overridden)"
+		}
+
+		w.row(r.Name(), string(sev)+note, r.Description())
+	}
+
+	w.flush()
+
+	return nil
+}
+
+func (o *Options) runListVersions(cmd *cobra.Command) error {
+	versions := o.store.Versions()
+	if len(versions) == 0 {
+		return ErrNoCatalogs
+	}
+
+	w := newColumns(cmd.OutOrStdout())
+
+	for i, v := range versions {
+		cat, err := o.store.Load(v)
+		if err != nil {
+			w.row(v, "unreadable: "+err.Error(), "")
+
+			continue
+		}
+
+		note := ""
+		if i == 0 {
+			note = "(latest)"
+		}
+
+		w.row(v, fmt.Sprintf("%d components", cat.Count()),
+			strings.Join(cat.Distributions, "+")+" "+note)
+	}
+
+	w.flush()
+
+	return nil
+}
+
+// columns renders the aligned output the list subcommands print.
+type columns struct{ w *tabwriter.Writer }
+
+// columnPadding is the gap between columns, in spaces.
+const columnPadding = 2
+
+func newColumns(w io.Writer) columns {
+	return columns{w: tabwriter.NewWriter(w, 0, 0, columnPadding, ' ', 0)}
+}
+
+func (c columns) row(cells ...string) {
+	for i, cell := range cells {
+		if i > 0 {
+			_, _ = io.WriteString(c.w, "\t")
+		}
+
+		_, _ = io.WriteString(c.w, cell)
+	}
+
+	_, _ = io.WriteString(c.w, "\n")
+}
+
+func (c columns) flush() { _ = c.w.Flush() }

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/samber/mo"
 	"github.com/spf13/cobra"
@@ -95,8 +94,6 @@ type Options struct {
 	verbose          bool
 	noColor          bool
 	exitOnError      bool
-	listRules        bool
-	listVersions     bool
 
 	// internal state
 	store catalog.Store
@@ -143,7 +140,7 @@ func NewCommand(opts *Options) *cobra.Command {
 	// this keeps it printing what the "version" subcommand prints.
 	cmd.SetVersionTemplate(versionTemplate)
 
-	cmd.AddCommand(newVersionCommand())
+	cmd.AddCommand(newVersionCommand(), newListCommand(opts))
 
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		cmd.PrintErr(cmd.UsageString())
@@ -165,18 +162,17 @@ Exit codes:
 
 // RegisterFlags declares every command line flag on the command.
 func (o *Options) RegisterFlags(cmd *cobra.Command) {
+	// The groups below are shared with the list subcommands, which take only
+	// the flags that change what they print.
+	o.registerSettingsFlag(cmd)
+	o.registerCatalogLocationFlag(cmd)
+	o.registerRuleFlags(cmd)
+
 	flags := cmd.Flags()
 
 	flags.StringVar(&o.collectorVersion, "collector-version", catalog.Latest,
 		"collector release to validate against, e.g. v0.157.0")
-	flags.StringSliceVar(&o.catalogLocations, "catalog-location", nil,
-		"where to find catalogs: a directory, a {{.Version}} template, a URL, or \"default\";\n"+
-			"repeat to search several in order (default: the built-in catalogs)")
 	flags.StringVar(&o.output, "output", "text", "output format: text, json, junit, tap or github")
-	flags.StringVar(&o.settingsFile, "config", "", "settings file (default "+DefaultSettingsFile+" if present)")
-	flags.StringVar(&o.disable, "disable", "", "comma-separated rules to turn off")
-	flags.StringVar(&o.severity, "severity", "",
-		"comma-separated rule=level overrides, e.g. missing-batch=warning")
 	flags.StringVar(&o.exclude, "exclude", "", "comma-separated glob patterns to skip when walking directories")
 	flags.StringVar(&o.minSeverity, "min-severity", "info", "lowest severity to report: error, warning or info")
 	flags.StringVar(&o.failOn, "fail-on", "error", "severity that makes a file invalid: error, warning or info")
@@ -189,8 +185,6 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 	flags.BoolVar(&o.verbose, "verbose", false, "also report files that passed")
 	flags.BoolVar(&o.noColor, "no-color", false, "disable coloured output")
 	flags.BoolVar(&o.exitOnError, "exit-on-error", false, "stop at the first file that fails")
-	flags.BoolVar(&o.listRules, "list-rules", false, "print the rules and their default severities, then exit")
-	flags.BoolVar(&o.listVersions, "list-versions", false, "print the available catalog versions, then exit")
 }
 
 // Prepare folds the settings file into the parsed flags and builds the catalog
@@ -208,25 +202,8 @@ func (o *Options) Prepare(cmd *cobra.Command) error {
 	return nil
 }
 
-// Run dispatches to whichever mode the flags asked for.
+// Run lints the given paths.
 func (o *Options) Run(cmd *cobra.Command, args []string) error {
-	switch {
-	case o.listVersions:
-		err := o.runListVersions(cmd)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	case o.listRules:
-		err := o.runListRules(cmd)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
 	if len(args) == 0 {
 		cmd.PrintErr(cmd.UsageString())
 
@@ -239,6 +216,30 @@ func (o *Options) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// registerSettingsFlag declares --config. Every command honours it: the
+// settings file states rule and catalog policy, not only lint options.
+func (o *Options) registerSettingsFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.settingsFile, "config", "",
+		"settings file (default "+DefaultSettingsFile+" if present)")
+}
+
+// registerCatalogLocationFlag declares --catalog-location, shared with
+// "list versions".
+func (o *Options) registerCatalogLocationFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&o.catalogLocations, "catalog-location", nil,
+		"where to find catalogs: a directory, a {{.Version}} template, a URL, or \"default\";\n"+
+			"repeat to search several in order (default: the built-in catalogs)")
+}
+
+// registerRuleFlags declares the severity overrides, shared with "list rules".
+func (o *Options) registerRuleFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	flags.StringVar(&o.disable, "disable", "", "comma-separated rules to turn off")
+	flags.StringVar(&o.severity, "severity", "",
+		"comma-separated rule=level overrides, e.g. missing-batch=warning")
 }
 
 // runLint resolves what to check and how to report it, then does the work.
@@ -384,60 +385,6 @@ func (o *Options) loadCatalog(cmd *cobra.Command) (*catalog.Catalog, error) {
 	return cat, nil
 }
 
-func (o *Options) runListRules(cmd *cobra.Command) error {
-	overrides, err := o.severityOverrides()
-	if err != nil {
-		return err
-	}
-
-	w := newColumns(cmd.OutOrStdout())
-
-	for _, r := range rule.All() {
-		sev := r.Severity()
-
-		note := ""
-		if s, ok := overrides[r.Name()]; ok && s != sev {
-			sev, note = s, " (overridden)"
-		}
-
-		w.row(r.Name(), string(sev)+note, r.Description())
-	}
-
-	w.flush()
-
-	return nil
-}
-
-func (o *Options) runListVersions(cmd *cobra.Command) error {
-	versions := o.store.Versions()
-	if len(versions) == 0 {
-		return ErrNoCatalogs
-	}
-
-	w := newColumns(cmd.OutOrStdout())
-
-	for i, v := range versions {
-		cat, err := o.store.Load(v)
-		if err != nil {
-			w.row(v, "unreadable: "+err.Error(), "")
-
-			continue
-		}
-
-		note := ""
-		if i == 0 {
-			note = "(latest)"
-		}
-
-		w.row(v, fmt.Sprintf("%d components", cat.Count()),
-			strings.Join(cat.Distributions, "+")+" "+note)
-	}
-
-	w.flush()
-
-	return nil
-}
-
 // severityOverrides builds the rule severity map from --disable and --severity.
 func (o *Options) severityOverrides() (map[string]diag.Severity, error) {
 	out := map[string]diag.Severity{}
@@ -563,30 +510,6 @@ func (o *Options) applySettings(s *settings, changed func(name string) bool) {
 		o.severity = joinList(strings.Join(pairs, ","), o.severity)
 	}
 }
-
-// columns renders aligned help output for --list-rules and --list-versions.
-type columns struct{ w *tabwriter.Writer }
-
-// columnPadding is the gap between columns, in spaces.
-const columnPadding = 2
-
-func newColumns(w io.Writer) columns {
-	return columns{w: tabwriter.NewWriter(w, 0, 0, columnPadding, ' ', 0)}
-}
-
-func (c columns) row(cells ...string) {
-	for i, cell := range cells {
-		if i > 0 {
-			_, _ = io.WriteString(c.w, "\t")
-		}
-
-		_, _ = io.WriteString(c.w, cell)
-	}
-
-	_, _ = io.WriteString(c.w, "\n")
-}
-
-func (c columns) flush() { _ = c.w.Flush() }
 
 func splitList(s string) []string {
 	var out []string

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -432,14 +432,74 @@ func TestDirectoryWalkFindsEveryFile(t *testing.T) {
 func TestListRulesAndVersions(t *testing.T) {
 	t.Parallel()
 
-	code, out, _ := run(t, "", "--list-rules")
+	code, out, _ := run(t, "", "list", "rules")
 	if code != 0 || !strings.Contains(out, "unknown-component") {
-		t.Errorf("--list-rules output looks wrong (exit %d):\n%s", code, out)
+		t.Errorf("list rules output looks wrong (exit %d):\n%s", code, out)
 	}
 
-	code, out, _ = run(t, "", "--list-versions")
+	code, out, _ = run(t, "", "list", "versions")
 	if code != 0 || !strings.Contains(out, "(latest)") || !strings.Contains(out, "components") {
-		t.Errorf("--list-versions output looks wrong (exit %d):\n%s", code, out)
+		t.Errorf("list versions output looks wrong (exit %d):\n%s", code, out)
+	}
+}
+
+// TestListRulesHonoursTheSeverityFlags pins that the overrides still reach the
+// listing now that it is a subcommand with its own flag set.
+func TestListRulesHonoursTheSeverityFlags(t *testing.T) {
+	t.Parallel()
+
+	code, out, errOut := run(t, "", "list", "rules", "--severity", "missing-batch=error")
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, errOut)
+	}
+
+	if !strings.Contains(out, "(overridden)") {
+		t.Errorf("--severity should be marked as an override:\n%s", out)
+	}
+
+	if code, _, errOut := run(t, "", "list", "rules", "--disable", "no-such-rule"); code != 2 ||
+		!strings.Contains(errOut, "unknown rule") {
+		t.Errorf("an unknown rule should be a usage error, got %d: %s", code, errOut)
+	}
+}
+
+// TestListVersionsHonoursTheCatalogLocation pins that the subcommand reports
+// the catalogs the run would actually use, not only the built-in ones.
+func TestListVersionsHonoursTheCatalogLocation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	catalogJSON := `{"collectorVersion":"v9.9.9","components":{}}`
+
+	err := os.WriteFile(filepath.Join(dir, "v9.9.9.json"), []byte(catalogJSON), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	code, out, errOut := run(t, "", "list", "versions", "--catalog-location", dir)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, errOut)
+	}
+
+	if !strings.Contains(out, "v9.9.9") {
+		t.Errorf("a project catalog should be listed:\n%s", out)
+	}
+}
+
+// TestListSubcommandsRejectLintFlags pins the point of the split: the listings
+// no longer advertise or accept the flags that only shape a lint run.
+func TestListSubcommandsRejectLintFlags(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		{"list", "rules", "--strict"},
+		{"list", "versions", "--output", "json"},
+	} {
+		code, _, errOut := run(t, "", args...)
+		if code != 2 || !strings.Contains(errOut, "unknown flag") {
+			t.Errorf("%v should be a usage error, got %d: %s", args, code, errOut)
+		}
 	}
 }
 


### PR DESCRIPTION
Part of #19.

`--list-rules` and `--list-versions` were print-and-exit bools dispatched from the switch in `Run`. As #19 notes, that means their `--help` advertises `--output`, `--strict` and every other lint flag next to them.

## What changed

Each is a subcommand under a `list` parent, in its own `list.go`, carrying only the flags that change what it prints:

| Command | Flags |
| --- | --- |
| `list rules` | `--disable`, `--severity`, `--config` |
| `list versions` | `--catalog-location`, `--config` |

`--config` is on both because the settings file states rule and catalog policy, not only lint options. `--collector-version` is deliberately absent from `list versions` — that is the command that says which versions exist.

`RegisterFlags` grows three small helpers so the subcommands share the declarations instead of restating them; `Options` keeps working as one struct, and `Prepare` needs no change because `pflag.FlagSet.Changed` reports false for a flag a command did not register. The listing code and the column writer move out of `otelcol-config-lint.go` into `list.go`.

The `list` command resets the usage template to cobra's default: the root appends an exit-code footer about files passing and failing, which a listing does neither of.

## Compatibility

**This breaks the CLI.** As #19 weighs it, #17 already carries a `-flag` to `--flag` break, so both land in the same release rather than one break per release. No deprecated aliases — there are no tagged releases yet.

`.github/workflows/test.yaml` used `--list-versions` for the catalog check and is updated in this PR.

## Verification

`go test ./...` and `golangci-lint run` are clean. New tests cover the severity overrides reaching `list rules`, `--catalog-location` reaching `list versions`, and both rejecting the lint-only flags — which is the point of the split.

```
$ otelcol-config-lint list rules --help
Print the rules and their default severities.

A severity changed by --disable, --severity or the settings file is
marked as overridden.

Usage:
  otelcol-config-lint list rules [flags]

Flags:
      --config string     settings file (default .otelcol-config-lint.yaml if present)
      --disable string    comma-separated rules to turn off
  -h, --help              help for rules
      --severity string   comma-separated rule=level overrides, e.g. missing-batch=warning
```

## Stacked on this

The `run` subcommand split (`otelcol-config-lint run <files>`, the way `golangci-lint run` works) branches off this one, since it moves the same `Run`/`RegisterFlags` code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)