### PR TITLE
feat(cli): move linting behind a "run" subcommand

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,4 +50,4 @@ jobs:
         with:
           go-version: 1.25
       - name: Lint the example configs
-        run: go run ./cmd/otelcol-config-lint --output github --summary testdata/valid
+        run: go run ./cmd/otelcol-config-lint run --output github --summary testdata/valid

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,6 @@ jobs:
           go run ./cmd/otelcol-config-lint list versions
           for f in catalogs/*.yaml; do
             version="$(basename "${f}" .yaml)"
-            go run ./cmd/otelcol-config-lint \
+            go run ./cmd/otelcol-config-lint run \
               --collector-version "${version}" --min-severity error testdata/valid
           done

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ release you target is a first-class input, the way `kubeconform` treats the
 Kubernetes version.
 
 ```console
-$ otelcol-config-lint --collector-version v0.157.0 config.yaml
+$ otelcol-config-lint run --collector-version v0.157.0 config.yaml
 config.yaml:6:3: error: unknown receiver type "prometheusreceiver" in collector v0.157.0 [unknown-component]
     hint: checked against collector v0.157.0; did you mean "prometheus"?
 config.yaml:11:14: error: "timeout" must be a duration such as 5s, 200ms or 1m30s [invalid-value]
@@ -32,7 +32,7 @@ Or run it as a container, mounting the configs to check:
 
 ```sh
 docker run --rm -v "$PWD:/workspace" \
-  ghcr.io/minuk-dev/otelcol-config-lint:latest --summary ./configs
+  ghcr.io/minuk-dev/otelcol-config-lint:latest run --summary ./configs
 ```
 
 Tagged releases publish binaries for Linux, macOS and Windows on amd64 and
@@ -41,7 +41,7 @@ arm64, plus a multi-arch image on ghcr.io.
 ## Usage
 
 ```
-otelcol-config-lint [flags] <file|dir|->...
+otelcol-config-lint run [flags] <file|dir|->...
 otelcol-config-lint list rules
 otelcol-config-lint list versions
 otelcol-config-lint version
@@ -49,9 +49,12 @@ otelcol-config-lint version
 
 | Command | Meaning |
 | --- | --- |
+| `run` | lint the given files, directories, or `-` for stdin |
 | `list rules` | the rules and their default severities, `--disable`/`--severity` applied |
 | `list versions` | the catalog versions available, honouring `--catalog-location` |
 | `version` | print the linter version (also available as `--version`) |
+
+The flags below belong to `run`:
 
 | Flag | Meaning |
 | --- | --- |
@@ -72,12 +75,12 @@ Exit codes: `0` everything passed, `1` at least one file failed, `2` the command
 could not run.
 
 ```sh
-otelcol-config-lint config.yaml                               # lint one file
-otelcol-config-lint --summary ./configs                       # walk a directory
-cat config.yaml | otelcol-config-lint -                       # read stdin
-otelcol-config-lint --output json ./configs > report.json     # machine-readable
-otelcol-config-lint --output github ./configs                 # PR annotations
-otelcol-config-lint --collector-version v0.110.0 config.yaml  # target an older release
+otelcol-config-lint run config.yaml                               # lint one file
+otelcol-config-lint run --summary ./configs                       # walk a directory
+cat config.yaml | otelcol-config-lint run -                       # read stdin
+otelcol-config-lint run --output json ./configs > report.json     # machine-readable
+otelcol-config-lint run --output github ./configs                 # PR annotations
+otelcol-config-lint run --collector-version v0.110.0 config.yaml  # target an older release
 ```
 
 ### Settings file
@@ -152,7 +155,7 @@ Because the catalogs sit at the repository root, they can be consumed without
 installing or cloning anything:
 
 ```sh
-otelcol-config-lint --catalog-location \
+otelcol-config-lint run --catalog-location \
   https://raw.githubusercontent.com/minuk-dev/otelcol-config-lint/main/catalogs/{{.Version}}.yaml \
   config.yaml
 ```

--- a/pkg/cmd/otelcol-config-lint/list.go
+++ b/pkg/cmd/otelcol-config-lint/list.go
@@ -21,18 +21,9 @@ func newListCommand(opts *Options) *cobra.Command {
   otelcol-config-lint list versions`,
 	}
 
-	// Children inherit the root's usage template, whose exit-code footer talks
-	// about files passing and failing. A listing does neither.
-	cmd.SetUsageTemplate(defaultUsageTemplate())
-
 	cmd.AddCommand(opts.newListRulesCommand(), opts.newListVersionsCommand())
 
 	return cmd
-}
-
-// defaultUsageTemplate is cobra's own, before the root command appends to it.
-func defaultUsageTemplate() string {
-	return new(cobra.Command).UsageTemplate()
 }
 
 // newListRulesCommand builds "list rules". The severity flags apply because

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -99,48 +99,32 @@ type Options struct {
 	store catalog.Store
 }
 
-// NewCommand builds the cobra command. A nil opts is allowed, in which case a
+// NewCommand builds the root command. A nil opts is allowed, in which case a
 // zero value is used.
 func NewCommand(opts *Options) *cobra.Command {
 	if opts == nil {
 		opts = &Options{} //nolint:exhaustruct // every field is filled in by RegisterFlags
 	}
 
+	// The root carries no work of its own: every mode is a subcommand, so a
+	// bare invocation prints the help that lists them.
 	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
-		Use:     "otelcol-config-lint [flags] <file|dir|->...",
+		Use:     "otelcol-config-lint <command> [flags]",
 		Short:   "Validate OpenTelemetry Collector config files against a specific collector release",
 		Version: Version,
-		Example: `  otelcol-config-lint config.yaml
-  otelcol-config-lint --collector-version v0.157.0 --summary ./configs
-  cat config.yaml | otelcol-config-lint -
-  otelcol-config-lint --output json --strict ./configs > report.json`,
-		Args: cobra.ArbitraryArgs,
+		// The subcommands print command-level errors themselves, with the tool
+		// prefix, and stay quiet about ErrFilesInvalid.
+		SilenceErrors: true,
 		// Findings are not usage errors, so the usage text is printed only
 		// where it helps: bad flags and a missing argument.
 		SilenceUsage: true,
-		// The caller prints command-level errors itself, with the tool prefix,
-		// and stays quiet about ErrFilesInvalid.
-		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			err := opts.Prepare(cmd)
-			if err != nil {
-				return err
-			}
-
-			err = opts.Run(cmd, args)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		},
 	}
 
 	// Setting Version above gives the root command a built-in --version flag;
 	// this keeps it printing what the "version" subcommand prints.
 	cmd.SetVersionTemplate(versionTemplate)
 
-	cmd.AddCommand(newVersionCommand(), newListCommand(opts))
+	cmd.AddCommand(newRunCommand(opts), newListCommand(opts), newVersionCommand())
 
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		cmd.PrintErr(cmd.UsageString())
@@ -148,19 +132,10 @@ func NewCommand(opts *Options) *cobra.Command {
 		return err
 	})
 
-	cmd.SetUsageTemplate(cmd.UsageTemplate() + fmt.Sprintf(`
-Exit codes:
-  %d  every file passed
-  %d  at least one file failed
-  %d  the command could not run
-`, ExitOK, ExitInvalid, ExitUsage))
-
-	opts.RegisterFlags(cmd)
-
 	return cmd
 }
 
-// RegisterFlags declares every command line flag on the command.
+// RegisterFlags declares every flag the lint run takes.
 func (o *Options) RegisterFlags(cmd *cobra.Command) {
 	// The groups below are shared with the list subcommands, which take only
 	// the flags that change what they print.

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -42,6 +42,13 @@ func run(t *testing.T, stdin string, args ...string) (int, string, string) {
 	return otelcolconfiglint.ExitCode(err), stdout.String(), stderr.String()
 }
 
+// lint invokes the "run" subcommand, which is where every lint flag lives.
+func lint(t *testing.T, stdin string, args ...string) (int, string, string) {
+	t.Helper()
+
+	return run(t, stdin, append([]string{"run"}, args...)...)
+}
+
 func TestExitCode(t *testing.T) {
 	t.Parallel()
 
@@ -72,7 +79,7 @@ func TestExitCode(t *testing.T) {
 func TestValidDirectoryPasses(t *testing.T) {
 	t.Parallel()
 
-	code, out, errOut := run(t, "", "--min-severity", "error", validConfig)
+	code, out, errOut := lint(t, "", "--min-severity", "error", validConfig)
 	if code != 0 {
 		t.Fatalf("exit %d, stdout=%q stderr=%q", code, out, errOut)
 	}
@@ -85,7 +92,7 @@ func TestValidDirectoryPasses(t *testing.T) {
 func TestInvalidFileFails(t *testing.T) {
 	t.Parallel()
 
-	code, out, _ := run(t, "", badConfig)
+	code, out, _ := lint(t, "", badConfig)
 	if code != 1 {
 		t.Fatalf("want exit 1, got %d", code)
 	}
@@ -100,7 +107,7 @@ func TestInvalidFileFails(t *testing.T) {
 func TestStdin(t *testing.T) {
 	t.Parallel()
 
-	code, out, _ := run(t, "receivers:\n  otlp:\n", "-")
+	code, out, _ := lint(t, "receivers:\n  otlp:\n", "-")
 	if code != 1 {
 		t.Fatalf("want exit 1, got %d: %s", code, out)
 	}
@@ -113,7 +120,7 @@ func TestStdin(t *testing.T) {
 func TestJSONOutput(t *testing.T) {
 	t.Parallel()
 
-	code, out, _ := run(t, "", "--output", "json", badConfig)
+	code, out, _ := lint(t, "", "--output", "json", badConfig)
 	if code != 1 {
 		t.Fatalf("want exit 1, got %d", code)
 	}
@@ -152,7 +159,7 @@ func TestJSONOutput(t *testing.T) {
 func TestGitHubOutput(t *testing.T) {
 	t.Parallel()
 
-	_, out, _ := run(t, "", "--output", "github", badConfig)
+	_, out, _ := lint(t, "", "--output", "github", badConfig)
 	if !strings.HasPrefix(out, "::error file=") {
 		t.Errorf("want workflow commands, got:\n%s", out)
 	}
@@ -165,12 +172,12 @@ func TestGitHubOutput(t *testing.T) {
 func TestJUnitAndTAPOutput(t *testing.T) {
 	t.Parallel()
 
-	_, junit, _ := run(t, "", "--output", "junit", badConfig)
+	_, junit, _ := lint(t, "", "--output", "junit", badConfig)
 	if !strings.Contains(junit, "<testsuite") || !strings.Contains(junit, "<failure") {
 		t.Errorf("unexpected junit output:\n%s", junit)
 	}
 
-	_, tap, _ := run(t, "", "--output", "tap", badConfig)
+	_, tap, _ := lint(t, "", "--output", "tap", badConfig)
 	if !strings.HasPrefix(tap, "1..1\nnot ok 1 - ") {
 		t.Errorf("unexpected tap output:\n%s", tap)
 	}
@@ -184,11 +191,11 @@ func TestFailOnWarningTightensTheGate(t *testing.T) {
 		"      receivers: [otlp]\n      processors: [batch]\n      exporters: [debug]\n" +
 		"extensions:\n  zpages:\n"
 	// The unused zpages extension is a warning, so the gate decides the outcome.
-	if code, _, _ := run(t, src, "-"); code != 0 {
+	if code, _, _ := lint(t, src, "-"); code != 0 {
 		t.Errorf("warnings alone should not fail by default, got exit %d", code)
 	}
 
-	if code, _, _ := run(t, src, "--fail-on", "warning", "-"); code != 1 {
+	if code, _, _ := lint(t, src, "--fail-on", "warning", "-"); code != 1 {
 		t.Errorf("--fail-on warning should fail, got exit %d", code)
 	}
 }
@@ -198,7 +205,7 @@ func TestDisableAndSeverityOverrides(t *testing.T) {
 
 	disabled := "unknown-top-level-key,invalid-value,undefined-reference,unknown-component"
 
-	code, out, _ := run(t, "", "--disable", disabled, badConfig)
+	code, out, _ := lint(t, "", "--disable", disabled, badConfig)
 	if strings.Contains(out, "[invalid-value]") {
 		t.Errorf("disabled rules must not report:\n%s", out)
 	}
@@ -207,12 +214,12 @@ func TestDisableAndSeverityOverrides(t *testing.T) {
 		t.Logf("remaining findings:\n%s", out)
 	}
 
-	_, out, _ = run(t, "", "--severity", "missing-batch=warning", "--min-severity", "warning", validConfig)
+	_, out, _ = lint(t, "", "--severity", "missing-batch=warning", "--min-severity", "warning", validConfig)
 	if strings.Contains(out, "[missing-batch]") {
 		t.Errorf("the valid config should not be missing batch:\n%s", out)
 	}
 
-	if code, _, errOut := run(t, "", "--disable", "no-such-rule", badConfig); code != 2 ||
+	if code, _, errOut := lint(t, "", "--disable", "no-such-rule", badConfig); code != 2 ||
 		!strings.Contains(errOut, "unknown rule") {
 		t.Errorf("an unknown rule should be a usage error, got %d: %s", code, errOut)
 	}
@@ -226,11 +233,11 @@ func TestCollectorVersionSelectsTheCatalog(t *testing.T) {
 	src := "receivers:\n  otlp:\n    protocols:\n      grpc:\nexporters:\n  logging:\n" +
 		"service:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      exporters: [logging]\n"
 
-	if code, out, _ := run(t, src, "--collector-version", "v0.110.0", "--min-severity", "error", "-"); code != 0 {
+	if code, out, _ := lint(t, src, "--collector-version", "v0.110.0", "--min-severity", "error", "-"); code != 0 {
 		t.Errorf("logging should exist in v0.110.0, got exit %d:\n%s", code, out)
 	}
 
-	code, out, _ := run(t, src, "--collector-version", "v0.157.0", "-")
+	code, out, _ := lint(t, src, "--collector-version", "v0.157.0", "-")
 	if code != 1 || !strings.Contains(out, "unknown-component") {
 		t.Errorf("logging should be unknown in v0.157.0, got exit %d:\n%s", code, out)
 	}
@@ -239,7 +246,7 @@ func TestCollectorVersionSelectsTheCatalog(t *testing.T) {
 func TestUnknownVersionFallsBackToTheNearestOlder(t *testing.T) {
 	t.Parallel()
 
-	code, _, errOut := run(t, "", "--collector-version", "v0.155.0", "--min-severity", "error", validConfig)
+	code, _, errOut := lint(t, "", "--collector-version", "v0.155.0", "--min-severity", "error", validConfig)
 	if code != 0 {
 		t.Fatalf("want a fallback, got exit %d: %s", code, errOut)
 	}
@@ -267,7 +274,7 @@ func TestCatalogLocationOverridesTheBuiltins(t *testing.T) {
 	src := "receivers:\n  custom:\nexporters:\n  custom:\n" +
 		"service:\n  pipelines:\n    logs:\n      receivers: [custom]\n      exporters: [custom]\n"
 
-	code, out, errOut := run(t, src,
+	code, out, errOut := lint(t, src,
 		"--catalog-location", dir, "--collector-version", "v9.9.9", "--min-severity", "error", "-")
 	if code != 0 {
 		t.Errorf("a project catalog should be honoured, got exit %d:\n%s%s", code, out, errOut)
@@ -279,11 +286,11 @@ func TestIgnoreMissingSchemas(t *testing.T) {
 
 	src := "receivers:\n  mycorp_custom:\nexporters:\n  debug:\n" +
 		"service:\n  pipelines:\n    logs:\n      receivers: [mycorp_custom]\n      exporters: [debug]\n"
-	if code, _, _ := run(t, src, "-"); code != 1 {
+	if code, _, _ := lint(t, src, "-"); code != 1 {
 		t.Error("an unknown component should fail by default")
 	}
 
-	if code, out, _ := run(t, src, "--ignore-missing-schemas", "-"); code != 0 {
+	if code, out, _ := lint(t, src, "--ignore-missing-schemas", "-"); code != 0 {
 		t.Errorf("--ignore-missing-schemas should tolerate it, got exit %d:\n%s", code, out)
 	}
 }
@@ -293,11 +300,11 @@ func TestStrictPromotesUnknownFields(t *testing.T) {
 
 	src := "receivers:\n  otlp:\n    protocols:\n      grpc:\nexporters:\n  debug:\n    verbosty: normal\n" +
 		"service:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      exporters: [debug]\n"
-	if code, _, _ := run(t, src, "-"); code != 0 {
+	if code, _, _ := lint(t, src, "-"); code != 0 {
 		t.Error("an unknown field is only a warning by default")
 	}
 
-	if code, _, _ := run(t, src, "--strict", "-"); code != 1 {
+	if code, _, _ := lint(t, src, "--strict", "-"); code != 1 {
 		t.Error("--strict should make an unknown field fail")
 	}
 }
@@ -317,11 +324,11 @@ func TestSettingsFile(t *testing.T) {
 	src := "receivers:\n  otlp:\n    protocols:\n      grpc:\nexporters:\n  logging:\n" +
 		"service:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      exporters: [logging]\n"
 
-	if code, out, _ := run(t, src, "--config", path, "-"); code != 0 {
+	if code, out, _ := lint(t, src, "--config", path, "-"); code != 0 {
 		t.Errorf("the settings file should select v0.110.0, got exit %d:\n%s", code, out)
 	}
 
-	if code, _, errOut := run(t, "", "--config", filepath.Join(dir, "missing.yaml"), validConfig); code != 2 ||
+	if code, _, errOut := lint(t, "", "--config", filepath.Join(dir, "missing.yaml"), validConfig); code != 2 ||
 		!strings.Contains(errOut, "missing.yaml") {
 		t.Errorf("an explicit settings file must exist, got %d: %s", code, errOut)
 	}
@@ -346,7 +353,7 @@ func TestFlagsWinOverTheSettingsFile(t *testing.T) {
 	src := "receivers:\n  otlp:\n    protocols:\n      grpc:\nexporters:\n  logging:\n" +
 		"service:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      exporters: [logging]\n"
 
-	code, out, _ := run(t, src, "--config", path, "--collector-version", "v0.157.0", "-")
+	code, out, _ := lint(t, src, "--config", path, "--collector-version", "v0.157.0", "-")
 	if code != 1 || !strings.Contains(out, "unknown-component") {
 		t.Errorf("--collector-version should beat the settings file, got exit %d:\n%s", code, out)
 	}
@@ -366,7 +373,7 @@ func TestAnEmptySettingsFileKeepsTheDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	code, out, errOut := run(t, "", "--config", path, "--min-severity", "error", validConfig)
+	code, out, errOut := lint(t, "", "--config", path, "--min-severity", "error", validConfig)
 	if code != 0 {
 		t.Fatalf("exit %d, stdout=%q stderr=%q", code, out, errOut)
 	}
@@ -386,11 +393,11 @@ func TestExcludeSkipsFilesInADirectoryWalk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if code, _, _ := run(t, "", dir); code != 1 {
+	if code, _, _ := lint(t, "", dir); code != 1 {
 		t.Error("the broken file should be linted without --exclude")
 	}
 
-	if code, _, errOut := run(t, "", "--exclude", "broken.yaml", dir); code != 2 ||
+	if code, _, errOut := lint(t, "", "--exclude", "broken.yaml", dir); code != 2 ||
 		!strings.Contains(errOut, "no YAML files") {
 		t.Errorf("--exclude should have skipped everything, got %d: %s", code, errOut)
 	}
@@ -419,7 +426,7 @@ func TestDirectoryWalkFindsEveryFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	code, out, errOut := run(t, "", "--summary", "--min-severity", "error", dir)
+	code, out, errOut := lint(t, "", "--summary", "--min-severity", "error", dir)
 	if code != 0 {
 		t.Fatalf("exit %d, stdout=%q stderr=%q", code, out, errOut)
 	}
@@ -530,10 +537,28 @@ func TestVersionTakesNoArguments(t *testing.T) {
 	}
 }
 
+// TestABareInvocationPrintsHelp pins that the root command does no work of its
+// own: with no subcommand there is nothing to run, so it lists the ones there
+// are instead of failing.
+func TestABareInvocationPrintsHelp(t *testing.T) {
+	t.Parallel()
+
+	code, out, errOut := run(t, "")
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, errOut)
+	}
+
+	for _, want := range []string{"run", "list", "version"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the help should list %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestNoArgumentsPrintsUsage(t *testing.T) {
 	t.Parallel()
 
-	code, _, errOut := run(t, "")
+	code, _, errOut := lint(t, "")
 	if code != 2 || !strings.Contains(errOut, "Usage:") {
 		t.Errorf("want usage on exit 2, got %d: %s", code, errOut)
 	}
@@ -542,9 +567,20 @@ func TestNoArgumentsPrintsUsage(t *testing.T) {
 func TestAnUnknownFlagIsAUsageError(t *testing.T) {
 	t.Parallel()
 
-	code, _, errOut := run(t, "", "--no-such-flag", validConfig)
+	code, _, errOut := lint(t, "", "--no-such-flag", validConfig)
 	if code != 2 || !strings.Contains(errOut, "Usage:") {
 		t.Errorf("want usage on exit 2, got %d: %s", code, errOut)
+	}
+}
+
+// TestTheRootRejectsLintFlags pins that the lint flags moved to "run" rather
+// than being shared, so a stale command line fails loudly.
+func TestTheRootRejectsLintFlags(t *testing.T) {
+	t.Parallel()
+
+	code, _, errOut := run(t, "", "--strict", validConfig)
+	if code != 2 || !strings.Contains(errOut, "unknown flag") {
+		t.Errorf("want a usage error, got %d: %s", code, errOut)
 	}
 }
 
@@ -553,7 +589,7 @@ func TestAnUnknownFlagIsAUsageError(t *testing.T) {
 func TestFindingsDoNotPrintUsage(t *testing.T) {
 	t.Parallel()
 
-	code, _, errOut := run(t, "", badConfig)
+	code, _, errOut := lint(t, "", badConfig)
 	if code != 1 {
 		t.Fatalf("want exit 1, got %d", code)
 	}
@@ -566,7 +602,7 @@ func TestFindingsDoNotPrintUsage(t *testing.T) {
 func TestSummaryCountsFiles(t *testing.T) {
 	t.Parallel()
 
-	_, out, _ := run(t, "", "--summary", "--min-severity", "error", validConfig, badConfig)
+	_, out, _ := lint(t, "", "--summary", "--min-severity", "error", validConfig, badConfig)
 	if !strings.Contains(out, "2 file(s) checked, 1 valid, 1 invalid") {
 		t.Errorf("unexpected summary:\n%s", out)
 	}
@@ -577,7 +613,7 @@ func TestSummaryCountsFiles(t *testing.T) {
 func TestAFileNamedTwiceIsCheckedOnce(t *testing.T) {
 	t.Parallel()
 
-	_, out, _ := run(t, "", "--summary", "--min-severity", "error",
+	_, out, _ := lint(t, "", "--summary", "--min-severity", "error",
 		validConfig, filepath.Join(validConfig, "agent.yaml"))
 	if !strings.Contains(out, "1 file(s) checked") {
 		t.Errorf("the file should have been de-duplicated:\n%s", out)
@@ -589,8 +625,8 @@ func TestAFileNamedTwiceIsCheckedOnce(t *testing.T) {
 func TestReportOrderDoesNotDependOnArgumentOrder(t *testing.T) {
 	t.Parallel()
 
-	_, forwards, _ := run(t, "", "--output", "tap", validConfig, invalidConfig)
-	_, backwards, _ := run(t, "", "--output", "tap", invalidConfig, validConfig)
+	_, forwards, _ := lint(t, "", "--output", "tap", validConfig, invalidConfig)
+	_, backwards, _ := lint(t, "", "--output", "tap", invalidConfig, validConfig)
 
 	if forwards != backwards {
 		t.Errorf("argument order changed the report:\n%s\nvs\n%s", forwards, backwards)

--- a/pkg/cmd/otelcol-config-lint/run.go
+++ b/pkg/cmd/otelcol-config-lint/run.go
@@ -1,0 +1,47 @@
+package otelcolconfiglint
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// newRunCommand builds "run", the command that actually lints. It is where
+// every lint flag lives, and the only one whose exit code carries findings.
+func newRunCommand(opts *Options) *cobra.Command {
+	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+		Use:   "run [flags] <file|dir|->...",
+		Short: "Lint the given config files",
+		Example: `  otelcol-config-lint run config.yaml
+  otelcol-config-lint run --collector-version v0.157.0 --summary ./configs
+  cat config.yaml | otelcol-config-lint run -
+  otelcol-config-lint run --output json --strict ./configs > report.json`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := opts.Prepare(cmd)
+			if err != nil {
+				return err
+			}
+
+			err = opts.Run(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	// Only this command can end in anything but 0 or 2, so the footer belongs
+	// here rather than on the root where every subcommand would inherit it.
+	cmd.SetUsageTemplate(cmd.UsageTemplate() + fmt.Sprintf(`
+Exit codes:
+  %d  every file passed
+  %d  at least one file failed
+  %d  the command could not run
+`, ExitOK, ExitInvalid, ExitUsage))
+
+	opts.RegisterFlags(cmd)
+
+	return cmd
+}


### PR DESCRIPTION
Follows #19 to its conclusion, the way `golangci-lint` spells it.

> **Stacked on #25.** Base is `feat/list-subcommand`; the diff collapses to this commit alone once that merges.

## What changed

The root command does no work of its own. Every mode is a subcommand:

```
otelcol-config-lint run [flags] <file|dir|->...
otelcol-config-lint list rules
otelcol-config-lint list versions
otelcol-config-lint version
```

A bare invocation prints the help that lists them (exit 0) rather than a usage error.

Every lint flag moves to `run`, so the root's `--help` is a list of commands instead of twenty flags only one of them uses:

```
Usage:
  otelcol-config-lint [command]

Available Commands:
  list        Print what the linter knows about
  run         Lint the given config files
  version     Print the linter version

Flags:
  -h, --help      help for otelcol-config-lint
  -v, --version   version for otelcol-config-lint
```

The exit-code footer moves with the flags: `run` is the only command that can exit 1, so it is the only one whose help should explain what 1 means. That also retires the usage template `list` had to set in #25 purely to suppress the footer it was inheriting.

## Compatibility

**This breaks the CLI**, in the same release as the other two splits. `otelcol-config-lint config.yaml` becomes `otelcol-config-lint run config.yaml`.

Updated with it:

- `.github/workflows/test.yaml` and `build.yaml`
- every README example, including the container one — the image's `ENTRYPOINT` is the binary, so `docker run … otelcol-config-lint:latest run --summary ./configs`

## Verification

`go test ./...` and `golangci-lint run` are clean. Two new tests pin the new shape: a bare invocation prints the command list and exits 0, and the root rejects `--strict` so a stale command line fails loudly instead of being silently ignored. The existing lint tests go through a `lint()` helper that prepends `run`, so they still assert on the real path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)