### PR TITLE
chore(lint): exclude cobra.Command from exhaustruct

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -38,6 +38,9 @@ linters:
         - 'github\.com/minuk-dev/otelcol-config-lint/pkg/lint\.(Options|FormatterOptions|Result|Summary)'
         - 'github\.com/minuk-dev/otelcol-config-lint/pkg/catalog\.(Store|Catalog|Component|Field)'
         - 'github\.com/minuk-dev/otelcol-config-lint/pkg/rule\.Context'
+        # cobra.Command has some forty fields and its zero values are the
+        # defaults every command wants; each one sets only what it changes.
+        - 'github\.com/spf13/cobra\.Command'
         # The parser fills these in as it walks the document.
         - 'github\.com/minuk-dev/otelcol-config-lint/pkg/config\..+'
         - 'net/http\.Client'

--- a/pkg/cmd/otelcol-config-lint/list.go
+++ b/pkg/cmd/otelcol-config-lint/list.go
@@ -14,7 +14,7 @@ import (
 // newListCommand builds "list" and its subcommands. Each one carries only the
 // flags that change what it prints, so their help stays short.
 func newListCommand(opts *Options) *cobra.Command {
-	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Print what the linter knows about",
 		Example: `  otelcol-config-lint list rules
@@ -29,7 +29,7 @@ func newListCommand(opts *Options) *cobra.Command {
 // newListRulesCommand builds "list rules". The severity flags apply because
 // they decide the severity the rules will actually run at.
 func (o *Options) newListRulesCommand() *cobra.Command {
-	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+	cmd := &cobra.Command{
 		Use:   "rules",
 		Short: "Print the rules and their default severities",
 		Long: "Print the rules and their default severities.\n\n" +
@@ -55,7 +55,7 @@ func (o *Options) newListRulesCommand() *cobra.Command {
 // newListVersionsCommand builds "list versions". --collector-version is
 // deliberately absent: this is the command that says which ones exist.
 func (o *Options) newListVersionsCommand() *cobra.Command {
-	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+	cmd := &cobra.Command{
 		Use:   "versions",
 		Short: "Print the available catalog versions",
 		Args:  cobra.NoArgs,

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -108,7 +108,7 @@ func NewCommand(opts *Options) *cobra.Command {
 
 	// The root carries no work of its own: every mode is a subcommand, so a
 	// bare invocation prints the help that lists them.
-	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+	cmd := &cobra.Command{
 		Use:     "otelcol-config-lint <command> [flags]",
 		Short:   "Validate OpenTelemetry Collector config files against a specific collector release",
 		Version: Version,

--- a/pkg/cmd/otelcol-config-lint/run.go
+++ b/pkg/cmd/otelcol-config-lint/run.go
@@ -9,7 +9,7 @@ import (
 // newRunCommand builds "run", the command that actually lints. It is where
 // every lint flag lives, and the only one whose exit code carries findings.
 func newRunCommand(opts *Options) *cobra.Command {
-	cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+	cmd := &cobra.Command{
 		Use:   "run [flags] <file|dir|->...",
 		Short: "Lint the given config files",
 		Example: `  otelcol-config-lint run config.yaml

--- a/pkg/cmd/otelcol-config-lint/version.go
+++ b/pkg/cmd/otelcol-config-lint/version.go
@@ -15,7 +15,7 @@ const versionTemplate = "otelcol-config-lint {{.Version}}\n"
 
 // newVersionCommand builds the "version" subcommand.
 func newVersionCommand() *cobra.Command {
-	return &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
+	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the linter version",
 		Args:  cobra.NoArgs,


### PR DESCRIPTION
Config change, no behaviour change.

> **Stacked on #26.** Base is `feat/run-subcommand`, because that PR is what brings the count of command literals to six. The diff collapses to this commit alone once #25 and #26 merge.

## Why

After the #19 split there are six `&cobra.Command{...}` literals, each carrying the same directive with the same reason:

```go
cmd := &cobra.Command{ //nolint:exhaustruct // cobra's zero values are the defaults we want
```

and every command added later would carry a seventh. `cobra.Command` has some forty fields whose zero values *are* the defaults, so nobody ever fills it exhaustively. That is a property of the type, not of each use, so it belongs in `.golangci.yaml` next to the other partially-set option structs:

```yaml
# cobra.Command has some forty fields and its zero values are the
# defaults every command wants; each one sets only what it changes.
- 'github\.com/spf13/cobra\.Command'
```

The six directives are then removed — `nolintlint` would flag them as unused anyway, so this has to be one change rather than two.

`&Options{}` keeps its directive: that one is filled in by `RegisterFlags`, which is a fact about the call site.

## Verification

`golangci-lint run` reports 0 issues. Checked that the exclusion is what silences them rather than the directives having been dead: dropping the three config lines and keeping the code as-is reports `6 issues: * exhaustruct: 6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)