### PR TITLE
fix(schemagen): drop entries that are not declarable components

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ left alone.
 [`catalogs/`](catalogs) holds one file per collector release, in both YAML (the
 readable form, meant to be reviewed in pull requests) and JSON. They are
 generated from the `metadata.yaml` that every upstream component ships, across
-**both core and contrib** — 342 components for v0.157.0.
+**both core and contrib** — 324 components for v0.157.0.
 
 ```yaml
 components:

--- a/catalogs/v0.110.0.json
+++ b/catalogs/v0.110.0.json
@@ -4,7 +4,7 @@
     "core",
     "contrib"
   ],
-  "generatedAt": "2026-07-31T13:05:51Z",
+  "generatedAt": "2026-08-02T06:26:57Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -3493,23 +3493,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver"
-      },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplereceiver"
       },
       "saphana": {
         "type": "saphana",

--- a/catalogs/v0.110.0.yaml
+++ b/catalogs/v0.110.0.yaml
@@ -2,7 +2,7 @@ collectorVersion: v0.110.0
 distributions:
   - core
   - contrib
-generatedAt: "2026-07-31T13:05:51Z"
+generatedAt: "2026-08-02T06:26:57Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -2484,19 +2484,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: development
-        metrics: stable
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/samplereceiver
     saphana:
       type: saphana
       signals:

--- a/catalogs/v0.120.0.json
+++ b/catalogs/v0.120.0.json
@@ -4,7 +4,7 @@
     "core",
     "contrib"
   ],
-  "generatedAt": "2026-07-31T13:05:51Z",
+  "generatedAt": "2026-08-02T06:26:58Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -1923,23 +1923,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor"
       },
-      "dynatracedetector": {
-        "type": "dynatracedetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace"
-      },
       "filter": {
         "type": "filter",
         "signals": [
@@ -2264,23 +2247,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor"
-      },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor"
       },
       "schema": {
         "type": "schema",
@@ -3756,23 +3722,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver"
-      },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplereceiver"
       },
       "saphana": {
         "type": "saphana",

--- a/catalogs/v0.120.0.yaml
+++ b/catalogs/v0.120.0.yaml
@@ -2,7 +2,7 @@ collectorVersion: v0.120.0
 distributions:
   - core
   - contrib
-generatedAt: "2026-07-31T13:05:51Z"
+generatedAt: "2026-08-02T06:26:58Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -1370,19 +1370,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
-    dynatracedetector:
-      type: dynatracedetector
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: alpha
-        metrics: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace
     filter:
       type: filter
       signals:
@@ -1628,19 +1615,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: development
-        metrics: stable
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor
     schema:
       type: schema
       signals:
@@ -2686,19 +2660,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: development
-        metrics: stable
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/samplereceiver
     saphana:
       type: saphana
       signals:

--- a/catalogs/v0.130.0.json
+++ b/catalogs/v0.130.0.json
@@ -4,7 +4,7 @@
     "core",
     "contrib"
   ],
-  "generatedAt": "2026-07-31T13:05:51Z",
+  "generatedAt": "2026-08-02T06:27:02Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -237,22 +237,6 @@
           "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
-      },
-      "sample": {
-        "type": "sample",
-        "stability": {
-          "metrics_to_metrics": "development"
-        },
-        "pairs": [
-          {
-            "from": "metrics",
-            "to": "metrics"
-          }
-        ],
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleconnector"
       },
       "servicegraph": {
         "type": "servicegraph",
@@ -2073,23 +2057,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor"
       },
-      "dynatracedetector": {
-        "type": "dynatracedetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace"
-      },
       "filter": {
         "type": "filter",
         "signals": [
@@ -2419,23 +2386,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor",
         "deprecated": "Use routing connector (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36616)"
-      },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor"
       },
       "schema": {
         "type": "schema",
@@ -3957,26 +3907,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver"
-      },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "profiles": "deprecated",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplereceiver",
-        "deprecated": "no migration needed"
       },
       "saphana": {
         "type": "saphana",

--- a/catalogs/v0.130.0.yaml
+++ b/catalogs/v0.130.0.yaml
@@ -2,7 +2,7 @@ collectorVersion: v0.130.0
 distributions:
   - core
   - contrib
-generatedAt: "2026-07-31T13:05:51Z"
+generatedAt: "2026-08-02T06:27:02Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -151,16 +151,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
-    sample:
-      type: sample
-      stability:
-        metrics_to_metrics: development
-      pairs:
-        - from: metrics
-          to: metrics
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleconnector
     servicegraph:
       type: servicegraph
       stability:
@@ -1478,19 +1468,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor
-    dynatracedetector:
-      type: dynatracedetector
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: alpha
-        metrics: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace
     filter:
       type: filter
       signals:
@@ -1741,19 +1718,6 @@ components:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
       deprecated: Use routing connector (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36616)
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: development
-        metrics: stable
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor
     schema:
       type: schema
       signals:
@@ -2833,22 +2797,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: stable
-        profiles: deprecated
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/samplereceiver
-      deprecated: no migration needed
     saphana:
       type: saphana
       signals:

--- a/catalogs/v0.140.0.json
+++ b/catalogs/v0.140.0.json
@@ -4,7 +4,7 @@
     "core",
     "contrib"
   ],
-  "generatedAt": "2026-07-31T13:05:51Z",
+  "generatedAt": "2026-08-02T06:27:04Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -242,22 +242,6 @@
           "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
-      },
-      "sample": {
-        "type": "sample",
-        "stability": {
-          "metrics_to_metrics": "development"
-        },
-        "pairs": [
-          {
-            "from": "metrics",
-            "to": "metrics"
-          }
-        ],
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleconnector"
       },
       "servicegraph": {
         "type": "servicegraph",
@@ -1899,25 +1883,6 @@
       }
     },
     "processor": {
-      "akamaidetector": {
-        "type": "akamaidetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/akamai"
-      },
       "attributes": {
         "type": "attributes",
         "signals": [
@@ -2054,25 +2019,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor"
       },
-      "digitaloceandetector": {
-        "type": "digitaloceandetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/digitalocean"
-      },
       "dnslookup": {
         "type": "dnslookup",
         "signals": [
@@ -2089,23 +2035,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor"
-      },
-      "dynatracedetector": {
-        "type": "dynatracedetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace"
       },
       "filter": {
         "type": "filter",
@@ -2176,25 +2105,6 @@
           "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor"
-      },
-      "hetznerdetector": {
-        "type": "hetznerdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/hetzner"
       },
       "interval": {
         "type": "interval",
@@ -2363,25 +2273,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
       },
-      "novadetector": {
-        "type": "novadetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openstack/nova"
-      },
       "probabilistic_sampler": {
         "type": "probabilistic_sampler",
         "signals": [
@@ -2475,42 +2366,6 @@
           "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
-      },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor"
-      },
-      "scalewaydetector": {
-        "type": "scalewaydetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/scaleway"
       },
       "schema": {
         "type": "schema",
@@ -2606,44 +2461,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor"
-      },
-      "upclouddetector": {
-        "type": "upclouddetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/upcloud"
-      },
-      "vultrdetector": {
-        "type": "vultrdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/vultr"
       }
     },
     "receiver": {
@@ -4125,26 +3942,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver"
-      },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "profiles": "deprecated",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplefactoryreceiver",
-        "deprecated": "no migration needed"
       },
       "saphana": {
         "type": "saphana",

--- a/catalogs/v0.140.0.yaml
+++ b/catalogs/v0.140.0.yaml
@@ -2,7 +2,7 @@ collectorVersion: v0.140.0
 distributions:
   - core
   - contrib
-generatedAt: "2026-07-31T13:05:51Z"
+generatedAt: "2026-08-02T06:27:04Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -154,16 +154,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
-    sample:
-      type: sample
-      stability:
-        metrics_to_metrics: development
-      pairs:
-        - from: metrics
-          to: metrics
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleconnector
     servicegraph:
       type: servicegraph
       stability:
@@ -1348,21 +1338,6 @@ components:
         - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
   processor:
-    akamaidetector:
-      type: akamaidetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/akamai
     attributes:
       type: attributes
       signals:
@@ -1462,21 +1437,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
-    digitaloceandetector:
-      type: digitaloceandetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/digitalocean
     dnslookup:
       type: dnslookup
       signals:
@@ -1490,19 +1450,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor
-    dynatracedetector:
-      type: dynatracedetector
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: alpha
-        metrics: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace
     filter:
       type: filter
       signals:
@@ -1557,21 +1504,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
-    hetznerdetector:
-      type: hetznerdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/hetzner
     interval:
       type: interval
       signals:
@@ -1695,21 +1627,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
-    novadetector:
-      type: novadetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openstack/nova
     probabilistic_sampler:
       type: probabilistic_sampler
       signals:
@@ -1784,34 +1701,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: development
-        metrics: stable
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor
-    scalewaydetector:
-      type: scalewaydetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/scaleway
     schema:
       type: schema
       signals:
@@ -1883,36 +1772,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor
-    upclouddetector:
-      type: upclouddetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/upcloud
-    vultrdetector:
-      type: vultrdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/vultr
   receiver:
     active_directory_ds:
       type: active_directory_ds
@@ -2960,22 +2819,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: stable
-        profiles: deprecated
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/samplefactoryreceiver
-      deprecated: no migration needed
     saphana:
       type: saphana
       signals:

--- a/catalogs/v0.150.0.json
+++ b/catalogs/v0.150.0.json
@@ -4,7 +4,7 @@
     "core",
     "contrib"
   ],
-  "generatedAt": "2026-07-31T13:05:52Z",
+  "generatedAt": "2026-08-02T06:27:08Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -258,27 +258,6 @@
           "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
-      },
-      "sample": {
-        "type": "sample",
-        "stability": {
-          "metrics_to_metrics": "development",
-          "profiles_to_profiles": "development"
-        },
-        "pairs": [
-          {
-            "from": "metrics",
-            "to": "metrics"
-          },
-          {
-            "from": "profiles",
-            "to": "profiles"
-          }
-        ],
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleconnector"
       },
       "servicegraph": {
         "type": "servicegraph",
@@ -2083,44 +2062,6 @@
       }
     },
     "processor": {
-      "akamaidetector": {
-        "type": "akamaidetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/akamai"
-      },
-      "alibabaecsdetector": {
-        "type": "alibabaecsdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/alibaba/ecs"
-      },
       "attributes": {
         "type": "attributes",
         "signals": [
@@ -2139,25 +2080,6 @@
           "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
-      },
-      "azuredetector": {
-        "type": "azuredetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "beta",
-          "metrics": "beta",
-          "profiles": "development",
-          "traces": "beta"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure"
       },
       "batch": {
         "type": "batch",
@@ -2263,25 +2185,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor"
       },
-      "digitaloceandetector": {
-        "type": "digitaloceandetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/digitalocean"
-      },
       "dnslookup": {
         "type": "dnslookup",
         "signals": [
@@ -2298,23 +2201,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor"
-      },
-      "dynatracedetector": {
-        "type": "dynatracedetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace"
       },
       "filter": {
         "type": "filter",
@@ -2385,63 +2271,6 @@
           "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor"
-      },
-      "hetznerdetector": {
-        "type": "hetznerdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/hetzner"
-      },
-      "ibmcloudclassicdetector": {
-        "type": "ibmcloudclassicdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "development",
-          "profiles": "development",
-          "traces": "development"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/classic"
-      },
-      "ibmcloudvpcdetector": {
-        "type": "ibmcloudvpcdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "development",
-          "profiles": "development",
-          "traces": "development"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/vpc"
       },
       "interval": {
         "type": "interval",
@@ -2662,44 +2491,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
       },
-      "novadetector": {
-        "type": "novadetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openstack/nova"
-      },
-      "oracleclouddetector": {
-        "type": "oracleclouddetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/oraclecloud"
-      },
       "probabilistic_sampler": {
         "type": "probabilistic_sampler",
         "signals": [
@@ -2794,44 +2585,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
       },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "profiles": "development",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor"
-      },
-      "scalewaydetector": {
-        "type": "scalewaydetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/scaleway"
-      },
       "schema": {
         "type": "schema",
         "signals": [
@@ -2907,25 +2660,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
       },
-      "tencentcvmdetector": {
-        "type": "tencentcvmdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/tencent/cvm"
-      },
       "transform": {
         "type": "transform",
         "signals": [
@@ -2958,44 +2692,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor"
-      },
-      "upclouddetector": {
-        "type": "upclouddetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/upcloud"
-      },
-      "vultrdetector": {
-        "type": "vultrdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/vultr"
       }
     },
     "receiver": {
@@ -4654,39 +4350,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver"
-      },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "profiles": "deprecated",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplefactoryreceiver",
-        "deprecated": "no migration needed"
-      },
-      "sampleentity": {
-        "type": "sampleentity",
-        "signals": [
-          "metrics"
-        ],
-        "stability": {
-          "metrics": "development"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleentityreceiver"
       },
       "saphana": {
         "type": "saphana",

--- a/catalogs/v0.150.0.yaml
+++ b/catalogs/v0.150.0.yaml
@@ -2,7 +2,7 @@ collectorVersion: v0.150.0
 distributions:
   - core
   - contrib
-generatedAt: "2026-07-31T13:05:52Z"
+generatedAt: "2026-08-02T06:27:08Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -164,19 +164,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
-    sample:
-      type: sample
-      stability:
-        metrics_to_metrics: development
-        profiles_to_profiles: development
-      pairs:
-        - from: metrics
-          to: metrics
-        - from: profiles
-          to: profiles
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleconnector
     servicegraph:
       type: servicegraph
       stability:
@@ -1489,36 +1476,6 @@ components:
         - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
   processor:
-    akamaidetector:
-      type: akamaidetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/akamai
-    alibabaecsdetector:
-      type: alibabaecsdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/alibaba/ecs
     attributes:
       type: attributes
       signals:
@@ -1534,21 +1491,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
-    azuredetector:
-      type: azuredetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: beta
-        metrics: beta
-        profiles: development
-        traces: beta
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure
     batch:
       type: batch
       signals:
@@ -1624,21 +1566,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
-    digitaloceandetector:
-      type: digitaloceandetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/digitalocean
     dnslookup:
       type: dnslookup
       signals:
@@ -1652,19 +1579,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor
-    dynatracedetector:
-      type: dynatracedetector
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: alpha
-        metrics: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace
     filter:
       type: filter
       signals:
@@ -1719,51 +1633,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
-    hetznerdetector:
-      type: hetznerdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/hetzner
-    ibmcloudclassicdetector:
-      type: ibmcloudclassicdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: development
-        profiles: development
-        traces: development
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/classic
-    ibmcloudvpcdetector:
-      type: ibmcloudvpcdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: development
-        profiles: development
-        traces: development
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/vpc
     interval:
       type: interval
       signals:
@@ -1927,36 +1796,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
-    novadetector:
-      type: novadetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openstack/nova
-    oracleclouddetector:
-      type: oracleclouddetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/oraclecloud
     probabilistic_sampler:
       type: probabilistic_sampler
       signals:
@@ -2031,36 +1870,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: stable
-        profiles: development
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor
-    scalewaydetector:
-      type: scalewaydetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/scaleway
     schema:
       type: schema
       signals:
@@ -2116,21 +1925,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
-    tencentcvmdetector:
-      type: tencentcvmdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/tencent/cvm
     transform:
       type: transform
       signals:
@@ -2156,36 +1950,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor
-    upclouddetector:
-      type: upclouddetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/upcloud
-    vultrdetector:
-      type: vultrdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/vultr
   receiver:
     active_directory_ds:
       type: active_directory_ds
@@ -3370,31 +3134,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: stable
-        profiles: deprecated
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/samplefactoryreceiver
-      deprecated: no migration needed
-    sampleentity:
-      type: sampleentity
-      signals:
-        - metrics
-      stability:
-        metrics: development
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleentityreceiver
     saphana:
       type: saphana
       signals:

--- a/catalogs/v0.157.0.json
+++ b/catalogs/v0.157.0.json
@@ -4,7 +4,7 @@
     "core",
     "contrib"
   ],
-  "generatedAt": "2026-07-31T13:05:52Z",
+  "generatedAt": "2026-08-02T06:27:12Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -337,27 +337,6 @@
           "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
-      },
-      "sample": {
-        "type": "sample",
-        "stability": {
-          "metrics_to_metrics": "development",
-          "profiles_to_profiles": "development"
-        },
-        "pairs": [
-          {
-            "from": "metrics",
-            "to": "metrics"
-          },
-          {
-            "from": "profiles",
-            "to": "profiles"
-          }
-        ],
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleconnector"
       },
       "service_graph": {
         "type": "service_graph",
@@ -2305,44 +2284,6 @@
       }
     },
     "processor": {
-      "akamaidetector": {
-        "type": "akamaidetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/akamai"
-      },
-      "alibabaecsdetector": {
-        "type": "alibabaecsdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/alibaba/ecs"
-      },
       "attributes": {
         "type": "attributes",
         "signals": [
@@ -2380,25 +2321,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/awsecsattributesprocessor"
-      },
-      "azuredetector": {
-        "type": "azuredetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "beta",
-          "metrics": "beta",
-          "profiles": "development",
-          "traces": "beta"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure"
       },
       "batch": {
         "type": "batch",
@@ -2534,25 +2456,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor"
       },
-      "digitaloceandetector": {
-        "type": "digitaloceandetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/digitalocean"
-      },
       "drain": {
         "type": "drain",
         "signals": [
@@ -2579,23 +2482,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/dynamicsamplingprocessor"
-      },
-      "dynatracedetector": {
-        "type": "dynatracedetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace"
       },
       "filter": {
         "type": "filter",
@@ -2679,63 +2565,6 @@
           "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor"
-      },
-      "hetznerdetector": {
-        "type": "hetznerdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/hetzner"
-      },
-      "ibmcloudclassicdetector": {
-        "type": "ibmcloudclassicdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "development",
-          "profiles": "development",
-          "traces": "development"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/classic"
-      },
-      "ibmcloudvpcdetector": {
-        "type": "ibmcloudvpcdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "development",
-          "profiles": "development",
-          "traces": "development"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/vpc"
       },
       "interval": {
         "type": "interval",
@@ -2994,44 +2823,6 @@
         "deprecated": "renamed to \"metrics_transform\" upstream; the old name still resolves for now",
         "aliasOf": "metrics_transform"
       },
-      "novadetector": {
-        "type": "novadetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openstack/nova"
-      },
-      "oracleclouddetector": {
-        "type": "oracleclouddetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/oraclecloud"
-      },
       "probabilistic_sampler": {
         "type": "probabilistic_sampler",
         "signals": [
@@ -3149,44 +2940,6 @@
         "deprecated": "renamed to \"resource_detection\" upstream; the old name still resolves for now",
         "aliasOf": "resource_detection"
       },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "profiles": "development",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor"
-      },
-      "scalewaydetector": {
-        "type": "scalewaydetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/scaleway"
-      },
       "schema": {
         "type": "schema",
         "signals": [
@@ -3278,25 +3031,6 @@
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
       },
-      "tencentcvmdetector": {
-        "type": "tencentcvmdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/tencent/cvm"
-      },
       "transform": {
         "type": "transform",
         "signals": [
@@ -3329,44 +3063,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor"
-      },
-      "upclouddetector": {
-        "type": "upclouddetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/upcloud"
-      },
-      "vultrdetector": {
-        "type": "vultrdetector",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "alpha",
-          "metrics": "alpha",
-          "profiles": "alpha",
-          "traces": "alpha"
-        },
-        "distributions": [
-          "contrib"
-        ],
-        "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/vultr"
       }
     },
     "receiver": {
@@ -5253,39 +4949,6 @@
           "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver"
-      },
-      "sample": {
-        "type": "sample",
-        "signals": [
-          "traces",
-          "metrics",
-          "logs",
-          "profiles"
-        ],
-        "stability": {
-          "logs": "development",
-          "metrics": "stable",
-          "profiles": "deprecated",
-          "traces": "beta"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/samplefactoryreceiver",
-        "deprecated": "no migration needed"
-      },
-      "sampleentity": {
-        "type": "sampleentity",
-        "signals": [
-          "metrics"
-        ],
-        "stability": {
-          "metrics": "development"
-        },
-        "distributions": [
-          "core"
-        ],
-        "module": "go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleentityreceiver"
       },
       "saphana": {
         "type": "saphana",

--- a/catalogs/v0.157.0.yaml
+++ b/catalogs/v0.157.0.yaml
@@ -2,7 +2,7 @@ collectorVersion: v0.157.0
 distributions:
   - core
   - contrib
-generatedAt: "2026-07-31T13:05:52Z"
+generatedAt: "2026-08-02T06:27:12Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -217,19 +217,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
-    sample:
-      type: sample
-      stability:
-        metrics_to_metrics: development
-        profiles_to_profiles: development
-      pairs:
-        - from: metrics
-          to: metrics
-        - from: profiles
-          to: profiles
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleconnector
     service_graph:
       type: service_graph
       stability:
@@ -1649,36 +1636,6 @@ components:
         - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
   processor:
-    akamaidetector:
-      type: akamaidetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/akamai
-    alibabaecsdetector:
-      type: alibabaecsdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/alibaba/ecs
     attributes:
       type: attributes
       signals:
@@ -1709,21 +1666,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/awsecsattributesprocessor
-    azuredetector:
-      type: azuredetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: beta
-        metrics: beta
-        profiles: development
-        traces: beta
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure
     batch:
       type: batch
       signals:
@@ -1821,21 +1763,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
-    digitaloceandetector:
-      type: digitaloceandetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/digitalocean
     drain:
       type: drain
       signals:
@@ -1855,19 +1782,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dynamicsamplingprocessor
-    dynatracedetector:
-      type: dynatracedetector
-      signals:
-        - traces
-        - metrics
-        - logs
-      stability:
-        logs: alpha
-        metrics: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace
     filter:
       type: filter
       signals:
@@ -1931,51 +1845,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
-    hetznerdetector:
-      type: hetznerdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/hetzner
-    ibmcloudclassicdetector:
-      type: ibmcloudclassicdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: development
-        profiles: development
-        traces: development
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/classic
-    ibmcloudvpcdetector:
-      type: ibmcloudvpcdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: development
-        profiles: development
-        traces: development
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/vpc
     interval:
       type: interval
       signals:
@@ -2169,36 +2038,6 @@ components:
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       deprecated: renamed to "metrics_transform" upstream; the old name still resolves for now
       aliasOf: metrics_transform
-    novadetector:
-      type: novadetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openstack/nova
-    oracleclouddetector:
-      type: oracleclouddetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/oraclecloud
     probabilistic_sampler:
       type: probabilistic_sampler
       signals:
@@ -2292,36 +2131,6 @@ components:
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       deprecated: renamed to "resource_detection" upstream; the old name still resolves for now
       aliasOf: resource_detection
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: stable
-        profiles: development
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleprocessor
-    scalewaydetector:
-      type: scalewaydetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/scaleway
     schema:
       type: schema
       signals:
@@ -2389,21 +2198,6 @@ components:
         - contrib
         - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
-    tencentcvmdetector:
-      type: tencentcvmdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/tencent/cvm
     transform:
       type: transform
       signals:
@@ -2429,36 +2223,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor
-    upclouddetector:
-      type: upclouddetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/upcloud
-    vultrdetector:
-      type: vultrdetector
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: alpha
-        metrics: alpha
-        profiles: alpha
-        traces: alpha
-      distributions:
-        - contrib
-      module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/vultr
   receiver:
     active_directory_ds:
       type: active_directory_ds
@@ -3819,31 +3583,6 @@ components:
       distributions:
         - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
-    sample:
-      type: sample
-      signals:
-        - traces
-        - metrics
-        - logs
-        - profiles
-      stability:
-        logs: development
-        metrics: stable
-        profiles: deprecated
-        traces: beta
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/samplefactoryreceiver
-      deprecated: no migration needed
-    sampleentity:
-      type: sampleentity
-      signals:
-        - metrics
-      stability:
-        metrics: development
-      distributions:
-        - core
-      module: go.opentelemetry.io/collector/cmd/mdatagen/internal/sampleentityreceiver
     saphana:
       type: saphana
       signals:

--- a/tools/schemagen/main.go
+++ b/tools/schemagen/main.go
@@ -390,12 +390,26 @@ func classKind(class string) (config.Kind, bool) {
 	return "", false
 }
 
-func convert(meta metadata, src source, tarPath string) (*catalog.Component, config.Kind, bool) {
+// configurable resolves the component kind for an upstream metadata file and
+// reports whether the file describes something a config can declare at all.
+func configurable(meta metadata, tarPath string) (config.Kind, bool) {
 	kind, ok := classKind(meta.Status.Class)
-	if !ok || meta.Type == "" || meta.Parent != "" {
-		// A parent means this is a sub-component such as a hostmetrics
-		// scraper, which is configured inside its parent rather than declared
-		// on its own.
+	if !ok || meta.Type == "" {
+		return "", false
+	}
+
+	// A parent means this is a sub-component such as a hostmetrics scraper,
+	// which is configured inside its parent rather than declared on its own.
+	if meta.Parent != "" || !declarable(tarPath) {
+		return "", false
+	}
+
+	return kind, true
+}
+
+func convert(meta metadata, src source, tarPath string) (*catalog.Component, config.Kind, bool) {
+	kind, ok := configurable(meta, tarPath)
+	if !ok {
 		return nil, "", false
 	}
 
@@ -452,6 +466,30 @@ func convert(meta metadata, src source, tarPath string) (*catalog.Component, con
 	}
 
 	return comp, kind, true
+}
+
+// declarable reports whether an in-archive metadata path belongs to a component
+// that can be declared in a config. A real component sits directly at
+// "<kind>/<name>", never under "cmd" — mdatagen ships sample components to
+// exercise its own code generation — and never under "internal", which holds a
+// component's sub-parts, such as the resourcedetection providers that are
+// configured inside their parent's "detectors" list. Upstream leaves the
+// metadata "parent" field unset for both, so the path is what tells them apart.
+func declarable(tarPath string) bool {
+	dir := path.Dir(tarPath)
+
+	_, rest, found := strings.Cut(dir, "/") // drop the archive root
+	if !found {
+		return false
+	}
+
+	for seg := range strings.SplitSeq(rest, "/") {
+		if seg == "cmd" || seg == "internal" {
+			return false
+		}
+	}
+
+	return true
 }
 
 // modulePath turns an in-archive path such as


### PR DESCRIPTION
Found while investigating #8. Two kinds of upstream `metadata.yaml` were harvested as though they were components, so the linter **accepted config no collector can load**:

```yaml
processors:
  akamaidetector:   # a resourcedetection provider, not a processor
  sample:           # an mdatagen code-generation fixture
```

Both pass clean on `main` today. That is the false-negative class this linter exists to prevent.

## What they actually are

| Entries | v0.157.0 | Module shape |
| --- | --- | --- |
| mdatagen fixtures | 4 | `go.opentelemetry.io/collector/cmd/mdatagen/internal/sample*` |
| resourcedetection providers | 14 | `.../resourcedetectionprocessor/internal/<provider>` |

`sample` and `sampleentity` exist to exercise mdatagen's own code generation. `akamaidetector` and friends are configured *inside* `resourcedetection`'s `detectors:` list, never as top-level processors.

`convert` already skips sub-components via `meta.Parent != ""`, but upstream leaves `parent` unset for both of these, so the guard never fired.

## The fix

A declarable component sits at `<kind>/<name>`, never under `cmd` or `internal`, so the archive path is what distinguishes them. One predicate, `declarable(tarPath)`, applied alongside the existing guards — which moved into a `configurable` helper to keep `convert` under the cyclop limit.

## Effect on the catalogs

| Release | Before | After | Removed |
| --- | --- | --- | --- |
| v0.110.0 | 228 | 227 | 1 |
| v0.120.0 | 244 | 241 | 3 |
| v0.130.0 | 260 | 256 | 4 |
| v0.140.0 | 269 | 258 | 11 |
| v0.150.0 | 304 | 286 | 18 |
| v0.157.0 | 342 | 324 | 18 |

## Verification

Regenerated all six releases and diffed structurally against the committed files, ignoring `generatedAt`:

- **removals only** — 0 components added in any release
- the removed set is exactly the 18 listed above, no legitimate component among them
- **no surviving component changes by a single field**
- `resourcedetection` itself, `filelog` and `otlp` all still present

Both formats still load (`--catalog-location catalogs/{{.Version}}.yaml` and `.json` each lint `testdata/valid` clean), `go test ./...` and `golangci-lint run` pass, and the config above now fails as it should:

```
stdin:2:3: error: unknown processor type "akamaidetector" in collector v0.157.0 [unknown-component]
stdin:3:3: error: unknown processor type "sample" in collector v0.157.0 [unknown-component]
```

## Next

First of four stacked PRs taking the catalogs to per-distribution files served from a remote registry, which is what closes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)