### PR TITLE
feat(cli): add --distribution, closing #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ otelcol-config-lint version
 | --- | --- |
 | `run` | lint the given files, directories, or `-` for stdin |
 | `list rules` | the rules and their default severities, `--disable`/`--severity` applied |
-| `list versions` | the schema versions available, honouring `--schema-location` |
+| `list versions` | the schema versions available, honouring `--schema-location` and `--distribution` |
 | `version` | print the linter version (also available as `--version`) |
 
 The flags below belong to `run`:
@@ -61,6 +61,7 @@ The flags below belong to `run`:
 | Flag | Meaning |
 | --- | --- |
 | `--collector-version` | release to validate against, e.g. `v0.157.0` (default `latest`) |
+| `--distribution` | collector binary to validate against: `core`, `contrib` (default), `k8s` or `otlp` |
 | `--schema-location` | where to find schemas: a registry directory or URL, a `{{.Version}}`/`{{.Distribution}}` template, or `default`. Repeat to search several in order |
 | `--output` | `text`, `json`, `junit`, `tap` or `github` |
 | `--strict` | unknown component settings become errors instead of warnings |
@@ -83,6 +84,7 @@ cat config.yaml | otelcol-config-lint run -                       # read stdin
 otelcol-config-lint run --output json ./configs > report.json     # machine-readable
 otelcol-config-lint run --output github ./configs                 # PR annotations
 otelcol-config-lint run --collector-version v0.110.0 config.yaml  # target an older release
+otelcol-config-lint run --distribution core config.yaml           # target plain otelcol
 ```
 
 ### Settings file
@@ -93,6 +95,7 @@ Explicit flags win over the file.
 
 ```yaml
 collectorVersion: v0.157.0
+distribution: contrib
 minSeverity: warning
 strict: true
 exclude:
@@ -118,8 +121,10 @@ schemaLocations:
 `connector-wiring` (a connector must export from one pipeline and receive into
 another, and must not close a loop).
 
-**Release compatibility** — `unknown-component` (with "exists in v0.110.0 but
-not in v0.157.0" when a component was removed), `signal-support` (a receiver
+**Release and distribution compatibility** — `unknown-component` (with "exists
+in v0.110.0 but not in v0.157.0" when a component was removed, or "not in the
+core distribution; it ships in contrib, k8s" when the binary simply does not
+carry it), `signal-support` (a receiver
 that only does traces used in a metrics pipeline), `component-stability`,
 `deprecated-component`.
 

--- a/pkg/cmd/otelcol-config-lint/list.go
+++ b/pkg/cmd/otelcol-config-lint/list.go
@@ -71,6 +71,7 @@ func (o *Options) newListVersionsCommand() *cobra.Command {
 
 	o.registerSettingsFlag(cmd)
 	o.registerSchemaLocationFlag(cmd)
+	o.registerDistributionFlag(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -79,6 +79,7 @@ const DefaultSettingsFile = ".otelcol-config-lint.yaml"
 type Options struct {
 	// flags
 	collectorVersion string
+	distribution     string
 	schemaLocations  []string
 	output           string
 	settingsFile     string
@@ -141,6 +142,7 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 	// the flags that change what they print.
 	o.registerSettingsFlag(cmd)
 	o.registerSchemaLocationFlag(cmd)
+	o.registerDistributionFlag(cmd)
 	o.registerRuleFlags(cmd)
 
 	flags := cmd.Flags()
@@ -172,7 +174,7 @@ func (o *Options) Prepare(cmd *cobra.Command) error {
 
 	o.applySettings(fileSettings, cmd.Flags().Changed)
 
-	o.store = schema.Store{Locations: o.schemaLocations}
+	o.store = schema.Store{Locations: o.schemaLocations, Distribution: o.distribution}
 
 	return nil
 }
@@ -198,6 +200,13 @@ func (o *Options) Run(cmd *cobra.Command, args []string) error {
 func (o *Options) registerSettingsFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.settingsFile, "config", "",
 		"settings file (default "+DefaultSettingsFile+" if present)")
+}
+
+// registerDistributionFlag declares --distribution, shared with
+// "list versions": both answer differently depending on which binary is meant.
+func (o *Options) registerDistributionFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.distribution, "distribution", schema.DefaultDistribution,
+		"collector distribution to validate against: core, contrib, k8s or otlp")
 }
 
 // registerSchemaLocationFlag declares --schema-location, shared with
@@ -324,6 +333,7 @@ func (o *Options) newLinter(cmd *cobra.Command) (*lint.Linter, error) {
 	return lint.New(lint.Options{
 		Schema:               cat,
 		Availability:         lint.NewVersionIndex(o.store),
+		Distributions:        lint.NewDistributionIndex(o.store, cat.CollectorVersion),
 		Severities:           severities,
 		Strict:               o.strict,
 		IgnoreMissingSchemas: o.ignoreMissing,
@@ -397,6 +407,8 @@ func (o *Options) severityOverrides() (map[string]diag.Severity, error) {
 // commit its linting policy instead of repeating flags in CI.
 type settings struct {
 	CollectorVersion string `yaml:"collectorVersion"`
+	// Distribution names the collector binary the config will run on.
+	Distribution string `yaml:"distribution"`
 	// SchemaLocations are searched in order before the published registry.
 	SchemaLocations      []string          `yaml:"schemaLocations"`
 	Output               string            `yaml:"output"`
@@ -455,6 +467,7 @@ func (o *Options) applySettings(s *settings, changed func(name string) bool) {
 	}
 
 	str("collector-version", &o.collectorVersion, s.CollectorVersion)
+	str("distribution", &o.distribution, s.Distribution)
 	str("output", &o.output, s.Output)
 	str("min-severity", &o.minSeverity, s.MinSeverity)
 	str("fail-on", &o.failOn, s.FailOn)

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -251,6 +251,47 @@ func TestCollectorVersionSelectsTheSchema(t *testing.T) {
 	}
 }
 
+// TestDistributionSelectsTheBinary is the bug #8 describes: filelog ships in
+// contrib but not in core, so a config using it starts fine on otelcol-contrib
+// and fails on plain otelcol with `unknown type: "filelog"`.
+func TestDistributionSelectsTheBinary(t *testing.T) {
+	t.Parallel()
+
+	src := "receivers:\n  filelog:\n    include: [/var/log/app.log]\nexporters:\n  debug:\n" +
+		"service:\n  pipelines:\n    logs:\n      receivers: [filelog]\n      exporters: [debug]\n"
+
+	if code, out, _ := lint(t, src, "--distribution", "contrib",
+		"--collector-version", "v0.157.0", "--min-severity", "error", "-"); code != 0 {
+		t.Errorf("filelog ships in contrib, got exit %d:\n%s", code, out)
+	}
+
+	code, out, _ := lint(t, src, "--distribution", "core",
+		"--collector-version", "v0.157.0", "--min-severity", "error", "-")
+	if code != 1 || !strings.Contains(out, "unknown-component") {
+		t.Fatalf("filelog is not in core, got exit %d:\n%s", code, out)
+	}
+
+	// The fix is switching binaries, not correcting a typo, so the hint has to
+	// say where it does ship rather than suggest a near-miss name.
+	if !strings.Contains(out, "not in the core distribution") || !strings.Contains(out, "contrib") {
+		t.Errorf("the hint should name the distributions that carry it:\n%s", out)
+	}
+}
+
+// TestTheDistributionIsNamedInDiagnostics keeps the report unambiguous: the
+// same config and release can pass or fail depending on the binary.
+func TestTheDistributionIsNamedInDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	src := "receivers:\n  nosuchreceiver:\nexporters:\n  debug:\n" +
+		"service:\n  pipelines:\n    logs:\n      receivers: [nosuchreceiver]\n      exporters: [debug]\n"
+
+	_, out, _ := lint(t, src, "--distribution", "core", "--collector-version", "v0.157.0", "-")
+	if !strings.Contains(out, "(core)") {
+		t.Errorf("the diagnostic should name the distribution checked against:\n%s", out)
+	}
+}
+
 func TestUnknownVersionFallsBackToTheNearestOlder(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lint/distributions.go
+++ b/pkg/lint/distributions.go
@@ -1,0 +1,60 @@
+package lint
+
+import (
+	"sync"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// DistributionIndex answers which distributions ship a component type at one
+// collector release. A schema holds only the distribution it describes, so a
+// component missing from it is simply absent, and saying where it does ship
+// means consulting the siblings.
+//
+// Like VersionIndex it is built on first use, so a run that never meets an
+// unknown component pays nothing for it.
+type DistributionIndex struct {
+	store   schema.Store
+	version string
+
+	once  sync.Once
+	byKey map[versionKey][]string
+}
+
+// NewDistributionIndex returns an index over the sibling distributions store
+// can serve at the given collector release.
+func NewDistributionIndex(store schema.Store, version string) *DistributionIndex {
+	return &DistributionIndex{store: store, version: version, once: sync.Once{}, byKey: nil}
+}
+
+// Distributions returns the distributions shipping the component, sorted. The
+// one already being checked against is not among them: the caller knows it is
+// absent there, which is why it is asking.
+func (d *DistributionIndex) Distributions(k config.Kind, typ string) []string {
+	d.once.Do(d.build)
+
+	return d.byKey[versionKey{k, typ}]
+}
+
+func (d *DistributionIndex) build() {
+	d.byKey = map[versionKey][]string{}
+
+	for _, dist := range d.store.Distributions() {
+		if dist == d.store.Distribution {
+			continue
+		}
+
+		c, err := d.store.WithDistribution(dist).Load(d.version)
+		if err != nil {
+			continue
+		}
+
+		for kind, byType := range c.Components {
+			for typ := range byType {
+				key := versionKey{kind, typ}
+				d.byKey[key] = append(d.byKey[key], dist)
+			}
+		}
+	}
+}

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -52,6 +52,8 @@ type Options struct {
 	Schema *schema.Schema
 	// Availability lets diagnostics mention other releases. May be nil.
 	Availability rule.Availability
+	// Distributions lets diagnostics mention other distributions. May be nil.
+	Distributions rule.Distributions
 	// Severities overrides the level individual rules report at. A value of
 	// diag.Off disables the rule.
 	Severities map[string]diag.Severity
@@ -152,6 +154,7 @@ func (l *Linter) Lint(path string, src []byte) Result {
 		Schema: l.opts.Schema,
 		Index:  rule.NewIndex(f),
 		Avail:  l.opts.Availability,
+		Dists:  l.opts.Distributions,
 		Strict: l.opts.Strict,
 	}
 

--- a/pkg/rule/component.go
+++ b/pkg/rule/component.go
@@ -28,6 +28,15 @@ type Availability interface {
 	Versions(k config.Kind, typ string) []string
 }
 
+// Distributions reports which distributions of the targeted release ship a
+// component type. A schema describes one distribution, so this is what lets a
+// rule say where a component the running binary lacks does ship.
+type Distributions interface {
+	// Distributions returns the distributions containing the component,
+	// sorted, excluding the one being checked against.
+	Distributions(k config.Kind, typ string) []string
+}
+
 // schemaReady reports whether a schema with components was resolved. Rules
 // that consult the schema stay silent otherwise rather than reporting every
 // component as unknown.
@@ -37,6 +46,10 @@ func (c *Context) schemaReady() bool { return c.Schema != nil && c.Schema.Count(
 func (c *Context) version() string {
 	if c.Schema == nil || c.Schema.CollectorVersion == "" {
 		return "the targeted release"
+	}
+
+	if c.Schema.Distribution != "" {
+		return "collector " + c.Schema.CollectorVersion + " (" + c.Schema.Distribution + ")"
 	}
 
 	return "collector " + c.Schema.CollectorVersion
@@ -70,7 +83,8 @@ func (r unknownComponent) Check(ctx *Context) {
 }
 
 // unknownHint explains an unknown component: it may be declared under the wrong
-// section, exist only in other releases, or simply be a typo.
+// section, ship only in other distributions, exist only in other releases, or
+// simply be a typo.
 func unknownHint(ctx *Context, kind config.Kind, typ string) string {
 	for _, other := range config.Kinds() {
 		if other == kind {
@@ -80,6 +94,15 @@ func unknownHint(ctx *Context, kind config.Kind, typ string) string {
 		if _, ok := ctx.Schema.Lookup(other, typ); ok {
 			return quote(typ) + " is " + article(string(other)) + " " + string(other) +
 				"; declare it under " + other.Section()
+		}
+	}
+
+	// A component the running binary does not ship is a different problem from
+	// a typo: the fix is switching distributions, not correcting the name.
+	if ctx.Dists != nil && ctx.Schema.Distribution != "" {
+		if dists := ctx.Dists.Distributions(kind, typ); len(dists) > 0 {
+			return quote(typ) + " is not in the " + ctx.Schema.Distribution +
+				" distribution; it ships in " + list(dists)
 		}
 	}
 

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -37,6 +37,8 @@ type Context struct {
 	Index *Index
 	// Avail reports which other releases ship a component. It may be nil.
 	Avail Availability
+	// Dists reports which other distributions ship a component. It may be nil.
+	Dists Distributions
 	// Strict makes lenient checks report at their strict severity, mirroring
 	// kubeconform's -strict flag.
 	Strict bool

--- a/pkg/schema/store.go
+++ b/pkg/schema/store.go
@@ -94,6 +94,26 @@ func (s Store) Versions() []string {
 	return out
 }
 
+// Distributions lists the distributions the store can serve, sorted. Only a
+// registry says what it carries, so other location kinds report none.
+func (s Store) Distributions() []string {
+	for _, loc := range s.locations() {
+		idx := s.indexAt(loc)
+		if idx != nil {
+			return idx.Names()
+		}
+	}
+
+	return nil
+}
+
+// WithDistribution returns a copy of the store serving another distribution.
+func (s Store) WithDistribution(distribution string) Store {
+	s.Distribution = distribution
+
+	return s
+}
+
 // Load returns the schema for a collector version. The special value "latest"
 // (or an empty string) selects the newest schema the store can enumerate.
 func (s Store) Load(version string) (*Schema, error) {
@@ -132,6 +152,28 @@ func (s Store) distribution() string {
 	}
 
 	return s.Distribution
+}
+
+// indexAt reads a location's index, or nil when it has none.
+func (s Store) indexAt(loc string) *Index {
+	switch kindOf(loc) {
+	case locRemote:
+		idx, err := s.fetchIndex(loc)
+		if err != nil {
+			return nil
+		}
+
+		return idx
+	case locDir:
+		idx, err := ReadIndexFile(filepath.Join(loc, IndexFile))
+		if err != nil {
+			return nil
+		}
+
+		return idx
+	default:
+		return nil
+	}
 }
 
 // versionsAt lists the versions one location can serve. A template names a


### PR DESCRIPTION
Closes #8. Last of the four. **Stacked on #31 → #32.**

A config using `filelog` starts fine on `otelcol-contrib` and fails on plain `otelcol` with `unknown type: "filelog"`. The linter only ever asked whether a component exists *somewhere* upstream. Now it asks whether the binary being targeted ships it.

```
$ otelcol-config-lint run --distribution contrib config.yaml   # exit 0
$ otelcol-config-lint run --distribution core    config.yaml
config.yaml:2:3: error: unknown receiver type "filelog" in collector v0.157.0 (core) [unknown-component]
    hint: "filelog" is not in the core distribution; it ships in contrib, k8s
```

That is the message #8 asked for, near enough verbatim.

## What changed

- `--distribution` on `run` and on `list versions` — the latter answers differently per distribution, since upstream had no `otlp` distribution before v0.120.0.
- `distribution:` in the settings file. Which binary a project deploys is policy, not a per-run choice.
- Diagnostics **name the distribution** they checked against. The same config and release can pass or fail depending on it, so a report that omits it is ambiguous.
- The hint says where a missing component *does* ship. A component the binary lacks is a different problem from a typo — the fix is switching binaries, not correcting the name — so it must not read as a spelling suggestion.

## How the hint is answered

A schema describes one distribution, so a component missing from it is simply absent; saying where it ships means consulting the siblings. `DistributionIndex` does that the way `VersionIndex` already reads other releases: built on first use, so a run that never meets an unknown component pays nothing, and at most three extra loads when it does.

## Verification

`go test ./...` and `golangci-lint run` clean, with no network.

Two new tests. `TestDistributionSelectsTheBinary` is #8 itself — the same config passing under `contrib` and failing under `core` — and asserts the hint names the carrying distributions rather than suggesting a near-miss name. `TestTheDistributionIsNamedInDiagnostics` pins the `(core)` in the message.

Checked by hand across all three:

| `--distribution` | filelog config |
| --- | --- |
| `contrib` | exit 0 |
| `core` | exit 1, `unknown-component` |
| `k8s` | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)