### PR TITLE
fix(schema): record the distribution once, in the right place

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ components:
         metrics: stable
         logs: stable
         profiles: alpha
-      distributions: [core, contrib, k8s, otlp]
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
 ```
 

--- a/pkg/cmd/otelcol-config-lint/list.go
+++ b/pkg/cmd/otelcol-config-lint/list.go
@@ -3,7 +3,6 @@ package otelcolconfiglint
 import (
 	"fmt"
 	"io"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -121,8 +120,7 @@ func (o *Options) runListVersions(cmd *cobra.Command) error {
 			note = "(latest)"
 		}
 
-		w.row(v, fmt.Sprintf("%d components", cat.Count()),
-			strings.Join(cat.Distributions, "+")+" "+note)
+		w.row(v, fmt.Sprintf("%d components", cat.Count()), cat.Distribution+" "+note)
 	}
 
 	w.flush()

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -22,13 +22,14 @@ import (
 type Schema struct {
 	// CollectorVersion is the upstream release tag, e.g. "v0.157.0".
 	CollectorVersion string `json:"collectorVersion" yaml:"collectorVersion"`
-	// Distribution names the binary this schema describes, e.g. "core". The
-	// special value "all" is the union of every distribution.
+	// Distribution names the binary this schema describes, e.g. "core". It is
+	// the one place a distribution is recorded: the components below carry no
+	// membership of their own, since a second answer could only disagree.
 	Distribution string `json:"distribution,omitempty" yaml:"distribution,omitempty"`
-	// Distributions lists which upstream distributions were merged in.
-	Distributions []string `json:"distributions"         yaml:"distributions"`
-	GeneratedAt   string   `json:"generatedAt,omitempty" yaml:"generatedAt,omitempty"`
-	// Sources maps each distribution to the module it was generated from.
+	GeneratedAt  string `json:"generatedAt,omitempty"  yaml:"generatedAt,omitempty"`
+	// Sources maps each upstream repository harvested to the module it was
+	// generated from. It is provenance, not distribution membership: both
+	// repositories are read whichever distribution is being written.
 	Sources map[string]string `json:"sources,omitempty" yaml:"sources,omitempty"`
 	// Components is indexed by kind ("receiver", "processor", ...) and then by
 	// component type ("otlp", "batch", ...).
@@ -47,6 +48,9 @@ type Component struct {
 	// Pairs lists the signal conversions a connector supports.
 	Pairs []Pair `json:"pairs,omitempty" yaml:"pairs,omitempty"`
 	// Distributions lists the upstream distributions shipping the component.
+	// It is what schemagen splits a release on and is not written to the
+	// published files, where the directory already names the distribution and
+	// a second answer could only disagree with it.
 	Distributions []string `json:"distributions,omitempty" yaml:"distributions,omitempty"`
 	// Module is the Go module path the component lives in.
 	Module string `json:"module,omitempty" yaml:"module,omitempty"`

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -2,7 +2,7 @@
 
 One file per OpenTelemetry Collector release **per distribution**, listing every
 component that release ships with the signals it supports, its per-signal
-stability, the distributions carrying it, and its Go module.
+stability, the settings it accepts, and its Go module.
 
 ```
 schemas/
@@ -65,12 +65,18 @@ used before schemas were split by distribution.
 The flag can be repeated to search several locations in order — put a private
 distribution's schema first and fall back to `default` for this registry.
 
+The distribution is recorded once, at the top of the file. Components carry no
+membership of their own: the file they sit in already answers that, and a second
+answer could only disagree with it.
+
 ## Shape
 
 ```yaml
 collectorVersion: v0.157.0
-distribution: core          # which binary this file describes
-distributions: [core, contrib]   # which upstream repos were harvested
+distribution: core                 # which binary this file describes
+sources:                           # which upstream repos were harvested
+  core: go.opentelemetry.io/collector
+  contrib: github.com/open-telemetry/opentelemetry-collector-contrib
 components:
   receiver:
     otlp:
@@ -79,7 +85,6 @@ components:
       stability:
         traces: stable
         profiles: alpha
-      distributions: [core, contrib, k8s, otlp]
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
   connector:
     spanmetrics:

--- a/schemas/contrib/v0.110.0.json
+++ b/schemas/contrib/v0.110.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.110.0",
   "distribution": "contrib",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:37Z",
+  "generatedAt": "2026-08-02T13:15:51Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -32,9 +28,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -78,9 +71,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector",
         "fields": {
@@ -159,9 +149,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
           "type": "map",
@@ -214,9 +201,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
           "type": "map",
@@ -268,11 +252,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "grafanacloud": {
@@ -285,9 +264,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector",
         "fields": {
@@ -328,9 +304,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"
       },
       "roundrobin": {
@@ -354,9 +327,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
       },
       "routing": {
@@ -379,9 +349,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -437,9 +404,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "fields": {
@@ -511,9 +475,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector",
         "fields": {
@@ -663,9 +624,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector",
         "fields": {
           "type": "map",
@@ -703,9 +661,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter",
         "fields": {
           "type": "map",
@@ -887,9 +842,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -926,9 +878,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter",
         "fields": {
           "type": "map",
@@ -1031,9 +980,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter",
         "fields": {
           "type": "map",
@@ -1207,9 +1153,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter",
         "fields": {
           "type": "map",
@@ -1307,9 +1250,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter",
         "fields": {
           "type": "map",
@@ -1370,9 +1310,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter",
         "fields": {
           "type": "map",
@@ -1470,9 +1407,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter",
         "fields": {
           "type": "map",
@@ -1575,9 +1509,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter",
         "fields": {
           "type": "map",
@@ -1629,9 +1560,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter",
         "fields": {
           "type": "map",
@@ -1715,9 +1643,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter",
         "fields": {
           "type": "map",
@@ -1785,9 +1710,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter",
         "fields": {
           "type": "map",
@@ -1902,9 +1824,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter",
         "fields": {
           "type": "map",
@@ -2516,9 +2435,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter",
         "fields": {
           "type": "map",
@@ -2868,9 +2784,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter",
         "fields": {
           "type": "map",
@@ -3033,11 +2946,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -3077,9 +2985,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter",
         "fields": {
           "type": "map",
@@ -3293,9 +3198,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter",
         "fields": {
           "type": "map",
@@ -3610,10 +3512,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/exporterhelper"
       },
       "file": {
@@ -3628,10 +3526,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -3701,9 +3595,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter",
         "fields": {
           "type": "map",
@@ -3744,9 +3635,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter",
         "fields": {
           "type": "map",
@@ -3835,9 +3723,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter",
         "fields": {
           "type": "map",
@@ -3897,9 +3782,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter",
         "fields": {
           "type": "map",
@@ -4113,9 +3995,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter",
         "fields": {
           "type": "map",
@@ -4335,9 +4214,6 @@
         "stability": {
           "traces": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/instanaexporter",
         "fields": {
           "type": "map",
@@ -4472,10 +4348,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -4736,9 +4608,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kineticaexporter",
         "fields": {
           "type": "map",
@@ -4773,9 +4642,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "fields": {
           "type": "map",
@@ -5047,10 +4913,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/loggingexporter",
         "fields": {
           "type": "map",
@@ -5081,9 +4943,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter",
         "fields": {
           "type": "map",
@@ -5281,9 +5140,6 @@
           "logs": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter",
         "fields": {
           "type": "map",
@@ -5470,9 +5326,6 @@
         "stability": {
           "logs": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter",
         "fields": {
           "type": "map",
@@ -5645,9 +5498,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter",
         "fields": {
           "type": "map",
@@ -5826,11 +5676,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "opencensus": {
@@ -5843,10 +5688,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter",
         "fields": {
           "type": "map",
@@ -6008,9 +5849,6 @@
           "logs": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter",
         "fields": {
           "type": "map",
@@ -6212,9 +6050,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -6443,11 +6278,6 @@
           "metrics": "stable",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -6646,11 +6476,6 @@
           "metrics": "stable",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -6831,10 +6656,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -7000,10 +6821,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -7226,9 +7043,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter",
         "fields": {
           "type": "map",
@@ -7421,9 +7235,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter",
         "fields": {
           "type": "map",
@@ -7568,9 +7379,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter",
         "fields": {
           "type": "map",
@@ -7654,9 +7462,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter",
         "fields": {
           "type": "map",
@@ -7685,9 +7490,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter",
         "fields": {
           "type": "map",
@@ -8322,9 +8124,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter",
         "fields": {
           "type": "map",
@@ -8620,9 +8419,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter",
         "fields": {
           "type": "map",
@@ -8812,9 +8608,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter",
         "fields": {
           "type": "map",
@@ -8941,9 +8734,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -8974,10 +8764,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -9151,9 +8937,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -9176,9 +8959,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension",
         "fields": {
           "type": "map",
@@ -9211,9 +8991,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension",
         "fields": {
           "type": "map",
@@ -9229,9 +9006,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy",
         "fields": {
           "type": "map",
@@ -9325,9 +9099,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -9362,9 +9133,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -9386,9 +9154,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver",
         "fields": {
           "type": "map",
@@ -9407,9 +9172,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage",
         "fields": {
           "type": "map",
@@ -9428,9 +9190,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver",
         "fields": {
           "type": "map",
@@ -9472,9 +9231,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver",
         "fields": {
           "type": "map",
@@ -9595,9 +9351,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver",
         "fields": {
           "type": "map",
@@ -9733,9 +9486,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -9792,9 +9542,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension"
       },
       "headers_setter": {
@@ -9802,9 +9549,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -9842,10 +9586,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -10009,9 +9749,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension",
         "fields": {
           "type": "map",
@@ -10470,9 +10207,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -10488,9 +10222,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -10748,9 +10479,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension",
         "fields": {
           "type": "map",
@@ -10766,9 +10494,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling",
         "fields": {
           "type": "map",
@@ -11153,9 +10878,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension",
         "fields": {
           "type": "map",
@@ -11171,9 +10893,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -11207,9 +10926,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -11304,9 +11020,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -11337,9 +11050,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -11514,9 +11224,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension",
         "fields": {
           "type": "map",
@@ -11532,10 +11239,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -11568,9 +11271,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension",
         "fields": {
           "type": "map",
@@ -11595,9 +11295,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension",
         "fields": {
           "type": "map",
@@ -11733,9 +11430,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension",
         "fields": {
           "type": "map",
@@ -11768,9 +11462,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension",
         "fields": {
           "type": "map",
@@ -11889,9 +11580,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension",
         "fields": {
           "type": "map",
@@ -12076,9 +11764,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension",
         "fields": {
           "type": "map",
@@ -12100,9 +11785,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension",
         "fields": {
           "type": "map",
@@ -12121,11 +11803,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -12270,10 +11947,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -12581,11 +12254,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -12626,9 +12294,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor",
         "fields": {
           "type": "map",
@@ -12648,9 +12313,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "fields": {
           "type": "map",
@@ -12726,9 +12388,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -12750,9 +12409,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -12776,9 +12432,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor",
         "fields": {
           "type": "map",
@@ -12829,10 +12482,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -13424,9 +13073,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor",
         "fields": {
           "type": "map",
@@ -13449,9 +13095,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -13475,9 +13118,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -13508,9 +13148,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -13544,9 +13181,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "fields": {
           "type": "map",
@@ -13730,9 +13364,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "fields": {
           "type": "map",
@@ -13765,9 +13396,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor",
         "fields": {
           "type": "map",
@@ -13817,11 +13445,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -13860,9 +13483,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "fields": {
           "type": "map",
@@ -13979,10 +13599,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -14026,10 +13642,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/processor/processorhelper"
       },
       "redaction": {
@@ -14044,9 +13656,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -14096,9 +13705,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -14245,10 +13851,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -14300,9 +13902,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "fields": {
           "type": "map",
@@ -15527,9 +15126,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor",
         "fields": {
           "type": "map",
@@ -15593,9 +15189,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor",
         "fields": {
           "type": "map",
@@ -15739,10 +15332,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -16061,9 +15650,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor",
         "fields": {
           "type": "map",
@@ -16191,9 +15777,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -16936,9 +16519,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -17049,9 +16629,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver",
         "fields": {
           "type": "map",
@@ -17225,9 +16802,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver",
         "fields": {
           "type": "map",
@@ -17521,9 +17095,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver",
         "fields": {
           "type": "map",
@@ -17843,9 +17414,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver",
         "fields": {
           "type": "map",
@@ -18741,9 +18309,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver",
         "fields": {
           "type": "map",
@@ -18820,9 +18385,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchmetricsreceiver",
         "fields": {
           "type": "map",
@@ -18893,9 +18455,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver",
         "fields": {
           "type": "map",
@@ -18926,9 +18485,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver",
         "fields": {
           "type": "map",
@@ -18947,9 +18503,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver",
         "fields": {
           "type": "map",
@@ -19098,9 +18651,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver",
         "fields": {
           "type": "map",
@@ -19168,9 +18718,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver",
         "fields": {
           "type": "map",
@@ -19288,9 +18835,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver",
         "fields": {
           "type": "map",
@@ -19360,9 +18904,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver",
         "fields": {
           "type": "map",
@@ -19397,9 +18938,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver",
         "fields": {
           "type": "map",
@@ -19497,9 +19035,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver",
         "fields": {
           "type": "map",
@@ -20145,9 +19680,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver",
         "fields": {
           "type": "map",
@@ -20189,9 +19721,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver",
         "fields": {
           "type": "map",
@@ -20280,9 +19809,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver",
         "fields": {
           "type": "map",
@@ -20367,9 +19893,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver",
         "fields": {
           "type": "map",
@@ -20527,9 +20050,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver",
         "fields": {
           "type": "map",
@@ -20677,9 +20197,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver",
         "fields": {
           "type": "map",
@@ -20935,9 +20452,6 @@
           "metrics": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver",
         "fields": {
           "type": "map",
@@ -21076,9 +20590,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver",
         "fields": {
           "type": "map",
@@ -21983,9 +21494,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver",
         "fields": {
           "type": "map",
@@ -23050,9 +22558,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver",
         "fields": {
           "type": "map",
@@ -23399,9 +22904,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
       },
       "filestats": {
@@ -23412,9 +22914,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver",
         "fields": {
           "type": "map",
@@ -23572,9 +23071,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver",
         "fields": {
           "type": "map",
@@ -24190,9 +23686,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "fields": {
           "type": "map",
@@ -24211,9 +23704,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver",
         "fields": {
           "type": "map",
@@ -24428,9 +23918,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver",
         "fields": {
           "type": "map",
@@ -24475,9 +23962,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver",
         "fields": {
           "type": "map",
@@ -24520,9 +24004,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver",
         "fields": {
           "type": "map",
@@ -24599,9 +24080,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver",
         "fields": {
           "type": "map",
@@ -25075,10 +24553,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -25109,9 +24583,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "fields": {
           "type": "map",
@@ -25290,9 +24761,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver",
         "fields": {
           "type": "map",
@@ -25503,9 +24971,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver",
         "fields": {
           "type": "map",
@@ -25644,10 +25109,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -26078,9 +25539,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver",
         "fields": {
           "type": "map",
@@ -26168,9 +25626,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
       },
       "k8s_cluster": {
@@ -26183,9 +25638,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -28082,9 +27534,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -28114,9 +27563,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "fields": {
           "type": "map",
@@ -28190,10 +27636,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -28435,9 +27877,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver",
         "fields": {
           "type": "map",
@@ -28799,9 +28238,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "fields": {
           "type": "map",
@@ -30004,9 +29440,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver",
         "fields": {
           "type": "map",
@@ -30286,9 +29719,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver",
         "fields": {
           "type": "map",
@@ -30420,9 +29850,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver",
         "fields": {
           "type": "map",
@@ -30901,9 +30328,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver",
         "fields": {
           "type": "map",
@@ -32250,9 +31674,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver",
         "fields": {
           "type": "map",
@@ -32787,9 +32208,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver"
       },
       "nginx": {
@@ -32800,9 +32218,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
         "fields": {
           "type": "map",
@@ -32977,10 +32392,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "nsxt": {
@@ -32991,9 +32402,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver",
         "fields": {
           "type": "map",
@@ -33361,10 +32769,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver",
         "fields": {
           "type": "map",
@@ -33511,9 +32915,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver",
         "fields": {
           "type": "map",
@@ -33819,9 +33220,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver",
         "fields": {
           "type": "map",
@@ -33861,9 +33259,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -34046,11 +33441,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -34331,9 +33721,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver",
         "fields": {
           "type": "map",
@@ -34502,9 +33889,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver",
         "fields": {
           "type": "map",
@@ -34799,9 +34183,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
         "fields": {
           "type": "map",
@@ -35317,10 +34698,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -35474,9 +34851,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver",
         "fields": {
           "type": "map",
@@ -35645,9 +35019,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver",
         "fields": {
           "type": "map",
@@ -35748,9 +35119,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver",
         "fields": {
           "type": "map",
@@ -36019,9 +35387,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver",
         "fields": {
           "type": "map",
@@ -36237,9 +35602,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver",
         "fields": {
           "type": "map",
@@ -36561,9 +35923,6 @@
           "metrics": "beta",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -36593,10 +35952,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/receiverhelper"
       },
       "redis": {
@@ -36607,9 +35962,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver",
         "fields": {
           "type": "map",
@@ -37116,9 +36468,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver",
         "fields": {
           "type": "map",
@@ -37361,9 +36710,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver",
         "fields": {
           "type": "map",
@@ -37907,9 +37253,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver",
         "fields": {
           "type": "map",
@@ -38055,10 +37398,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/scraperhelper"
       },
       "signalfx": {
@@ -38071,9 +37410,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver",
         "fields": {
           "type": "map",
@@ -38217,9 +37553,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver",
         "fields": {
           "type": "map",
@@ -38496,9 +37829,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver",
         "fields": {
           "type": "map",
@@ -38562,9 +37892,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver",
         "fields": {
           "type": "map",
@@ -38940,9 +38267,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver",
         "fields": {
           "type": "map",
@@ -39070,9 +38394,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver",
         "fields": {
           "type": "map",
@@ -39252,9 +38573,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver",
         "fields": {
           "type": "map",
@@ -39869,9 +39187,6 @@
           "logs": "development",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver",
         "fields": {
           "type": "map",
@@ -40011,9 +39326,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver",
         "fields": {
           "type": "map",
@@ -40402,9 +39714,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver",
         "fields": {
           "type": "map",
@@ -40548,9 +39857,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver",
         "fields": {
           "type": "map",
@@ -40629,9 +39935,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver"
       },
       "tcplog": {
@@ -40642,9 +39945,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver"
       },
       "udplog": {
@@ -40655,9 +39955,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver"
       },
       "vcenter": {
@@ -40668,9 +39965,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver",
         "fields": {
           "type": "map",
@@ -41774,9 +41068,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver",
         "fields": {
           "type": "map",
@@ -41809,9 +41100,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver",
         "fields": {
           "type": "map",
@@ -41967,9 +41255,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
       },
       "windowsperfcounters": {
@@ -41980,9 +41265,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver",
         "fields": {
           "type": "map",
@@ -42055,10 +41337,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",
@@ -42200,9 +41478,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver",
         "fields": {
           "type": "map",

--- a/schemas/contrib/v0.110.0.yaml
+++ b/schemas/contrib/v0.110.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.110.0
 distribution: contrib
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:37Z"
+generatedAt: "2026-08-02T13:15:51Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -22,8 +19,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -53,8 +48,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
       fields:
         type: map
@@ -104,8 +97,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -138,8 +129,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -172,10 +161,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     grafanacloud:
       type: grafanacloud
@@ -184,8 +169,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector
       fields:
         type: map
@@ -210,8 +193,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
     roundrobin:
       type: roundrobin
@@ -226,8 +207,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
     routing:
       type: routing
@@ -242,8 +221,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -279,8 +256,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       fields:
         type: map
@@ -326,8 +301,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
       fields:
         type: map
@@ -421,8 +394,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector
       fields:
         type: map
@@ -449,8 +420,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter
       fields:
         type: map
@@ -572,8 +541,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
       fields:
         type: map
@@ -598,8 +565,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
       fields:
         type: map
@@ -668,8 +633,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
       fields:
         type: map
@@ -783,8 +746,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
       fields:
         type: map
@@ -850,8 +811,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter
       fields:
         type: map
@@ -892,8 +851,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
       fields:
         type: map
@@ -959,8 +916,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter
       fields:
         type: map
@@ -1030,8 +985,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
       fields:
         type: map
@@ -1066,8 +1019,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
       fields:
         type: map
@@ -1123,8 +1074,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter
       fields:
         type: map
@@ -1170,8 +1119,6 @@ components:
         logs: beta
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter
       fields:
         type: map
@@ -1249,8 +1196,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
       fields:
         type: map
@@ -1654,8 +1599,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
       fields:
         type: map
@@ -1884,8 +1827,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter
       fields:
         type: map
@@ -1993,10 +1934,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -2026,8 +1963,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter
       fields:
         type: map
@@ -2170,8 +2105,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
       fields:
         type: map
@@ -2378,9 +2311,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/exporter/exporterhelper
     file:
       type: file
@@ -2392,9 +2322,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -2442,8 +2369,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
       fields:
         type: map
@@ -2472,8 +2397,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
       fields:
         type: map
@@ -2532,8 +2455,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
       fields:
         type: map
@@ -2573,8 +2494,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
       fields:
         type: map
@@ -2716,8 +2635,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
       fields:
         type: map
@@ -2862,8 +2779,6 @@ components:
         - traces
       stability:
         traces: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/instanaexporter
       fields:
         type: map
@@ -2954,9 +2869,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -3128,8 +3040,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kineticaexporter
       fields:
         type: map
@@ -3154,8 +3064,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       fields:
         type: map
@@ -3334,9 +3242,6 @@ components:
         logs: deprecated
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/exporter/loggingexporter
       fields:
         type: map
@@ -3358,8 +3263,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter
       fields:
         type: map
@@ -3490,8 +3393,6 @@ components:
       stability:
         logs: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
       fields:
         type: map
@@ -3615,8 +3516,6 @@ components:
         - logs
       stability:
         logs: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter
       fields:
         type: map
@@ -3731,8 +3630,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter
       fields:
         type: map
@@ -3852,10 +3749,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     opencensus:
       type: opencensus
@@ -3865,9 +3758,6 @@ components:
       stability:
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter
       fields:
         type: map
@@ -3975,8 +3865,6 @@ components:
       stability:
         logs: development
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter
       fields:
         type: map
@@ -4111,8 +3999,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -4264,10 +4150,6 @@ components:
         logs: beta
         metrics: stable
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -4405,10 +4287,6 @@ components:
         logs: beta
         metrics: stable
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -4528,9 +4406,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -4639,9 +4514,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -4789,8 +4661,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
       fields:
         type: map
@@ -4918,8 +4788,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter
       fields:
         type: map
@@ -5014,8 +4882,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
       fields:
         type: map
@@ -5071,8 +4937,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
       fields:
         type: map
@@ -5093,8 +4957,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
       fields:
         type: map
@@ -5517,8 +5379,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
       fields:
         type: map
@@ -5715,8 +5575,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
       fields:
         type: map
@@ -5842,8 +5700,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter
       fields:
         type: map
@@ -5927,8 +5783,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
       fields:
         type: map
@@ -5949,9 +5803,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -6066,8 +5917,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -6083,8 +5932,6 @@ components:
       type: asapclient
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
       fields:
         type: map
@@ -6106,8 +5953,6 @@ components:
       type: avro_log_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension
       fields:
         type: map
@@ -6118,8 +5963,6 @@ components:
       type: awsproxy
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
       fields:
         type: map
@@ -6181,8 +6024,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -6205,8 +6046,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -6221,8 +6060,6 @@ components:
       type: cfgarden_observer
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver
       fields:
         type: map
@@ -6235,8 +6072,6 @@ components:
       type: db_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
       fields:
         type: map
@@ -6249,8 +6084,6 @@ components:
       type: docker_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
       fields:
         type: map
@@ -6278,8 +6111,6 @@ components:
       type: ecs_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
       fields:
         type: map
@@ -6357,8 +6188,6 @@ components:
       type: ecs_task_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver
       fields:
         type: map
@@ -6448,8 +6277,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -6487,15 +6314,11 @@ components:
       type: googleclientauth
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension
     headers_setter:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -6520,9 +6343,6 @@ components:
       type: health_check
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -6629,8 +6449,6 @@ components:
       type: healthcheckv2
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension
       fields:
         type: map
@@ -6928,8 +6746,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -6940,8 +6756,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -7110,8 +6924,6 @@ components:
       type: jaeger_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension
       fields:
         type: map
@@ -7122,8 +6934,6 @@ components:
       type: jaegerremotesampling
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
       fields:
         type: map
@@ -7374,8 +7184,6 @@ components:
       type: json_log_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension
       fields:
         type: map
@@ -7386,8 +7194,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -7410,8 +7216,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -7474,8 +7278,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -7496,8 +7298,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -7612,8 +7412,6 @@ components:
       type: otlp_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension
       fields:
         type: map
@@ -7624,9 +7422,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -7648,8 +7443,6 @@ components:
       type: redis_storage
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension
       fields:
         type: map
@@ -7666,8 +7459,6 @@ components:
       type: remotetap
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension
       fields:
         type: map
@@ -7756,8 +7547,6 @@ components:
       type: sigv4auth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension
       fields:
         type: map
@@ -7779,8 +7568,6 @@ components:
       type: solarwindsapmsettings
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension
       fields:
         type: map
@@ -7859,8 +7646,6 @@ components:
       type: sumologic
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension
       fields:
         type: map
@@ -7983,8 +7768,6 @@ components:
       type: text_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension
       fields:
         type: map
@@ -7999,8 +7782,6 @@ components:
       type: zipkin_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension
       fields:
         type: map
@@ -8013,10 +7794,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -8112,9 +7889,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -8312,10 +8086,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -8344,8 +8114,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor
       fields:
         type: map
@@ -8359,8 +8127,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       fields:
         type: map
@@ -8409,8 +8175,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -8425,8 +8189,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -8442,8 +8204,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
       fields:
         type: map
@@ -8478,9 +8238,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -8857,8 +8614,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor
       fields:
         type: map
@@ -8875,8 +8630,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -8892,8 +8645,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -8914,8 +8665,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -8939,8 +8688,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       fields:
         type: map
@@ -9057,8 +8804,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       fields:
         type: map
@@ -9080,8 +8825,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor
       fields:
         type: map
@@ -9116,10 +8859,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -9147,8 +8886,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       fields:
         type: map
@@ -9225,9 +8962,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -9258,9 +8992,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/processor/processorhelper
     redaction:
       type: redaction
@@ -9272,8 +9003,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -9307,8 +9036,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -9406,9 +9133,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -9444,8 +9168,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       fields:
         type: map
@@ -10217,8 +9939,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
       fields:
         type: map
@@ -10261,8 +9981,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor
       fields:
         type: map
@@ -10357,9 +10075,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -10563,8 +10278,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor
       fields:
         type: map
@@ -10646,8 +10359,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -11119,8 +10830,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -11190,8 +10899,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver
       fields:
         type: map
@@ -11301,8 +11008,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
       fields:
         type: map
@@ -11489,8 +11194,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
       fields:
         type: map
@@ -11695,8 +11398,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
       fields:
         type: map
@@ -12261,8 +11962,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver
       fields:
         type: map
@@ -12312,8 +12011,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchmetricsreceiver
       fields:
         type: map
@@ -12359,8 +12056,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
       fields:
         type: map
@@ -12381,8 +12076,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
       fields:
         type: map
@@ -12395,8 +12088,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver
       fields:
         type: map
@@ -12495,8 +12186,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver
       fields:
         type: map
@@ -12541,8 +12230,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
       fields:
         type: map
@@ -12620,8 +12307,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
       fields:
         type: map
@@ -12668,8 +12353,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
       fields:
         type: map
@@ -12693,8 +12376,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
       fields:
         type: map
@@ -12758,8 +12439,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
       fields:
         type: map
@@ -13168,8 +12847,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
       fields:
         type: map
@@ -13197,8 +12874,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver
       fields:
         type: map
@@ -13255,8 +12930,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
       fields:
         type: map
@@ -13313,8 +12986,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
       fields:
         type: map
@@ -13418,8 +13089,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
       fields:
         type: map
@@ -13516,8 +13185,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
       fields:
         type: map
@@ -13683,8 +13350,6 @@ components:
       stability:
         metrics: development
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
       fields:
         type: map
@@ -13775,8 +13440,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
       fields:
         type: map
@@ -14344,8 +14007,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
       fields:
         type: map
@@ -15016,8 +14677,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver
       fields:
         type: map
@@ -15239,8 +14898,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
     filestats:
       type: filestats
@@ -15248,8 +14905,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
       fields:
         type: map
@@ -15349,8 +15004,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
       fields:
         type: map
@@ -15740,8 +15393,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       fields:
         type: map
@@ -15754,8 +15405,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver
       fields:
         type: map
@@ -15891,8 +15540,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
       fields:
         type: map
@@ -15923,8 +15570,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
       fields:
         type: map
@@ -15953,8 +15598,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
       fields:
         type: map
@@ -16004,8 +15647,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
       fields:
         type: map
@@ -16307,9 +15948,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -16330,8 +15968,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       fields:
         type: map
@@ -16448,8 +16084,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
       fields:
         type: map
@@ -16582,8 +16216,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
       fields:
         type: map
@@ -16674,9 +16306,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -16957,8 +16586,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
       fields:
         type: map
@@ -17017,8 +16644,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
     k8s_cluster:
       type: k8s_cluster
@@ -17028,8 +16653,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -18216,8 +17839,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -18237,8 +17858,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       fields:
         type: map
@@ -18288,9 +17907,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -18447,8 +18063,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
       fields:
         type: map
@@ -18679,8 +18293,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       fields:
         type: map
@@ -19435,8 +19047,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver
       fields:
         type: map
@@ -19618,8 +19228,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
       fields:
         type: map
@@ -19703,8 +19311,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
       fields:
         type: map
@@ -20007,8 +19613,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
       fields:
         type: map
@@ -20855,8 +20459,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
       fields:
         type: map
@@ -21194,8 +20796,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
     nginx:
       type: nginx
@@ -21203,8 +20803,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
       fields:
         type: map
@@ -21320,9 +20918,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     nsxt:
       type: nsxt
@@ -21330,8 +20925,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
       fields:
         type: map
@@ -21567,9 +21160,6 @@ components:
       stability:
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
       fields:
         type: map
@@ -21665,8 +21255,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver
       fields:
         type: map
@@ -21859,8 +21447,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver
       fields:
         type: map
@@ -21888,8 +21474,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -22010,10 +21594,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -22202,8 +21782,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
       fields:
         type: map
@@ -22314,8 +21892,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
       fields:
         type: map
@@ -22501,8 +22077,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
       fields:
         type: map
@@ -22828,9 +22402,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -22933,8 +22504,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
       fields:
         type: map
@@ -23048,8 +22617,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver
       fields:
         type: map
@@ -23115,8 +22682,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver
       fields:
         type: map
@@ -23291,8 +22856,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver
       fields:
         type: map
@@ -23433,8 +22996,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
       fields:
         type: map
@@ -23642,8 +23203,6 @@ components:
         logs: alpha
         metrics: beta
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -23665,9 +23224,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/receiverhelper
     redis:
       type: redis
@@ -23675,8 +23231,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
       fields:
         type: map
@@ -23996,8 +23550,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
       fields:
         type: map
@@ -24154,8 +23706,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
       fields:
         type: map
@@ -24498,8 +24048,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver
       fields:
         type: map
@@ -24596,9 +24144,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/scraperhelper
     signalfx:
       type: signalfx
@@ -24608,8 +24153,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
       fields:
         type: map
@@ -24704,8 +24247,6 @@ components:
       stability:
         metrics: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver
       fields:
         type: map
@@ -24885,8 +24426,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
       fields:
         type: map
@@ -24930,8 +24469,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
       fields:
         type: map
@@ -25168,8 +24705,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver
       fields:
         type: map
@@ -25253,8 +24788,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
       fields:
         type: map
@@ -25372,8 +24905,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver
       fields:
         type: map
@@ -25771,8 +25302,6 @@ components:
       stability:
         logs: development
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver
       fields:
         type: map
@@ -25863,8 +25392,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
       fields:
         type: map
@@ -26109,8 +25636,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
       fields:
         type: map
@@ -26202,8 +25727,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
       fields:
         type: map
@@ -26254,8 +25777,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
     tcplog:
       type: tcplog
@@ -26263,8 +25784,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
     udplog:
       type: udplog
@@ -26272,8 +25791,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
     vcenter:
       type: vcenter
@@ -26281,8 +25798,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
       fields:
         type: map
@@ -26975,8 +26490,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
       fields:
         type: map
@@ -26998,8 +26511,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver
       fields:
         type: map
@@ -27101,8 +26612,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
     windowsperfcounters:
       type: windowsperfcounters
@@ -27110,8 +26619,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
       fields:
         type: map
@@ -27159,9 +26666,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map
@@ -27254,8 +26758,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
       fields:
         type: map

--- a/schemas/contrib/v0.120.0.json
+++ b/schemas/contrib/v0.120.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.120.0",
   "distribution": "contrib",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:37Z",
+  "generatedAt": "2026-08-02T13:15:51Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -32,10 +28,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -79,9 +71,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector",
         "fields": {
@@ -160,10 +149,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
           "type": "map",
@@ -216,10 +201,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
           "type": "map",
@@ -271,11 +252,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "grafanacloud": {
@@ -288,9 +264,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector",
         "fields": {
@@ -331,10 +304,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"
       },
       "roundrobin": {
@@ -358,10 +327,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
       },
       "routing": {
@@ -384,10 +349,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -446,10 +407,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "fields": {
@@ -532,9 +489,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector"
       },
       "spanmetrics": {
@@ -547,9 +501,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector",
         "fields": {
@@ -699,9 +650,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector",
         "fields": {
           "type": "map",
@@ -739,9 +687,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter",
         "fields": {
           "type": "map",
@@ -942,9 +887,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -981,9 +923,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter",
         "fields": {
           "type": "map",
@@ -1089,9 +1028,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter",
         "fields": {
           "type": "map",
@@ -1265,9 +1201,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter",
         "fields": {
           "type": "map",
@@ -1368,9 +1301,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter",
         "fields": {
           "type": "map",
@@ -1455,9 +1385,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter",
         "fields": {
           "type": "map",
@@ -1555,9 +1482,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter",
         "fields": {
           "type": "map",
@@ -1666,9 +1590,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter",
         "fields": {
           "type": "map",
@@ -1723,9 +1644,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter",
         "fields": {
           "type": "map",
@@ -1895,9 +1813,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter",
         "fields": {
           "type": "map",
@@ -1984,9 +1899,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter",
         "fields": {
           "type": "map",
@@ -2054,9 +1966,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter",
         "fields": {
           "type": "map",
@@ -2219,9 +2128,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter",
         "fields": {
           "type": "map",
@@ -2876,9 +2782,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter",
         "fields": {
           "type": "map",
@@ -3250,9 +3153,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter",
         "fields": {
           "type": "map",
@@ -3420,11 +3320,6 @@
           "profiles": "development",
           "traces": "development"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -3464,9 +3359,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter",
         "fields": {
           "type": "map",
@@ -3701,9 +3593,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter",
         "fields": {
           "type": "map",
@@ -4041,11 +3930,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -4115,9 +3999,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter",
         "fields": {
           "type": "map",
@@ -4161,9 +4042,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter",
         "fields": {
           "type": "map",
@@ -4255,9 +4133,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter",
         "fields": {
           "type": "map",
@@ -4323,9 +4198,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter",
         "fields": {
           "type": "map",
@@ -4558,9 +4430,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter",
         "fields": {
           "type": "map",
@@ -4803,10 +4672,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -5078,9 +4943,6 @@
           "metrics": "unmaintained",
           "traces": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kineticaexporter",
         "fields": {
           "type": "map",
@@ -5115,10 +4977,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "fields": {
           "type": "map",
@@ -5449,9 +5307,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter",
         "fields": {
           "type": "map",
@@ -5668,9 +5523,6 @@
           "logs": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter",
         "fields": {
           "type": "map",
@@ -5876,9 +5728,6 @@
         "stability": {
           "logs": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter",
         "fields": {
           "type": "map",
@@ -6070,9 +5919,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter",
         "fields": {
           "type": "map",
@@ -6270,11 +6116,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "opencensus": {
@@ -6287,10 +6128,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter",
         "fields": {
           "type": "map",
@@ -6463,9 +6300,6 @@
           "logs": "unmaintained",
           "traces": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter",
         "fields": {
           "type": "map",
@@ -6704,10 +6538,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -6949,12 +6779,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -7155,12 +6979,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -7360,10 +7178,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -7537,10 +7351,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -7782,9 +7592,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter",
         "fields": {
           "type": "map",
@@ -7980,9 +7787,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter",
         "fields": {
           "type": "map",
@@ -8138,9 +7942,6 @@
         "stability": {
           "traces": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter",
         "fields": {
           "type": "map",
@@ -8229,9 +8030,6 @@
           "logs": "development",
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter"
       },
       "sentry": {
@@ -8242,9 +8040,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter",
         "fields": {
           "type": "map",
@@ -8273,9 +8068,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter",
         "fields": {
           "type": "map",
@@ -8961,9 +8753,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter",
         "fields": {
           "type": "map",
@@ -9291,9 +9080,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter",
         "fields": {
           "type": "map",
@@ -9468,9 +9254,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter",
         "fields": {
           "type": "map",
@@ -9679,9 +9462,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter",
         "fields": {
           "type": "map",
@@ -9819,9 +9599,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -9852,10 +9629,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -10048,10 +9821,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -10074,9 +9843,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension",
         "fields": {
           "type": "map",
@@ -10109,9 +9875,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension",
         "fields": {
           "type": "map",
@@ -10127,9 +9890,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy",
         "fields": {
           "type": "map",
@@ -10231,10 +9991,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -10269,10 +10025,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -10294,9 +10046,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver",
         "fields": {
           "type": "map",
@@ -10360,9 +10109,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension",
         "fields": {
           "type": "map",
@@ -10394,9 +10140,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage",
         "fields": {
           "type": "map",
@@ -10415,9 +10158,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver",
         "fields": {
           "type": "map",
@@ -10459,9 +10199,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver",
         "fields": {
           "type": "map",
@@ -10582,9 +10319,6 @@
         "stability": {
           "extension": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver",
         "fields": {
           "type": "map",
@@ -10736,10 +10470,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -10796,9 +10526,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension"
       },
       "googlecloudlogentry_encoding": {
@@ -10806,9 +10533,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension",
         "fields": {
           "type": "map",
@@ -10827,10 +10551,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -10868,11 +10588,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -11044,9 +10759,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension",
         "fields": {
           "type": "map",
@@ -11529,10 +11241,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -11548,10 +11256,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -11833,9 +11537,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension",
         "fields": {
           "type": "map",
@@ -11851,9 +11552,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling",
         "fields": {
           "type": "map",
@@ -12262,9 +11960,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension",
         "fields": {
           "type": "map",
@@ -12280,9 +11975,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector",
         "fields": {
           "type": "map",
@@ -12316,10 +12008,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -12353,9 +12041,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver",
         "fields": {
           "type": "map",
@@ -12524,10 +12209,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -12633,10 +12314,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -12667,10 +12344,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -12872,9 +12545,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension",
         "fields": {
           "type": "map",
@@ -12890,11 +12560,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -12927,9 +12592,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension",
         "fields": {
           "type": "map",
@@ -12954,9 +12616,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension",
         "fields": {
           "type": "map",
@@ -13100,9 +12759,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension",
         "fields": {
           "type": "map",
@@ -13135,9 +12791,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension"
       },
       "solarwindsapmsettings": {
@@ -13145,9 +12798,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension",
         "fields": {
           "type": "map",
@@ -13274,9 +12924,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension",
         "fields": {
           "type": "map",
@@ -13477,9 +13124,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension",
         "fields": {
           "type": "map",
@@ -13501,9 +13145,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension",
         "fields": {
           "type": "map",
@@ -13522,11 +13163,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -13679,11 +13315,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -13991,11 +13622,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -14036,9 +13662,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor",
         "fields": {
           "type": "map",
@@ -14058,10 +13681,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "fields": {
           "type": "map",
@@ -14153,10 +13772,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -14178,10 +13793,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -14209,11 +13820,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -14805,9 +14411,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor",
         "fields": {
           "type": "map",
@@ -14830,10 +14433,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -14857,10 +14456,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -14891,10 +14486,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -14930,10 +14521,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "fields": {
           "type": "map",
@@ -15123,10 +14710,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "fields": {
           "type": "map",
@@ -15175,9 +14758,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor",
         "fields": {
           "type": "map",
@@ -15227,11 +14807,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -15270,9 +14845,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor",
         "fields": {
           "type": "map",
@@ -15319,9 +14891,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor"
       },
       "metricstransform": {
@@ -15332,10 +14901,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "fields": {
           "type": "map",
@@ -15452,11 +15017,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -15500,10 +15060,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -15561,10 +15117,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -15719,11 +15271,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -15777,10 +15324,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "fields": {
           "type": "map",
@@ -17094,9 +16637,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor",
         "fields": {
           "type": "map",
@@ -17160,9 +16700,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor",
         "fields": {
           "type": "map",
@@ -17322,10 +16859,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -17647,9 +17180,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor",
         "fields": {
           "type": "map",
@@ -17777,10 +17307,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -18526,10 +18052,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -18649,9 +18171,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver",
         "fields": {
           "type": "map",
@@ -18825,9 +18344,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver",
         "fields": {
           "type": "map",
@@ -19129,9 +18645,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver",
         "fields": {
           "type": "map",
@@ -19467,9 +18980,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver",
         "fields": {
           "type": "map",
@@ -20381,9 +19891,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver",
         "fields": {
           "type": "map",
@@ -20460,9 +19967,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchmetricsreceiver",
         "fields": {
           "type": "map",
@@ -20533,9 +20037,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver",
         "fields": {
           "type": "map",
@@ -20566,9 +20067,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver",
         "fields": {
           "type": "map",
@@ -20589,9 +20087,6 @@
           "logs": "alpha",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver",
         "fields": {
           "type": "map",
@@ -20748,9 +20243,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver",
         "fields": {
           "type": "map",
@@ -20827,9 +20319,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver",
         "fields": {
           "type": "map",
@@ -20955,9 +20444,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver",
         "fields": {
           "type": "map",
@@ -21027,9 +20513,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver",
         "fields": {
           "type": "map",
@@ -21096,9 +20579,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver",
         "fields": {
           "type": "map",
@@ -21196,9 +20676,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver",
         "fields": {
           "type": "map",
@@ -21860,9 +21337,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver",
         "fields": {
           "type": "map",
@@ -21904,9 +21378,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver",
         "fields": {
           "type": "map",
@@ -21995,9 +21466,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver",
         "fields": {
           "type": "map",
@@ -22090,9 +21558,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver",
         "fields": {
           "type": "map",
@@ -22266,9 +21731,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver",
         "fields": {
           "type": "map",
@@ -22424,9 +21886,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver",
         "fields": {
           "type": "map",
@@ -22698,9 +22157,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver",
         "fields": {
           "type": "map",
@@ -22847,9 +22303,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver",
         "fields": {
           "type": "map",
@@ -23754,9 +23207,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver",
         "fields": {
           "type": "map",
@@ -24837,9 +24287,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver",
         "fields": {
           "type": "map",
@@ -24986,9 +24433,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver",
         "fields": {
           "type": "map",
@@ -25351,10 +24795,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
       },
       "filestats": {
@@ -25365,9 +24805,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver",
         "fields": {
           "type": "map",
@@ -25525,9 +24962,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver",
         "fields": {
           "type": "map",
@@ -26159,10 +25593,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "fields": {
           "type": "map",
@@ -26183,9 +25613,6 @@
           "metrics": "alpha",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver",
         "fields": {
           "type": "map",
@@ -26536,9 +25963,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver",
         "fields": {
           "type": "map",
@@ -26703,9 +26127,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver",
         "fields": {
           "type": "map",
@@ -26753,9 +26174,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver",
         "fields": {
           "type": "map",
@@ -26798,9 +26216,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver",
         "fields": {
           "type": "map",
@@ -26877,9 +26292,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver",
         "fields": {
           "type": "map",
@@ -27369,11 +26781,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -27404,10 +26811,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "fields": {
           "type": "map",
@@ -27610,9 +27013,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver",
         "fields": {
           "type": "map",
@@ -27834,9 +27234,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver",
         "fields": {
           "type": "map",
@@ -28047,9 +27444,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver",
         "fields": {
           "type": "map",
@@ -28196,11 +27590,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -28655,9 +28044,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver",
         "fields": {
           "type": "map",
@@ -28745,10 +28131,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
       },
       "k8s_cluster": {
@@ -28761,10 +28143,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -30664,10 +30042,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -30697,10 +30071,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "fields": {
           "type": "map",
@@ -30774,10 +30144,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -31027,9 +30393,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver",
         "fields": {
           "type": "map",
@@ -31399,10 +30762,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "fields": {
           "type": "map",
@@ -32615,9 +31974,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver",
         "fields": {
           "type": "map",
@@ -32838,9 +32194,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver",
         "fields": {
           "type": "map",
@@ -33136,9 +32489,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver",
         "fields": {
           "type": "map",
@@ -33270,9 +32620,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver",
         "fields": {
           "type": "map",
@@ -33762,9 +33109,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver",
         "fields": {
           "type": "map",
@@ -35143,9 +34487,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver",
         "fields": {
           "type": "map",
@@ -35688,9 +35029,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver"
       },
       "netflow": {
@@ -35701,9 +35039,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver",
         "fields": {
           "type": "map",
@@ -35737,9 +35072,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
         "fields": {
           "type": "map",
@@ -35930,10 +35262,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "nsxt": {
@@ -35944,9 +35272,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver",
         "fields": {
           "type": "map",
@@ -36328,9 +35653,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver",
         "fields": {
           "type": "map",
@@ -36421,11 +35743,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver",
         "fields": {
           "type": "map",
@@ -36580,9 +35897,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver",
         "fields": {
           "type": "map",
@@ -36888,9 +36202,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver",
         "fields": {
           "type": "map",
@@ -36930,10 +36241,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -37135,12 +36442,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -37423,9 +36724,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver",
         "fields": {
           "type": "map",
@@ -37600,9 +36898,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver",
         "fields": {
           "type": "map",
@@ -37897,9 +37192,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
         "fields": {
           "type": "map",
@@ -38479,11 +37771,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -38653,9 +37940,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver",
         "fields": {
           "type": "map",
@@ -38839,9 +38123,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver",
         "fields": {
           "type": "map",
@@ -38992,9 +38273,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver",
         "fields": {
           "type": "map",
@@ -39095,9 +38373,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver",
         "fields": {
           "type": "map",
@@ -39385,9 +38660,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver",
         "fields": {
           "type": "map",
@@ -39619,9 +38891,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver",
         "fields": {
           "type": "map",
@@ -39959,10 +39228,6 @@
           "metrics": "beta",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -40004,9 +39269,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver",
         "fields": {
           "type": "map",
@@ -40521,9 +39783,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver",
         "fields": {
           "type": "map",
@@ -40782,9 +40041,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver",
         "fields": {
           "type": "map",
@@ -41336,9 +40592,6 @@
         "stability": {
           "traces": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver",
         "fields": {
           "type": "map",
@@ -41487,9 +40740,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver",
         "fields": {
           "type": "map",
@@ -41641,9 +40891,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver",
         "fields": {
           "type": "map",
@@ -41936,9 +41183,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver",
         "fields": {
           "type": "map",
@@ -42002,9 +41246,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver",
         "fields": {
           "type": "map",
@@ -42380,9 +41621,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver",
         "fields": {
           "type": "map",
@@ -42518,9 +41756,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver",
         "fields": {
           "type": "map",
@@ -42708,9 +41943,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver",
         "fields": {
           "type": "map",
@@ -43469,9 +42701,6 @@
           "logs": "development",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver",
         "fields": {
           "type": "map",
@@ -43611,9 +42840,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver",
         "fields": {
           "type": "map",
@@ -44002,9 +43228,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver",
         "fields": {
           "type": "map",
@@ -44148,9 +43371,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver",
         "fields": {
           "type": "map",
@@ -44232,9 +43452,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver"
       },
       "systemd": {
@@ -44245,9 +43462,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver"
       },
       "tcplog": {
@@ -44258,9 +43472,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver"
       },
       "tlscheck": {
@@ -44271,9 +43482,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver",
         "fields": {
           "type": "map",
@@ -44369,9 +43577,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver"
       },
       "vcenter": {
@@ -44382,9 +43587,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver",
         "fields": {
           "type": "map",
@@ -45536,9 +44738,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver",
         "fields": {
           "type": "map",
@@ -45571,9 +44770,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver",
         "fields": {
           "type": "map",
@@ -45737,9 +44933,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
       },
       "windowsperfcounters": {
@@ -45750,9 +44943,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver",
         "fields": {
           "type": "map",
@@ -45825,11 +45015,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",
@@ -45979,9 +45164,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver",
         "fields": {
           "type": "map",

--- a/schemas/contrib/v0.120.0.yaml
+++ b/schemas/contrib/v0.120.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.120.0
 distribution: contrib
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:37Z"
+generatedAt: "2026-08-02T13:15:51Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -22,9 +19,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -54,8 +48,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
       fields:
         type: map
@@ -105,9 +97,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -140,9 +129,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -175,10 +161,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     grafanacloud:
       type: grafanacloud
@@ -187,8 +169,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector
       fields:
         type: map
@@ -213,9 +193,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
     roundrobin:
       type: roundrobin
@@ -230,9 +207,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
     routing:
       type: routing
@@ -247,9 +221,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -287,9 +258,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       fields:
         type: map
@@ -341,8 +309,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
     spanmetrics:
       type: spanmetrics
@@ -351,8 +317,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
       fields:
         type: map
@@ -446,8 +410,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector
       fields:
         type: map
@@ -474,8 +436,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter
       fields:
         type: map
@@ -609,8 +569,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
       fields:
         type: map
@@ -635,8 +593,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
       fields:
         type: map
@@ -707,8 +663,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
       fields:
         type: map
@@ -822,8 +776,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
       fields:
         type: map
@@ -891,8 +843,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter
       fields:
         type: map
@@ -949,8 +899,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
       fields:
         type: map
@@ -1016,8 +964,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter
       fields:
         type: map
@@ -1091,8 +1037,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
       fields:
         type: map
@@ -1129,8 +1073,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter
       fields:
         type: map
@@ -1242,8 +1184,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
       fields:
         type: map
@@ -1301,8 +1241,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter
       fields:
         type: map
@@ -1348,8 +1286,6 @@ components:
         logs: beta
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter
       fields:
         type: map
@@ -1457,8 +1393,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
       fields:
         type: map
@@ -1889,8 +1823,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
       fields:
         type: map
@@ -2133,8 +2065,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter
       fields:
         type: map
@@ -2246,10 +2176,6 @@ components:
         metrics: development
         profiles: development
         traces: development
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -2279,8 +2205,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter
       fields:
         type: map
@@ -2437,8 +2361,6 @@ components:
         metrics: development
         profiles: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
       fields:
         type: map
@@ -2660,10 +2582,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -2711,8 +2629,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
       fields:
         type: map
@@ -2743,8 +2659,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
       fields:
         type: map
@@ -2805,8 +2719,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
       fields:
         type: map
@@ -2850,8 +2762,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
       fields:
         type: map
@@ -3005,8 +2915,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
       fields:
         type: map
@@ -3167,9 +3075,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -3348,8 +3253,6 @@ components:
         logs: unmaintained
         metrics: unmaintained
         traces: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kineticaexporter
       fields:
         type: map
@@ -3374,9 +3277,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       fields:
         type: map
@@ -3593,8 +3493,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter
       fields:
         type: map
@@ -3737,8 +3635,6 @@ components:
       stability:
         logs: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
       fields:
         type: map
@@ -3874,8 +3770,6 @@ components:
         - logs
       stability:
         logs: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter
       fields:
         type: map
@@ -4002,8 +3896,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter
       fields:
         type: map
@@ -4135,10 +4027,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     opencensus:
       type: opencensus
@@ -4148,9 +4036,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter
       fields:
         type: map
@@ -4265,8 +4150,6 @@ components:
       stability:
         logs: unmaintained
         traces: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter
       fields:
         type: map
@@ -4425,9 +4308,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -4588,11 +4468,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -4732,11 +4607,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -4868,9 +4738,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -4984,9 +4851,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -5146,8 +5010,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
       fields:
         type: map
@@ -5277,8 +5139,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter
       fields:
         type: map
@@ -5380,8 +5240,6 @@ components:
         - traces
       stability:
         traces: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
       fields:
         type: map
@@ -5441,8 +5299,6 @@ components:
       stability:
         logs: development
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter
     sentry:
       type: sentry
@@ -5450,8 +5306,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
       fields:
         type: map
@@ -5472,8 +5326,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
       fields:
         type: map
@@ -5928,8 +5780,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
       fields:
         type: map
@@ -6145,8 +5995,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter
       fields:
         type: map
@@ -6263,8 +6111,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
       fields:
         type: map
@@ -6402,8 +6248,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter
       fields:
         type: map
@@ -6494,8 +6338,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
       fields:
         type: map
@@ -6516,9 +6358,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -6645,9 +6484,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -6663,8 +6499,6 @@ components:
       type: asapclient
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
       fields:
         type: map
@@ -6686,8 +6520,6 @@ components:
       type: avro_log_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension
       fields:
         type: map
@@ -6698,8 +6530,6 @@ components:
       type: awsproxy
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
       fields:
         type: map
@@ -6766,9 +6596,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -6791,9 +6618,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -6808,8 +6632,6 @@ components:
       type: cfgarden_observer
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver
       fields:
         type: map
@@ -6851,8 +6673,6 @@ components:
       type: cgroupruntime
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension
       fields:
         type: map
@@ -6873,8 +6693,6 @@ components:
       type: db_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
       fields:
         type: map
@@ -6887,8 +6705,6 @@ components:
       type: docker_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
       fields:
         type: map
@@ -6916,8 +6732,6 @@ components:
       type: ecs_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
       fields:
         type: map
@@ -6995,8 +6809,6 @@ components:
       type: ecs_task_observer
       stability:
         extension: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver
       fields:
         type: map
@@ -7096,9 +6908,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -7136,15 +6945,11 @@ components:
       type: googleclientauth
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension
     googlecloudlogentry_encoding:
       type: googlecloudlogentry_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
       fields:
         type: map
@@ -7157,9 +6962,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -7184,10 +6986,6 @@ components:
       type: health_check
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -7299,8 +7097,6 @@ components:
       type: healthcheckv2
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension
       fields:
         type: map
@@ -7613,9 +7409,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -7626,9 +7419,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -7812,8 +7602,6 @@ components:
       type: jaeger_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension
       fields:
         type: map
@@ -7824,8 +7612,6 @@ components:
       type: jaegerremotesampling
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
       fields:
         type: map
@@ -8091,8 +7877,6 @@ components:
       type: json_log_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension
       fields:
         type: map
@@ -8103,8 +7887,6 @@ components:
       type: k8s_leader_elector
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
       fields:
         type: map
@@ -8127,9 +7909,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -8152,8 +7931,6 @@ components:
       type: kafkatopics_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver
       fields:
         type: map
@@ -8263,9 +8040,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -8335,9 +8109,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -8358,9 +8129,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -8493,8 +8261,6 @@ components:
       type: otlp_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension
       fields:
         type: map
@@ -8505,10 +8271,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -8530,8 +8292,6 @@ components:
       type: redis_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension
       fields:
         type: map
@@ -8548,8 +8308,6 @@ components:
       type: remotetap
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension
       fields:
         type: map
@@ -8643,8 +8401,6 @@ components:
       type: sigv4auth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension
       fields:
         type: map
@@ -8666,15 +8422,11 @@ components:
       type: skywalking_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension
     solarwindsapmsettings:
       type: solarwindsapmsettings
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension
       fields:
         type: map
@@ -8758,8 +8510,6 @@ components:
       type: sumologic
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension
       fields:
         type: map
@@ -8892,8 +8642,6 @@ components:
       type: text_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension
       fields:
         type: map
@@ -8908,8 +8656,6 @@ components:
       type: zipkin_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension
       fields:
         type: map
@@ -8922,10 +8668,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -9026,10 +8768,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -9227,10 +8965,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -9259,8 +8993,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor
       fields:
         type: map
@@ -9274,9 +9006,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       fields:
         type: map
@@ -9335,9 +9064,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -9352,9 +9078,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -9374,10 +9097,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -9754,8 +9473,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor
       fields:
         type: map
@@ -9772,9 +9489,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -9790,9 +9504,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -9813,9 +9524,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -9841,9 +9549,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       fields:
         type: map
@@ -9964,9 +9669,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       fields:
         type: map
@@ -9998,8 +9700,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor
       fields:
         type: map
@@ -10034,10 +9734,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -10065,8 +9761,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
       fields:
         type: map
@@ -10097,8 +9791,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor
     metricstransform:
       type: metricstransform
@@ -10106,9 +9798,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       fields:
         type: map
@@ -10185,10 +9874,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -10219,9 +9904,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -10260,9 +9942,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -10365,10 +10044,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -10406,9 +10081,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       fields:
         type: map
@@ -11236,8 +10908,6 @@ components:
         logs: deprecated
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
       fields:
         type: map
@@ -11280,8 +10950,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor
       fields:
         type: map
@@ -11386,9 +11054,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -11594,8 +11259,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor
       fields:
         type: map
@@ -11677,9 +11340,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -12153,9 +11813,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -12231,8 +11888,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver
       fields:
         type: map
@@ -12342,8 +11997,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
       fields:
         type: map
@@ -12535,8 +12188,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
       fields:
         type: map
@@ -12751,8 +12402,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
       fields:
         type: map
@@ -13327,8 +12976,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver
       fields:
         type: map
@@ -13378,8 +13025,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchmetricsreceiver
       fields:
         type: map
@@ -13425,8 +13070,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
       fields:
         type: map
@@ -13447,8 +13090,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
       fields:
         type: map
@@ -13463,8 +13104,6 @@ components:
       stability:
         logs: alpha
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver
       fields:
         type: map
@@ -13568,8 +13207,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver
       fields:
         type: map
@@ -13620,8 +13257,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
       fields:
         type: map
@@ -13704,8 +13339,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
       fields:
         type: map
@@ -13752,8 +13385,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
       fields:
         type: map
@@ -13797,8 +13428,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
       fields:
         type: map
@@ -13862,8 +13491,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
       fields:
         type: map
@@ -14282,8 +13909,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
       fields:
         type: map
@@ -14311,8 +13936,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver
       fields:
         type: map
@@ -14369,8 +13992,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
       fields:
         type: map
@@ -14432,8 +14053,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
       fields:
         type: map
@@ -14547,8 +14166,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
       fields:
         type: map
@@ -14650,8 +14267,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
       fields:
         type: map
@@ -14827,8 +14442,6 @@ components:
       stability:
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
       fields:
         type: map
@@ -14924,8 +14537,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
       fields:
         type: map
@@ -15493,8 +15104,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
       fields:
         type: map
@@ -16175,8 +15784,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver
       fields:
         type: map
@@ -16272,8 +15879,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver
       fields:
         type: map
@@ -16505,9 +16110,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
     filestats:
       type: filestats
@@ -16515,8 +16117,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
       fields:
         type: map
@@ -16616,8 +16216,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
       fields:
         type: map
@@ -17017,9 +16615,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       fields:
         type: map
@@ -17034,8 +16629,6 @@ components:
       stability:
         metrics: alpha
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver
       fields:
         type: map
@@ -17260,8 +16853,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver
       fields:
         type: map
@@ -17369,8 +16960,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
       fields:
         type: map
@@ -17403,8 +16992,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
       fields:
         type: map
@@ -17433,8 +17020,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
       fields:
         type: map
@@ -17484,8 +17069,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
       fields:
         type: map
@@ -17797,10 +17380,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -17821,9 +17400,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       fields:
         type: map
@@ -17955,8 +17531,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver
       fields:
         type: map
@@ -18102,8 +17676,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
       fields:
         type: map
@@ -18236,8 +17808,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
       fields:
         type: map
@@ -18333,10 +17903,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -18632,8 +18198,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
       fields:
         type: map
@@ -18692,9 +18256,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
     k8s_cluster:
       type: k8s_cluster
@@ -18704,9 +18265,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -19895,9 +19453,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -19917,9 +19472,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       fields:
         type: map
@@ -19969,9 +19521,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -20133,8 +19682,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
       fields:
         type: map
@@ -20370,9 +19917,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       fields:
         type: map
@@ -21134,8 +20678,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver
       fields:
         type: map
@@ -21278,8 +20820,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver
       fields:
         type: map
@@ -21471,8 +21011,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
       fields:
         type: map
@@ -21556,8 +21094,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
       fields:
         type: map
@@ -21867,8 +21403,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
       fields:
         type: map
@@ -22735,8 +22269,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
       fields:
         type: map
@@ -23079,8 +22611,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
     netflow:
       type: netflow
@@ -23088,8 +22618,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver
       fields:
         type: map
@@ -23112,8 +22640,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
       fields:
         type: map
@@ -23239,9 +22765,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     nsxt:
       type: nsxt
@@ -23249,8 +22772,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
       fields:
         type: map
@@ -23494,8 +23015,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver
       fields:
         type: map
@@ -23554,10 +23073,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
       fields:
         type: map
@@ -23658,8 +23173,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver
       fields:
         type: map
@@ -23852,8 +23365,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver
       fields:
         type: map
@@ -23881,9 +23392,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -24016,11 +23524,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -24211,8 +23714,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
       fields:
         type: map
@@ -24327,8 +23828,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
       fields:
         type: map
@@ -24514,8 +24013,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
       fields:
         type: map
@@ -24881,10 +24378,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -24997,8 +24490,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
       fields:
         type: map
@@ -25120,8 +24611,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
       fields:
         type: map
@@ -25221,8 +24710,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver
       fields:
         type: map
@@ -25288,8 +24775,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver
       fields:
         type: map
@@ -25476,8 +24961,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver
       fields:
         type: map
@@ -25628,8 +25111,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
       fields:
         type: map
@@ -25847,9 +25328,6 @@ components:
         logs: alpha
         metrics: beta
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -25877,8 +25355,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
       fields:
         type: map
@@ -26203,8 +25679,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
       fields:
         type: map
@@ -26371,8 +25845,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
       fields:
         type: map
@@ -26720,8 +26192,6 @@ components:
         - traces
       stability:
         traces: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver
       fields:
         type: map
@@ -26819,8 +26289,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
       fields:
         type: map
@@ -26920,8 +26388,6 @@ components:
       stability:
         metrics: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver
       fields:
         type: map
@@ -27111,8 +26577,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
       fields:
         type: map
@@ -27156,8 +26620,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
       fields:
         type: map
@@ -27394,8 +26856,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver
       fields:
         type: map
@@ -27484,8 +26944,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
       fields:
         type: map
@@ -27608,8 +27066,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver
       fields:
         type: map
@@ -28097,8 +27553,6 @@ components:
       stability:
         logs: development
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver
       fields:
         type: map
@@ -28189,8 +27643,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
       fields:
         type: map
@@ -28435,8 +27887,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
       fields:
         type: map
@@ -28528,8 +27978,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
       fields:
         type: map
@@ -28582,8 +28030,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
     systemd:
       type: systemd
@@ -28591,8 +28037,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver
     tcplog:
       type: tcplog
@@ -28600,8 +28044,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
     tlscheck:
       type: tlscheck
@@ -28609,8 +28051,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
       fields:
         type: map
@@ -28671,8 +28111,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
     vcenter:
       type: vcenter
@@ -28680,8 +28118,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
       fields:
         type: map
@@ -29404,8 +28840,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
       fields:
         type: map
@@ -29427,8 +28861,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver
       fields:
         type: map
@@ -29535,8 +28967,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
     windowsperfcounters:
       type: windowsperfcounters
@@ -29544,8 +28974,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
       fields:
         type: map
@@ -29593,10 +29021,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map
@@ -29694,8 +29118,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
       fields:
         type: map

--- a/schemas/contrib/v0.130.0.json
+++ b/schemas/contrib/v0.130.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.130.0",
   "distribution": "contrib",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:38Z",
+  "generatedAt": "2026-08-02T13:15:52Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -37,10 +33,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -88,9 +80,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector",
         "fields": {
@@ -172,10 +161,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
           "type": "map",
@@ -228,10 +213,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
           "type": "map",
@@ -283,11 +264,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "grafanacloud": {
@@ -300,9 +276,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector",
         "fields": {
@@ -343,10 +316,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"
       },
       "roundrobin": {
@@ -370,10 +339,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
       },
       "routing": {
@@ -396,10 +361,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -458,10 +419,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "fields": {
@@ -554,9 +511,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector"
       },
       "spanmetrics": {
@@ -569,9 +523,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector",
         "fields": {
@@ -764,9 +715,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector",
         "fields": {
           "type": "map",
@@ -804,9 +752,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter",
         "fields": {
           "type": "map",
@@ -1074,9 +1019,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -1113,9 +1055,6 @@
         "stability": {
           "logs": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter",
         "fields": {
           "type": "map",
@@ -1249,9 +1188,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter",
         "fields": {
           "type": "map",
@@ -1428,9 +1364,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter",
         "fields": {
           "type": "map",
@@ -1556,9 +1489,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter",
         "fields": {
           "type": "map",
@@ -1691,9 +1621,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter",
         "fields": {
           "type": "map",
@@ -1794,9 +1721,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter",
         "fields": {
           "type": "map",
@@ -1931,9 +1855,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter",
         "fields": {
           "type": "map",
@@ -2067,9 +1988,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter",
         "fields": {
           "type": "map",
@@ -2158,9 +2076,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter",
         "fields": {
           "type": "map",
@@ -2361,9 +2276,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter",
         "fields": {
           "type": "map",
@@ -2475,9 +2387,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter",
         "fields": {
           "type": "map",
@@ -2545,9 +2454,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter",
         "fields": {
           "type": "map",
@@ -2737,9 +2643,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter",
         "fields": {
           "type": "map",
@@ -3732,9 +3635,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
       },
       "dataset": {
@@ -3747,9 +3647,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter",
         "fields": {
           "type": "map",
@@ -3942,11 +3839,6 @@
           "profiles": "development",
           "traces": "development"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -3986,9 +3878,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter",
         "fields": {
           "type": "map",
@@ -4288,9 +4177,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter",
         "fields": {
           "type": "map",
@@ -4709,9 +4595,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter",
         "fields": {
           "type": "map",
@@ -4961,11 +4844,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -5035,9 +4913,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter",
         "fields": {
           "type": "map",
@@ -5106,9 +4981,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter",
         "fields": {
           "type": "map",
@@ -5239,9 +5111,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter",
         "fields": {
           "type": "map",
@@ -5332,9 +5201,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter",
         "fields": {
           "type": "map",
@@ -5623,9 +5489,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter",
         "fields": {
           "type": "map",
@@ -5924,10 +5787,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -6375,9 +6234,6 @@
           "metrics": "unmaintained",
           "traces": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kineticaexporter",
         "fields": {
           "type": "map",
@@ -6412,10 +6268,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "fields": {
           "type": "map",
@@ -6818,9 +6670,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter",
         "fields": {
           "type": "map",
@@ -7093,9 +6942,6 @@
           "logs": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter",
         "fields": {
           "type": "map",
@@ -7357,9 +7203,6 @@
         "stability": {
           "logs": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter",
         "deprecated": "Use OTLP exporter (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33916)",
         "fields": {
@@ -7608,9 +7451,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter",
         "fields": {
           "type": "map",
@@ -7864,11 +7704,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "opencensus": {
@@ -7881,10 +7716,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter",
         "deprecated": "Use OTLP exporter (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)",
         "fields": {
@@ -8114,9 +7945,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter",
         "fields": {
           "type": "map",
@@ -8417,10 +8245,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -8701,12 +8525,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -8907,12 +8725,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -9168,10 +8980,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -9376,10 +9184,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -9648,9 +9452,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter",
         "fields": {
           "type": "map",
@@ -9871,9 +9672,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter",
         "fields": {
           "type": "map",
@@ -10046,9 +9844,6 @@
         "stability": {
           "traces": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter",
         "deprecated": "use OTLP exporter",
         "fields": {
@@ -10163,9 +9958,6 @@
           "logs": "development",
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter",
         "fields": {
           "type": "map",
@@ -10434,9 +10226,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter",
         "fields": {
           "type": "map",
@@ -10465,9 +10254,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter",
         "fields": {
           "type": "map",
@@ -11202,9 +10988,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter",
         "fields": {
           "type": "map",
@@ -11592,9 +11375,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter",
         "fields": {
           "type": "map",
@@ -11825,9 +11605,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter",
         "fields": {
           "type": "map",
@@ -12092,9 +11869,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter",
         "fields": {
           "type": "map",
@@ -12274,9 +12048,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -12311,9 +12082,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter",
         "fields": {
           "type": "map",
@@ -12587,10 +12355,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -12839,10 +12603,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -12865,9 +12625,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension",
         "fields": {
           "type": "map",
@@ -12900,9 +12657,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension",
         "fields": {
           "type": "map",
@@ -12918,9 +12672,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension",
         "fields": {
           "type": "map",
@@ -12936,9 +12687,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension",
         "fields": {
           "type": "map",
@@ -12962,9 +12710,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy",
         "fields": {
           "type": "map",
@@ -13083,9 +12828,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension",
         "fields": {
           "type": "map",
@@ -13140,10 +12882,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -13178,10 +12916,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -13214,9 +12948,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver",
         "fields": {
           "type": "map",
@@ -13280,9 +13011,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension",
         "fields": {
           "type": "map",
@@ -13314,9 +13042,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension",
         "fields": {
           "type": "map",
@@ -13675,9 +13400,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage",
         "fields": {
           "type": "map",
@@ -13696,9 +13418,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver",
         "fields": {
           "type": "map",
@@ -13740,9 +13459,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver",
         "fields": {
           "type": "map",
@@ -13863,9 +13579,6 @@
         "stability": {
           "extension": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver",
         "fields": {
           "type": "map",
@@ -14048,10 +13761,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -14108,9 +13817,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension"
       },
       "googlecloudlogentry_encoding": {
@@ -14118,9 +13824,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension",
         "fields": {
           "type": "map",
@@ -14139,10 +13842,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -14183,11 +13882,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -14390,9 +14084,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension",
         "fields": {
           "type": "map",
@@ -14968,10 +14659,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -14987,10 +14674,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -15334,9 +15017,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension",
         "fields": {
           "type": "map",
@@ -15352,9 +15032,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling",
         "fields": {
           "type": "map",
@@ -15856,9 +15533,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension",
         "fields": {
           "type": "map",
@@ -15877,9 +15551,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector",
         "fields": {
           "type": "map",
@@ -15913,10 +15584,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -15958,9 +15625,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver",
         "fields": {
           "type": "map",
@@ -16242,10 +15906,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -16368,10 +16028,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -16405,10 +16061,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -16650,9 +16302,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension",
         "fields": {
           "type": "map",
@@ -16668,11 +16317,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -16705,9 +16349,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension",
         "fields": {
           "type": "map",
@@ -16812,9 +16453,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension",
         "fields": {
           "type": "map",
@@ -16989,9 +16627,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension",
         "fields": {
           "type": "map",
@@ -17027,9 +16662,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension"
       },
       "solarwindsapmsettings": {
@@ -17037,9 +16669,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension",
         "fields": {
           "type": "map",
@@ -17197,9 +16826,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension",
         "fields": {
           "type": "map",
@@ -17431,9 +17057,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension",
         "fields": {
           "type": "map",
@@ -17455,9 +17078,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension",
         "fields": {
           "type": "map",
@@ -17476,11 +17096,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -17672,11 +17287,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -17984,11 +17594,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -18029,9 +17634,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor",
         "fields": {
           "type": "map",
@@ -18055,10 +17657,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "fields": {
           "type": "map",
@@ -18150,9 +17748,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/datadogsemanticsprocessor",
         "fields": {
           "type": "map",
@@ -18171,10 +17766,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -18196,10 +17787,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -18227,9 +17814,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor"
       },
       "filter": {
@@ -18244,11 +17828,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -18840,9 +18419,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor",
         "fields": {
           "type": "map",
@@ -18874,10 +18450,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -18901,10 +18473,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -18935,10 +18503,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -18974,10 +18538,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "fields": {
           "type": "map",
@@ -19164,10 +18724,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "fields": {
           "type": "map",
@@ -19216,9 +18772,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor",
         "fields": {
           "type": "map",
@@ -19270,11 +18823,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -19313,9 +18861,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor",
         "fields": {
           "type": "map",
@@ -19362,9 +18907,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor",
         "fields": {
           "type": "map",
@@ -19389,10 +18931,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "fields": {
           "type": "map",
@@ -19509,11 +19047,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -19557,10 +19090,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -19629,10 +19158,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -19820,11 +19345,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -19878,10 +19398,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "fields": {
           "type": "map",
@@ -21334,9 +20850,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor",
         "deprecated": "Use routing connector (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36616)",
         "fields": {
@@ -21401,9 +20914,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor",
         "fields": {
           "type": "map",
@@ -21594,10 +21104,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -21919,9 +21425,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor",
         "fields": {
           "type": "map",
@@ -22049,10 +21552,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -22974,10 +22473,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -23129,9 +22624,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver",
         "fields": {
           "type": "map",
@@ -23305,9 +22797,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver",
         "fields": {
           "type": "map",
@@ -23626,9 +23115,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver",
         "fields": {
           "type": "map",
@@ -23995,9 +23481,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver",
         "fields": {
           "type": "map",
@@ -24940,9 +24423,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver",
         "fields": {
           "type": "map",
@@ -25026,9 +24506,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchmetricsreceiver",
         "fields": {
           "type": "map",
@@ -25099,9 +24576,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver",
         "fields": {
           "type": "map",
@@ -25132,9 +24606,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver",
         "fields": {
           "type": "map",
@@ -25155,9 +24626,6 @@
           "logs": "alpha",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver",
         "fields": {
           "type": "map",
@@ -25348,9 +24816,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver",
         "fields": {
           "type": "map",
@@ -25447,9 +24912,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver",
         "fields": {
           "type": "map",
@@ -25592,9 +25054,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver",
         "fields": {
           "type": "map",
@@ -25664,9 +25123,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver",
         "fields": {
           "type": "map",
@@ -25733,9 +25189,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver",
         "fields": {
           "type": "map",
@@ -25874,9 +25327,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver",
         "fields": {
           "type": "map",
@@ -26569,9 +26019,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver",
         "fields": {
           "type": "map",
@@ -26613,9 +26060,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver",
         "fields": {
           "type": "map",
@@ -26704,9 +26148,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver",
         "fields": {
           "type": "map",
@@ -26819,9 +26260,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver",
         "fields": {
           "type": "map",
@@ -27026,9 +26464,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver",
         "fields": {
           "type": "map",
@@ -27215,9 +26650,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver",
         "fields": {
           "type": "map",
@@ -27520,9 +26952,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver",
         "fields": {
           "type": "map",
@@ -27730,9 +27159,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver",
         "fields": {
           "type": "map",
@@ -28637,9 +28063,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver",
         "fields": {
           "type": "map",
@@ -29751,9 +29174,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver",
         "fields": {
           "type": "map",
@@ -29931,9 +29351,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver",
         "fields": {
           "type": "map",
@@ -30329,9 +29746,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver",
         "fields": {
           "type": "map",
@@ -30509,10 +29923,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
       },
       "filestats": {
@@ -30523,9 +29933,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver",
         "fields": {
           "type": "map",
@@ -30683,9 +30090,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver",
         "fields": {
           "type": "map",
@@ -31348,10 +30752,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "fields": {
           "type": "map",
@@ -31372,9 +30772,6 @@
           "metrics": "alpha",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver",
         "fields": {
           "type": "map",
@@ -31756,9 +31153,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver",
         "fields": {
           "type": "map",
@@ -31954,9 +31348,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver",
         "fields": {
           "type": "map",
@@ -32004,9 +31395,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver",
         "fields": {
           "type": "map",
@@ -32052,9 +31440,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver",
         "fields": {
           "type": "map",
@@ -32131,9 +31516,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver",
         "fields": {
           "type": "map",
@@ -32654,11 +32036,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -32689,10 +32066,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "fields": {
           "type": "map",
@@ -32926,9 +32299,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver",
         "fields": {
           "type": "map",
@@ -33181,9 +32551,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver",
         "fields": {
           "type": "map",
@@ -33410,9 +32777,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver",
         "fields": {
           "type": "map",
@@ -33590,11 +32954,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -34142,9 +33501,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver",
         "fields": {
           "type": "map",
@@ -34232,10 +33588,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
       },
       "k8s_cluster": {
@@ -34248,10 +33600,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -36275,10 +35623,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -36308,9 +35652,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8slogreceiver",
         "fields": {
           "type": "map",
@@ -36563,10 +35904,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "fields": {
           "type": "map",
@@ -36647,10 +35984,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -37059,9 +36392,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver",
         "fields": {
           "type": "map",
@@ -37547,10 +36877,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "fields": {
           "type": "map",
@@ -38791,9 +38117,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver",
         "fields": {
           "type": "map",
@@ -39045,9 +38368,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver",
         "fields": {
           "type": "map",
@@ -39405,9 +38725,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver",
         "fields": {
           "type": "map",
@@ -39539,9 +38856,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver",
         "fields": {
           "type": "map",
@@ -40184,9 +39498,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver",
         "fields": {
           "type": "map",
@@ -41585,9 +40896,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver",
         "fields": {
           "type": "map",
@@ -42155,9 +41463,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver"
       },
       "netflow": {
@@ -42168,9 +41473,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver",
         "fields": {
           "type": "map",
@@ -42207,9 +41509,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
         "fields": {
           "type": "map",
@@ -42431,10 +41730,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "nsxt": {
@@ -42445,9 +41740,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver",
         "fields": {
           "type": "map",
@@ -42860,9 +42152,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver",
         "fields": {
           "type": "map",
@@ -42953,11 +42242,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver",
         "deprecated": "Use OTLP receiver (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)",
         "fields": {
@@ -43144,9 +42428,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver",
         "fields": {
           "type": "map",
@@ -43564,9 +42845,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver",
         "fields": {
           "type": "map",
@@ -43606,10 +42884,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -43842,12 +43116,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -44130,9 +43398,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver",
         "fields": {
           "type": "map",
@@ -44310,9 +43575,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver",
         "fields": {
           "type": "map",
@@ -44609,9 +43871,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
         "fields": {
           "type": "map",
@@ -45391,9 +44650,6 @@
         "stability": {
           "profiles": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver",
         "fields": {
           "type": "map",
@@ -45568,11 +44824,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -45948,9 +45199,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver",
         "fields": {
           "type": "map",
@@ -46165,9 +45413,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver",
         "fields": {
           "type": "map",
@@ -46349,9 +45594,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver",
         "fields": {
           "type": "map",
@@ -46452,9 +45694,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver",
         "fields": {
           "type": "map",
@@ -46773,9 +46012,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver",
         "fields": {
           "type": "map",
@@ -47038,9 +46274,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver",
         "fields": {
           "type": "map",
@@ -48001,10 +47234,6 @@
           "metrics": "beta",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -48050,9 +47279,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver",
         "fields": {
           "type": "map",
@@ -48584,9 +47810,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver",
         "fields": {
           "type": "map",
@@ -48876,9 +48099,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver",
         "fields": {
           "type": "map",
@@ -49447,9 +48667,6 @@
         "stability": {
           "traces": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver",
         "deprecated": "use OTLP receiver",
         "fields": {
@@ -49630,9 +48847,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver",
         "fields": {
           "type": "map",
@@ -49815,9 +49029,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver",
         "fields": {
           "type": "map",
@@ -50172,9 +49383,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver",
         "fields": {
           "type": "map",
@@ -50238,9 +49446,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver",
         "fields": {
           "type": "map",
@@ -50616,9 +49821,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver",
         "fields": {
           "type": "map",
@@ -50771,9 +49973,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver",
         "fields": {
           "type": "map",
@@ -50992,9 +50191,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver",
         "fields": {
           "type": "map",
@@ -51921,9 +51117,6 @@
           "logs": "development",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver",
         "fields": {
           "type": "map",
@@ -52087,9 +51280,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver",
         "fields": {
           "type": "map",
@@ -53015,9 +52205,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver",
         "fields": {
           "type": "map",
@@ -53161,9 +52348,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver",
         "fields": {
           "type": "map",
@@ -53249,9 +52433,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver",
         "fields": {
           "type": "map",
@@ -53432,9 +52613,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver"
       },
       "systemd": {
@@ -53445,9 +52623,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver"
       },
       "tcpcheck": {
@@ -53458,9 +52633,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver",
         "fields": {
           "type": "map",
@@ -53535,9 +52707,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver"
       },
       "tlscheck": {
@@ -53548,9 +52717,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver",
         "fields": {
           "type": "map",
@@ -53657,9 +52823,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver"
       },
       "vcenter": {
@@ -53670,9 +52833,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver",
         "fields": {
           "type": "map",
@@ -54841,9 +54001,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver",
         "fields": {
           "type": "map",
@@ -54876,9 +54033,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver",
         "fields": {
           "type": "map",
@@ -55082,9 +54236,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
       },
       "windowsperfcounters": {
@@ -55095,9 +54246,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver",
         "fields": {
           "type": "map",
@@ -55170,9 +54318,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver",
         "fields": {
           "type": "map",
@@ -55226,11 +54371,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",
@@ -55411,9 +54551,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver",
         "fields": {
           "type": "map",

--- a/schemas/contrib/v0.130.0.yaml
+++ b/schemas/contrib/v0.130.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.130.0
 distribution: contrib
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:38Z"
+generatedAt: "2026-08-02T13:15:52Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,9 +22,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -60,8 +54,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
       fields:
         type: map
@@ -113,9 +105,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -148,9 +137,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -183,10 +169,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     grafanacloud:
       type: grafanacloud
@@ -195,8 +177,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector
       fields:
         type: map
@@ -221,9 +201,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
     roundrobin:
       type: roundrobin
@@ -238,9 +215,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
     routing:
       type: routing
@@ -255,9 +229,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -295,9 +266,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       fields:
         type: map
@@ -355,8 +323,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
     spanmetrics:
       type: spanmetrics
@@ -365,8 +331,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
       fields:
         type: map
@@ -487,8 +451,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector
       fields:
         type: map
@@ -515,8 +477,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter
       fields:
         type: map
@@ -694,8 +654,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
       fields:
         type: map
@@ -720,8 +678,6 @@ components:
         - logs
       stability:
         logs: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
       fields:
         type: map
@@ -811,8 +767,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
       fields:
         type: map
@@ -928,8 +882,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
       fields:
         type: map
@@ -1014,8 +966,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter
       fields:
         type: map
@@ -1104,8 +1054,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
       fields:
         type: map
@@ -1173,8 +1121,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter
       fields:
         type: map
@@ -1265,8 +1211,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter
       fields:
         type: map
@@ -1357,8 +1301,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
       fields:
         type: map
@@ -1418,8 +1360,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter
       fields:
         type: map
@@ -1551,8 +1491,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
       fields:
         type: map
@@ -1627,8 +1565,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter
       fields:
         type: map
@@ -1674,8 +1610,6 @@ components:
         logs: beta
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter
       fields:
         type: map
@@ -1802,8 +1736,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
       fields:
         type: map
@@ -2454,8 +2386,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
     dataset:
       type: dataset
@@ -2465,8 +2395,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter
       fields:
         type: map
@@ -2595,10 +2523,6 @@ components:
         metrics: development
         profiles: development
         traces: development
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -2628,8 +2552,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter
       fields:
         type: map
@@ -2829,8 +2751,6 @@ components:
         metrics: development
         profiles: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
       fields:
         type: map
@@ -3104,8 +3024,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter
       fields:
         type: map
@@ -3272,10 +3190,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -3323,8 +3237,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
       fields:
         type: map
@@ -3372,8 +3284,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
       fields:
         type: map
@@ -3460,8 +3370,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
       fields:
         type: map
@@ -3522,8 +3430,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
       fields:
         type: map
@@ -3714,8 +3620,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
       fields:
         type: map
@@ -3913,9 +3817,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -4208,8 +4109,6 @@ components:
         logs: unmaintained
         metrics: unmaintained
         traces: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kineticaexporter
       fields:
         type: map
@@ -4234,9 +4133,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       fields:
         type: map
@@ -4501,8 +4397,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter
       fields:
         type: map
@@ -4682,8 +4576,6 @@ components:
       stability:
         logs: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
       fields:
         type: map
@@ -4856,8 +4748,6 @@ components:
         - logs
       stability:
         logs: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter
       deprecated: Use OTLP exporter (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33916)
       fields:
@@ -5022,8 +4912,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter
       fields:
         type: map
@@ -5192,10 +5080,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     opencensus:
       type: opencensus
@@ -5205,9 +5089,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter
       deprecated: Use OTLP exporter (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)
       fields:
@@ -5360,8 +5241,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter
       fields:
         type: map
@@ -5561,9 +5440,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -5750,11 +5626,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -5894,11 +5765,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -6067,9 +5933,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -6203,9 +6066,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -6383,8 +6243,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
       fields:
         type: map
@@ -6531,8 +6389,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter
       fields:
         type: map
@@ -6645,8 +6501,6 @@ components:
         - traces
       stability:
         traces: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
       deprecated: use OTLP exporter
       fields:
@@ -6724,8 +6578,6 @@ components:
       stability:
         logs: development
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter
       fields:
         type: map
@@ -6902,8 +6754,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
       fields:
         type: map
@@ -6924,8 +6774,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
       fields:
         type: map
@@ -7409,8 +7257,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
       fields:
         type: map
@@ -7666,8 +7512,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter
       fields:
         type: map
@@ -7821,8 +7665,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
       fields:
         type: map
@@ -7997,8 +7839,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter
       fields:
         type: map
@@ -8117,8 +7957,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
       fields:
         type: map
@@ -8143,8 +7981,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter
       fields:
         type: map
@@ -8324,9 +8160,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -8490,9 +8323,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -8508,8 +8338,6 @@ components:
       type: asapclient
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
       fields:
         type: map
@@ -8531,8 +8359,6 @@ components:
       type: avro_log_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension
       fields:
         type: map
@@ -8543,8 +8369,6 @@ components:
       type: awscloudwatchmetricstreams_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension
       fields:
         type: map
@@ -8555,8 +8379,6 @@ components:
       type: awslogs_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
       fields:
         type: map
@@ -8572,8 +8394,6 @@ components:
       type: awsproxy
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
       fields:
         type: map
@@ -8651,8 +8471,6 @@ components:
       type: azureauth
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension
       fields:
         type: map
@@ -8688,9 +8506,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -8713,9 +8528,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -8737,8 +8549,6 @@ components:
       type: cfgarden_observer
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver
       fields:
         type: map
@@ -8780,8 +8590,6 @@ components:
       type: cgroupruntime
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension
       fields:
         type: map
@@ -8802,8 +8610,6 @@ components:
       type: datadog
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension
       fields:
         type: map
@@ -9037,8 +8843,6 @@ components:
       type: db_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
       fields:
         type: map
@@ -9051,8 +8855,6 @@ components:
       type: docker_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
       fields:
         type: map
@@ -9080,8 +8882,6 @@ components:
       type: ecs_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
       fields:
         type: map
@@ -9159,8 +8959,6 @@ components:
       type: ecs_task_observer
       stability:
         extension: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver
       fields:
         type: map
@@ -9280,9 +9078,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -9320,15 +9115,11 @@ components:
       type: googleclientauth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension
     googlecloudlogentry_encoding:
       type: googlecloudlogentry_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
       fields:
         type: map
@@ -9341,9 +9132,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -9370,10 +9158,6 @@ components:
       type: health_check
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -9505,8 +9289,6 @@ components:
       type: healthcheckv2
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension
       fields:
         type: map
@@ -9879,9 +9661,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -9892,9 +9671,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -10118,8 +9894,6 @@ components:
       type: jaeger_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension
       fields:
         type: map
@@ -10130,8 +9904,6 @@ components:
       type: jaegerremotesampling
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
       fields:
         type: map
@@ -10457,8 +10229,6 @@ components:
       type: json_log_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension
       fields:
         type: map
@@ -10471,8 +10241,6 @@ components:
       type: k8s_leader_elector
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
       fields:
         type: map
@@ -10495,9 +10263,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -10525,8 +10290,6 @@ components:
       type: kafkatopics_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver
       fields:
         type: map
@@ -10709,9 +10472,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -10792,9 +10552,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -10817,9 +10574,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -10978,8 +10732,6 @@ components:
       type: otlp_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension
       fields:
         type: map
@@ -10990,10 +10742,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -11015,8 +10763,6 @@ components:
       type: redis_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension
       fields:
         type: map
@@ -11085,8 +10831,6 @@ components:
       type: remotetap
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension
       fields:
         type: map
@@ -11200,8 +10944,6 @@ components:
       type: sigv4auth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension
       fields:
         type: map
@@ -11225,15 +10967,11 @@ components:
       type: skywalking_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension
     solarwindsapmsettings:
       type: solarwindsapmsettings
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension
       fields:
         type: map
@@ -11337,8 +11075,6 @@ components:
       type: sumologic
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension
       fields:
         type: map
@@ -11491,8 +11227,6 @@ components:
       type: text_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension
       fields:
         type: map
@@ -11507,8 +11241,6 @@ components:
       type: zipkin_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension
       fields:
         type: map
@@ -11521,10 +11253,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -11650,10 +11378,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -11851,10 +11575,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -11883,8 +11603,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor
       fields:
         type: map
@@ -11900,9 +11618,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       fields:
         type: map
@@ -11961,8 +11676,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/datadogsemanticsprocessor
       fields:
         type: map
@@ -11975,9 +11688,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -11992,9 +11702,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -12014,8 +11721,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor
     filter:
       type: filter
@@ -12027,10 +11732,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -12407,8 +12108,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor
       fields:
         type: map
@@ -12431,9 +12130,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -12449,9 +12145,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -12472,9 +12165,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -12500,9 +12190,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       fields:
         type: map
@@ -12621,9 +12308,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       fields:
         type: map
@@ -12655,8 +12339,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor
       fields:
         type: map
@@ -12693,10 +12375,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -12724,8 +12402,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
       fields:
         type: map
@@ -12756,8 +12432,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor
       fields:
         type: map
@@ -12774,9 +12448,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       fields:
         type: map
@@ -12853,10 +12524,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -12887,9 +12554,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -12935,9 +12599,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -13062,10 +12723,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -13103,9 +12760,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       fields:
         type: map
@@ -14021,8 +13675,6 @@ components:
         logs: deprecated
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
       deprecated: Use routing connector (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36616)
       fields:
@@ -14066,8 +13718,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor
       fields:
         type: map
@@ -14192,9 +13842,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -14400,8 +14047,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor
       fields:
         type: map
@@ -14483,9 +14128,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -15071,9 +14713,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -15169,8 +14808,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver
       fields:
         type: map
@@ -15280,8 +14917,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
       fields:
         type: map
@@ -15484,8 +15119,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
       fields:
         type: map
@@ -15720,8 +15353,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
       fields:
         type: map
@@ -16316,8 +15947,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver
       fields:
         type: map
@@ -16372,8 +16001,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchmetricsreceiver
       fields:
         type: map
@@ -16419,8 +16046,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
       fields:
         type: map
@@ -16441,8 +16066,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
       fields:
         type: map
@@ -16457,8 +16080,6 @@ components:
       stability:
         logs: alpha
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver
       fields:
         type: map
@@ -16584,8 +16205,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver
       fields:
         type: map
@@ -16649,8 +16268,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
       fields:
         type: map
@@ -16744,8 +16361,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
       fields:
         type: map
@@ -16792,8 +16407,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
       fields:
         type: map
@@ -16837,8 +16450,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
       fields:
         type: map
@@ -16929,8 +16540,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
       fields:
         type: map
@@ -17369,8 +16978,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
       fields:
         type: map
@@ -17398,8 +17005,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver
       fields:
         type: map
@@ -17456,8 +17061,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
       fields:
         type: map
@@ -17532,8 +17135,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
       fields:
         type: map
@@ -17667,8 +17268,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
       fields:
         type: map
@@ -17790,8 +17389,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
       fields:
         type: map
@@ -17987,8 +17584,6 @@ components:
       stability:
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
       fields:
         type: map
@@ -18123,8 +17718,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
       fields:
         type: map
@@ -18692,8 +18285,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
       fields:
         type: map
@@ -19394,8 +18985,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver
       fields:
         type: map
@@ -19511,8 +19100,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver
       fields:
         type: map
@@ -19766,8 +19353,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver
       fields:
         type: map
@@ -19883,9 +19468,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
     filestats:
       type: filestats
@@ -19893,8 +19475,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
       fields:
         type: map
@@ -19994,8 +19574,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
       fields:
         type: map
@@ -20415,9 +19993,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       fields:
         type: map
@@ -20432,8 +20007,6 @@ components:
       stability:
         metrics: alpha
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver
       fields:
         type: map
@@ -20678,8 +20251,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver
       fields:
         type: map
@@ -20807,8 +20378,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
       fields:
         type: map
@@ -20841,8 +20410,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
       fields:
         type: map
@@ -20873,8 +20440,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
       fields:
         type: map
@@ -20924,8 +20489,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
       fields:
         type: map
@@ -21257,10 +20820,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -21281,9 +20840,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       fields:
         type: map
@@ -21435,8 +20991,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver
       fields:
         type: map
@@ -21602,8 +21156,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
       fields:
         type: map
@@ -21746,8 +21298,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
       fields:
         type: map
@@ -21863,10 +21413,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -22222,8 +21768,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
       fields:
         type: map
@@ -22282,9 +21826,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
     k8s_cluster:
       type: k8s_cluster
@@ -22294,9 +21835,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -23563,9 +23101,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -23585,8 +23120,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8slogreceiver
       fields:
         type: map
@@ -23747,9 +23280,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       fields:
         type: map
@@ -23804,9 +23334,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -24071,8 +23598,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
       fields:
         type: map
@@ -24383,9 +23908,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       fields:
         type: map
@@ -25165,8 +24687,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver
       fields:
         type: map
@@ -25329,8 +24849,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver
       fields:
         type: map
@@ -25562,8 +25080,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
       fields:
         type: map
@@ -25647,8 +25163,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
       fields:
         type: map
@@ -26054,8 +25568,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
       fields:
         type: map
@@ -26935,8 +26447,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
       fields:
         type: map
@@ -27295,8 +26805,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
     netflow:
       type: netflow
@@ -27304,8 +26812,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver
       fields:
         type: map
@@ -27330,8 +26836,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
       fields:
         type: map
@@ -27477,9 +26981,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     nsxt:
       type: nsxt
@@ -27487,8 +26988,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
       fields:
         type: map
@@ -27752,8 +27251,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver
       fields:
         type: map
@@ -27812,10 +27309,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
       deprecated: Use OTLP receiver (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)
       fields:
@@ -27937,8 +27430,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver
       fields:
         type: map
@@ -28201,8 +27692,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver
       fields:
         type: map
@@ -28230,9 +27719,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -28385,11 +27871,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -28580,8 +28061,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
       fields:
         type: map
@@ -28698,8 +28177,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
       fields:
         type: map
@@ -28887,8 +28364,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
       fields:
         type: map
@@ -29380,8 +28855,6 @@ components:
         - profiles
       stability:
         profiles: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver
       fields:
         type: map
@@ -29496,10 +28969,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -29745,8 +29214,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
       fields:
         type: map
@@ -29888,8 +29355,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
       fields:
         type: map
@@ -30009,8 +29474,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver
       fields:
         type: map
@@ -30076,8 +29539,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver
       fields:
         type: map
@@ -30284,8 +29745,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver
       fields:
         type: map
@@ -30456,8 +29915,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
       fields:
         type: map
@@ -31065,9 +30522,6 @@ components:
         logs: alpha
         metrics: beta
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -31098,8 +30552,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
       fields:
         type: map
@@ -31435,8 +30887,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
       fields:
         type: map
@@ -31623,8 +31073,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
       fields:
         type: map
@@ -31983,8 +31431,6 @@ components:
         - traces
       stability:
         traces: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver
       deprecated: use OTLP receiver
       fields:
@@ -32103,8 +31549,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
       fields:
         type: map
@@ -32224,8 +31668,6 @@ components:
       stability:
         metrics: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver
       fields:
         type: map
@@ -32455,8 +31897,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
       fields:
         type: map
@@ -32500,8 +31940,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
       fields:
         type: map
@@ -32738,8 +32176,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver
       fields:
         type: map
@@ -32839,8 +32275,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
       fields:
         type: map
@@ -32983,8 +32417,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver
       fields:
         type: map
@@ -33579,8 +33011,6 @@ components:
       stability:
         logs: development
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver
       fields:
         type: map
@@ -33688,8 +33118,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
       fields:
         type: map
@@ -34270,8 +33698,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
       fields:
         type: map
@@ -34363,8 +33789,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
       fields:
         type: map
@@ -34420,8 +33844,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver
       fields:
         type: map
@@ -34539,8 +33961,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
     systemd:
       type: systemd
@@ -34548,8 +33968,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver
     tcpcheck:
       type: tcpcheck
@@ -34557,8 +33975,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver
       fields:
         type: map
@@ -34606,8 +34022,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
     tlscheck:
       type: tlscheck
@@ -34615,8 +34029,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
       fields:
         type: map
@@ -34684,8 +34096,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
     vcenter:
       type: vcenter
@@ -34693,8 +34103,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
       fields:
         type: map
@@ -35428,8 +34836,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
       fields:
         type: map
@@ -35451,8 +34857,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver
       fields:
         type: map
@@ -35585,8 +34989,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
     windowsperfcounters:
       type: windowsperfcounters
@@ -35594,8 +34996,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
       fields:
         type: map
@@ -35643,8 +35043,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver
       fields:
         type: map
@@ -35679,10 +35077,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map
@@ -35800,8 +35194,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
       fields:
         type: map

--- a/schemas/contrib/v0.140.0.json
+++ b/schemas/contrib/v0.140.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.140.0",
   "distribution": "contrib",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:39Z",
+  "generatedAt": "2026-08-02T13:15:53Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -37,10 +33,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -88,9 +80,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector",
         "fields": {
@@ -172,10 +161,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
           "type": "map",
@@ -227,10 +212,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
@@ -334,11 +315,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "grafanacloud": {
@@ -351,9 +327,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector",
         "fields": {
@@ -394,10 +367,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"
       },
       "roundrobin": {
@@ -421,10 +390,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
       },
       "routing": {
@@ -447,10 +412,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -509,10 +470,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "fields": {
@@ -611,9 +568,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector"
       },
       "slowsql": {
@@ -626,9 +580,6 @@
             "from": "traces",
             "to": "logs"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector",
         "fields": {
@@ -674,9 +625,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector",
         "fields": {
@@ -872,9 +820,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector",
         "fields": {
           "type": "map",
@@ -912,9 +857,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter",
         "fields": {
           "type": "map",
@@ -1182,9 +1124,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -1221,9 +1160,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter",
         "fields": {
           "type": "map",
@@ -1357,9 +1293,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter",
         "fields": {
           "type": "map",
@@ -1536,9 +1469,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter",
         "fields": {
           "type": "map",
@@ -1664,9 +1594,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter",
         "fields": {
           "type": "map",
@@ -1811,9 +1738,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter",
         "fields": {
           "type": "map",
@@ -1914,9 +1838,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter",
         "fields": {
           "type": "map",
@@ -2063,9 +1984,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter",
         "fields": {
           "type": "map",
@@ -2199,9 +2117,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter",
         "fields": {
           "type": "map",
@@ -2446,9 +2361,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter",
         "fields": {
           "type": "map",
@@ -2649,9 +2561,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter",
         "fields": {
           "type": "map",
@@ -2763,9 +2672,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter",
         "fields": {
           "type": "map",
@@ -2833,9 +2739,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter",
         "fields": {
           "type": "map",
@@ -3102,9 +3005,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter",
         "fields": {
           "type": "map",
@@ -3973,9 +3873,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
       },
       "dataset": {
@@ -3988,9 +3885,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter",
         "fields": {
           "type": "map",
@@ -4183,11 +4077,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -4227,9 +4116,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter",
         "fields": {
           "type": "map",
@@ -4529,9 +4415,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter",
         "fields": {
           "type": "map",
@@ -4937,9 +4820,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter",
         "fields": {
           "type": "map",
@@ -5189,11 +5069,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -5263,9 +5138,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter",
         "fields": {
           "type": "map",
@@ -5334,9 +5206,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter",
         "fields": {
           "type": "map",
@@ -5467,9 +5336,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter",
         "fields": {
           "type": "map",
@@ -5509,9 +5375,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter",
         "fields": {
           "type": "map",
@@ -5602,9 +5465,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter",
         "fields": {
           "type": "map",
@@ -5893,9 +5753,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter",
         "fields": {
           "type": "map",
@@ -6199,10 +6056,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -6679,10 +6532,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "fields": {
           "type": "map",
@@ -7082,9 +6931,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter",
         "fields": {
           "type": "map",
@@ -7357,9 +7203,6 @@
           "logs": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter",
         "fields": {
           "type": "map",
@@ -7621,9 +7464,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter",
         "fields": {
           "type": "map",
@@ -7877,11 +7717,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "opensearch": {
@@ -7894,9 +7729,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter",
         "fields": {
           "type": "map",
@@ -8206,10 +8038,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -8487,12 +8315,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -8693,12 +8515,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -8957,10 +8773,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -9214,10 +9026,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -9489,9 +9297,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter",
         "fields": {
           "type": "map",
@@ -9718,9 +9523,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter",
         "fields": {
           "type": "map",
@@ -9893,9 +9695,6 @@
         "stability": {
           "traces": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter",
         "deprecated": "use OTLP exporter",
         "fields": {
@@ -10010,9 +9809,6 @@
           "logs": "development",
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter",
         "fields": {
           "type": "map",
@@ -10281,9 +10077,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter",
         "fields": {
           "type": "map",
@@ -10312,9 +10105,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter",
         "fields": {
           "type": "map",
@@ -11049,9 +10839,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter",
         "fields": {
           "type": "map",
@@ -11422,9 +11209,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter",
         "fields": {
           "type": "map",
@@ -11652,9 +11436,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter",
         "fields": {
           "type": "map",
@@ -11919,9 +11700,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter",
         "fields": {
           "type": "map",
@@ -12101,9 +11879,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -12138,9 +11913,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter",
         "fields": {
           "type": "map",
@@ -12443,10 +12215,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -12695,10 +12463,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -12721,9 +12485,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension",
         "fields": {
           "type": "map",
@@ -12756,9 +12517,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension",
         "fields": {
           "type": "map",
@@ -12774,9 +12532,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension",
         "fields": {
           "type": "map",
@@ -12792,9 +12547,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension",
         "fields": {
           "type": "map",
@@ -12826,9 +12578,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy",
         "fields": {
           "type": "map",
@@ -12947,9 +12696,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension",
         "fields": {
           "type": "map",
@@ -13012,10 +12758,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -13050,10 +12792,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -13086,9 +12824,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver",
         "fields": {
           "type": "map",
@@ -13152,9 +12887,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension",
         "fields": {
           "type": "map",
@@ -13186,9 +12918,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension",
         "fields": {
           "type": "map",
@@ -13547,9 +13276,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage",
         "fields": {
           "type": "map",
@@ -13568,9 +13294,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver",
         "fields": {
           "type": "map",
@@ -13612,9 +13335,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver",
         "fields": {
           "type": "map",
@@ -13735,10 +13455,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -13798,9 +13514,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension"
       },
       "googlecloudlogentry_encoding": {
@@ -13808,9 +13521,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension",
         "fields": {
           "type": "map",
@@ -13829,10 +13539,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -13873,11 +13579,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -14080,9 +13781,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension",
         "fields": {
           "type": "map",
@@ -14658,10 +14356,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -14677,10 +14371,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -15024,9 +14714,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension",
         "fields": {
           "type": "map",
@@ -15042,9 +14729,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling",
         "fields": {
           "type": "map",
@@ -15543,9 +15227,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension",
         "fields": {
           "type": "map",
@@ -15564,10 +15245,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector",
         "fields": {
           "type": "map",
@@ -15601,10 +15278,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -15646,9 +15319,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver",
         "fields": {
           "type": "map",
@@ -15936,10 +15606,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -16062,10 +15728,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -16127,10 +15789,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -16372,9 +16030,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension",
         "fields": {
           "type": "map",
@@ -16390,11 +16045,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -16427,9 +16077,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension",
         "fields": {
           "type": "map",
@@ -16534,9 +16181,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension",
         "fields": {
           "type": "map",
@@ -16711,9 +16355,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension",
         "fields": {
           "type": "map",
@@ -16749,9 +16390,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension"
       },
       "solarwindsapmsettings": {
@@ -16759,9 +16397,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension",
         "fields": {
           "type": "map",
@@ -16783,9 +16418,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension",
         "fields": {
           "type": "map",
@@ -17017,9 +16649,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension",
         "fields": {
           "type": "map",
@@ -17041,9 +16670,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension",
         "fields": {
           "type": "map",
@@ -17062,11 +16688,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -17258,11 +16879,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -17570,11 +17186,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -17615,9 +17226,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor",
         "fields": {
           "type": "map",
@@ -17641,10 +17249,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "fields": {
           "type": "map",
@@ -17736,9 +17340,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/datadogsemanticsprocessor",
         "fields": {
           "type": "map",
@@ -17757,10 +17358,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -17782,10 +17379,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -17813,9 +17406,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor"
       },
       "filter": {
@@ -17832,11 +17422,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -18473,9 +18058,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor",
         "fields": {
           "type": "map",
@@ -18507,10 +18089,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -18534,10 +18112,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -18568,10 +18142,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -18605,9 +18175,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/isolationforestprocessor",
         "fields": {
           "type": "map",
@@ -18765,10 +18332,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "fields": {
           "type": "map",
@@ -18958,10 +18521,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "fields": {
           "type": "map",
@@ -19010,9 +18569,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor",
         "fields": {
           "type": "map",
@@ -19064,11 +18620,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -19107,9 +18658,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor",
         "fields": {
           "type": "map",
@@ -19156,9 +18704,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor",
         "fields": {
           "type": "map",
@@ -19183,10 +18728,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "fields": {
           "type": "map",
@@ -19303,11 +18844,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -19351,10 +18887,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -19559,10 +19091,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -19750,11 +19278,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -19808,10 +19331,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "fields": {
           "type": "map",
@@ -21777,9 +21296,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor",
         "fields": {
           "type": "map",
@@ -21970,10 +21486,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -22295,9 +21807,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor",
         "fields": {
           "type": "map",
@@ -22425,10 +21934,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -23353,10 +22858,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -23506,9 +23007,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor",
         "fields": {
           "type": "map",
@@ -23529,9 +23027,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver",
         "fields": {
           "type": "map",
@@ -23705,9 +23200,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver",
         "fields": {
           "type": "map",
@@ -24026,9 +23518,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver",
         "fields": {
           "type": "map",
@@ -24403,9 +23892,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver",
         "fields": {
           "type": "map",
@@ -25348,9 +24834,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver",
         "fields": {
           "type": "map",
@@ -25437,9 +24920,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver",
         "fields": {
           "type": "map",
@@ -25470,9 +24950,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver",
         "fields": {
           "type": "map",
@@ -25493,9 +24970,6 @@
           "logs": "alpha",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver",
         "fields": {
           "type": "map",
@@ -25682,9 +25156,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver",
         "fields": {
           "type": "map",
@@ -25707,9 +25178,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver",
         "fields": {
           "type": "map",
@@ -25806,9 +25274,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver",
         "fields": {
           "type": "map",
@@ -25951,9 +25416,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver",
         "fields": {
           "type": "map",
@@ -26023,9 +25485,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver",
         "fields": {
           "type": "map",
@@ -26101,9 +25560,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver",
         "fields": {
           "type": "map",
@@ -26247,9 +25703,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver",
         "fields": {
           "type": "map",
@@ -26942,9 +26395,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver",
         "fields": {
           "type": "map",
@@ -26986,9 +26436,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver",
         "fields": {
           "type": "map",
@@ -27077,9 +26524,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver",
         "fields": {
           "type": "map",
@@ -27142,9 +26586,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver",
         "fields": {
           "type": "map",
@@ -27260,9 +26701,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver",
         "fields": {
           "type": "map",
@@ -27467,9 +26905,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver",
         "fields": {
           "type": "map",
@@ -27656,9 +27091,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver",
         "fields": {
           "type": "map",
@@ -27963,9 +27395,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver",
         "fields": {
           "type": "map",
@@ -28173,9 +27602,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver",
         "fields": {
           "type": "map",
@@ -29080,9 +28506,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver",
         "fields": {
           "type": "map",
@@ -30194,9 +29617,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver",
         "fields": {
           "type": "map",
@@ -30374,9 +29794,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver",
         "fields": {
           "type": "map",
@@ -30772,9 +30189,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver",
         "fields": {
           "type": "map",
@@ -30952,10 +30366,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
       },
       "filestats": {
@@ -30966,9 +30376,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver",
         "fields": {
           "type": "map",
@@ -31126,9 +30533,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver",
         "fields": {
           "type": "map",
@@ -31791,10 +31195,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "fields": {
           "type": "map",
@@ -31815,9 +31215,6 @@
           "metrics": "alpha",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver",
         "fields": {
           "type": "map",
@@ -32202,9 +31599,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver",
         "fields": {
           "type": "map",
@@ -32403,9 +31797,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver",
         "fields": {
           "type": "map",
@@ -32453,9 +31844,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver",
         "fields": {
           "type": "map",
@@ -32501,9 +31889,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver",
         "fields": {
           "type": "map",
@@ -32685,9 +32070,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver",
         "fields": {
           "type": "map",
@@ -32764,9 +32146,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver",
         "fields": {
           "type": "map",
@@ -33343,11 +32722,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -33378,10 +32752,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "fields": {
           "type": "map",
@@ -33724,9 +33094,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver",
         "fields": {
           "type": "map",
@@ -33979,9 +33346,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver",
         "fields": {
           "type": "map",
@@ -34158,9 +33522,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver",
         "fields": {
           "type": "map",
@@ -34387,9 +33748,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver",
         "fields": {
           "type": "map",
@@ -34567,11 +33925,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -35116,9 +34469,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver",
         "fields": {
           "type": "map",
@@ -35212,10 +34562,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
       },
       "k8s_cluster": {
@@ -35228,10 +34574,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -37279,10 +36621,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -37316,9 +36654,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8slogreceiver",
         "fields": {
           "type": "map",
@@ -37571,10 +36906,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "fields": {
           "type": "map",
@@ -37660,10 +36991,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -38113,9 +37440,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver",
         "fields": {
           "type": "map",
@@ -38607,10 +37931,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "fields": {
           "type": "map",
@@ -39835,9 +39155,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver",
         "fields": {
           "type": "map",
@@ -40089,9 +39406,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver",
         "fields": {
           "type": "map",
@@ -40449,9 +39763,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver",
         "fields": {
           "type": "map",
@@ -40583,9 +39894,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver",
         "fields": {
           "type": "map",
@@ -41228,9 +40536,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver",
         "fields": {
           "type": "map",
@@ -42631,9 +41936,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver",
         "fields": {
           "type": "map",
@@ -43293,9 +42595,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver"
       },
       "netflow": {
@@ -43306,9 +42605,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver",
         "fields": {
           "type": "map",
@@ -43345,9 +42641,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
         "fields": {
           "type": "map",
@@ -43569,10 +42862,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "nsxt": {
@@ -43583,9 +42872,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver",
         "fields": {
           "type": "map",
@@ -43998,9 +43284,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver",
         "fields": {
           "type": "map",
@@ -44091,9 +43374,6 @@
           "logs": "development",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver",
         "fields": {
           "type": "map",
@@ -44735,9 +44015,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver",
         "fields": {
           "type": "map",
@@ -44777,10 +44054,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -45013,12 +44286,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -45301,9 +44568,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver",
         "fields": {
           "type": "map",
@@ -45484,9 +44748,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver",
         "fields": {
           "type": "map",
@@ -45783,9 +45044,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
         "fields": {
           "type": "map",
@@ -46575,9 +45833,6 @@
         "stability": {
           "profiles": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver",
         "fields": {
           "type": "map",
@@ -46752,11 +46007,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -47132,9 +46382,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver",
         "fields": {
           "type": "map",
@@ -47349,9 +46596,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver",
         "fields": {
           "type": "map",
@@ -47533,9 +46777,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver",
         "fields": {
           "type": "map",
@@ -47642,9 +46883,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver",
         "fields": {
           "type": "map",
@@ -47963,9 +47201,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver",
         "fields": {
           "type": "map",
@@ -48228,9 +47463,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver",
         "fields": {
           "type": "map",
@@ -49191,10 +48423,6 @@
           "metrics": "beta",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -49240,9 +48468,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redfishreceiver",
         "fields": {
           "type": "map",
@@ -49412,9 +48637,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver",
         "fields": {
           "type": "map",
@@ -50074,9 +49296,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver",
         "fields": {
           "type": "map",
@@ -50366,9 +49585,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver",
         "fields": {
           "type": "map",
@@ -50939,9 +50155,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver",
         "fields": {
           "type": "map",
@@ -51121,9 +50334,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver",
         "fields": {
           "type": "map",
@@ -51478,9 +50688,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver",
         "fields": {
           "type": "map",
@@ -51544,9 +50751,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver",
         "fields": {
           "type": "map",
@@ -51922,9 +51126,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver",
         "fields": {
           "type": "map",
@@ -52077,9 +51278,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver",
         "fields": {
           "type": "map",
@@ -52298,9 +51496,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver",
         "fields": {
           "type": "map",
@@ -53235,9 +52430,6 @@
           "logs": "development",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver",
         "fields": {
           "type": "map",
@@ -53401,9 +52593,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver",
         "fields": {
           "type": "map",
@@ -54409,9 +53598,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver",
         "fields": {
           "type": "map",
@@ -54555,9 +53741,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver",
         "fields": {
           "type": "map",
@@ -54664,9 +53847,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver",
         "fields": {
           "type": "map",
@@ -54847,9 +54027,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver"
       },
       "systemd": {
@@ -54860,9 +54037,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver",
         "fields": {
           "type": "map",
@@ -54956,9 +54130,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver",
         "fields": {
           "type": "map",
@@ -55033,9 +54204,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver"
       },
       "tlscheck": {
@@ -55046,9 +54214,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver",
         "fields": {
           "type": "map",
@@ -55155,9 +54320,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver"
       },
       "vcenter": {
@@ -55168,9 +54330,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver",
         "fields": {
           "type": "map",
@@ -56339,9 +55498,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver",
         "fields": {
           "type": "map",
@@ -56374,9 +55530,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver",
         "fields": {
           "type": "map",
@@ -56583,9 +55736,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
       },
       "windowsperfcounters": {
@@ -56596,9 +55746,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver",
         "fields": {
           "type": "map",
@@ -56671,9 +55818,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver",
         "fields": {
           "type": "map",
@@ -56727,9 +55871,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver"
       },
       "zipkin": {
@@ -56740,11 +55881,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",
@@ -56925,9 +56061,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver",
         "fields": {
           "type": "map",

--- a/schemas/contrib/v0.140.0.yaml
+++ b/schemas/contrib/v0.140.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.140.0
 distribution: contrib
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:39Z"
+generatedAt: "2026-08-02T13:15:53Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,9 +22,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -60,8 +54,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
       fields:
         type: map
@@ -113,9 +105,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -148,9 +137,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -217,10 +203,6 @@ components:
           to: profiles
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     grafanacloud:
       type: grafanacloud
@@ -229,8 +211,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector
       fields:
         type: map
@@ -255,9 +235,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
     roundrobin:
       type: roundrobin
@@ -272,9 +249,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
     routing:
       type: routing
@@ -289,9 +263,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -329,9 +300,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       fields:
         type: map
@@ -393,8 +361,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
     slowsql:
       type: slowsql
@@ -403,8 +369,6 @@ components:
       pairs:
         - from: traces
           to: logs
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector
       fields:
         type: map
@@ -433,8 +397,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
       fields:
         type: map
@@ -557,8 +519,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector
       fields:
         type: map
@@ -585,8 +545,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter
       fields:
         type: map
@@ -764,8 +722,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
       fields:
         type: map
@@ -790,8 +746,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
       fields:
         type: map
@@ -881,8 +835,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
       fields:
         type: map
@@ -998,8 +950,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
       fields:
         type: map
@@ -1084,8 +1034,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter
       fields:
         type: map
@@ -1182,8 +1130,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
       fields:
         type: map
@@ -1251,8 +1197,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter
       fields:
         type: map
@@ -1351,8 +1295,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter
       fields:
         type: map
@@ -1443,8 +1385,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
       fields:
         type: map
@@ -1606,8 +1546,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter
       fields:
         type: map
@@ -1739,8 +1677,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
       fields:
         type: map
@@ -1815,8 +1751,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter
       fields:
         type: map
@@ -1862,8 +1796,6 @@ components:
         logs: beta
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter
       fields:
         type: map
@@ -2040,8 +1972,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
       fields:
         type: map
@@ -2611,8 +2541,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
     dataset:
       type: dataset
@@ -2622,8 +2550,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter
       fields:
         type: map
@@ -2752,10 +2678,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -2785,8 +2707,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter
       fields:
         type: map
@@ -2986,8 +2906,6 @@ components:
         metrics: development
         profiles: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
       fields:
         type: map
@@ -3252,8 +3170,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter
       fields:
         type: map
@@ -3420,10 +3336,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -3471,8 +3383,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
       fields:
         type: map
@@ -3520,8 +3430,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
       fields:
         type: map
@@ -3608,8 +3516,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter
       fields:
         type: map
@@ -3636,8 +3542,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
       fields:
         type: map
@@ -3698,8 +3602,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
       fields:
         type: map
@@ -3890,8 +3792,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
       fields:
         type: map
@@ -4093,9 +3993,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -4407,9 +4304,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       fields:
         type: map
@@ -4672,8 +4566,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter
       fields:
         type: map
@@ -4853,8 +4745,6 @@ components:
       stability:
         logs: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
       fields:
         type: map
@@ -5027,8 +4917,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter
       fields:
         type: map
@@ -5197,10 +5085,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     opensearch:
       type: opensearch
@@ -5210,8 +5094,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter
       fields:
         type: map
@@ -5417,9 +5299,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -5604,11 +5483,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -5748,11 +5622,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -5923,9 +5792,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -6092,9 +5958,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -6274,8 +6137,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
       fields:
         type: map
@@ -6426,8 +6287,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter
       fields:
         type: map
@@ -6540,8 +6399,6 @@ components:
         - traces
       stability:
         traces: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
       deprecated: use OTLP exporter
       fields:
@@ -6619,8 +6476,6 @@ components:
       stability:
         logs: development
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter
       fields:
         type: map
@@ -6797,8 +6652,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
       fields:
         type: map
@@ -6819,8 +6672,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
       fields:
         type: map
@@ -7304,8 +7155,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
       fields:
         type: map
@@ -7550,8 +7399,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter
       fields:
         type: map
@@ -7703,8 +7550,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
       fields:
         type: map
@@ -7879,8 +7724,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter
       fields:
         type: map
@@ -7999,8 +7842,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
       fields:
         type: map
@@ -8025,8 +7866,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter
       fields:
         type: map
@@ -8224,9 +8063,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -8390,9 +8226,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -8408,8 +8241,6 @@ components:
       type: asapclient
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
       fields:
         type: map
@@ -8431,8 +8262,6 @@ components:
       type: avro_log_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension
       fields:
         type: map
@@ -8443,8 +8272,6 @@ components:
       type: awscloudwatchmetricstreams_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension
       fields:
         type: map
@@ -8455,8 +8282,6 @@ components:
       type: awslogs_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
       fields:
         type: map
@@ -8477,8 +8302,6 @@ components:
       type: awsproxy
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
       fields:
         type: map
@@ -8556,8 +8379,6 @@ components:
       type: azureauth
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension
       fields:
         type: map
@@ -8598,9 +8419,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -8623,9 +8441,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -8647,8 +8462,6 @@ components:
       type: cfgarden_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver
       fields:
         type: map
@@ -8690,8 +8503,6 @@ components:
       type: cgroupruntime
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension
       fields:
         type: map
@@ -8712,8 +8523,6 @@ components:
       type: datadog
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension
       fields:
         type: map
@@ -8947,8 +8756,6 @@ components:
       type: db_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
       fields:
         type: map
@@ -8961,8 +8768,6 @@ components:
       type: docker_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
       fields:
         type: map
@@ -8990,8 +8795,6 @@ components:
       type: ecs_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
       fields:
         type: map
@@ -9069,9 +8872,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -9111,15 +8911,11 @@ components:
       type: googleclientauth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension
     googlecloudlogentry_encoding:
       type: googlecloudlogentry_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
       fields:
         type: map
@@ -9132,9 +8928,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -9161,10 +8954,6 @@ components:
       type: health_check
       stability:
         extension: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -9296,8 +9085,6 @@ components:
       type: healthcheckv2
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension
       fields:
         type: map
@@ -9670,9 +9457,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -9683,9 +9467,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -9909,8 +9690,6 @@ components:
       type: jaeger_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension
       fields:
         type: map
@@ -9921,8 +9700,6 @@ components:
       type: jaegerremotesampling
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
       fields:
         type: map
@@ -10246,8 +10023,6 @@ components:
       type: json_log_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension
       fields:
         type: map
@@ -10260,9 +10035,6 @@ components:
       type: k8s_leader_elector
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
       fields:
         type: map
@@ -10285,9 +10057,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -10315,8 +10084,6 @@ components:
       type: kafkatopics_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver
       fields:
         type: map
@@ -10503,9 +10270,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -10586,9 +10350,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -10629,9 +10390,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -10790,8 +10548,6 @@ components:
       type: otlp_encoding
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension
       fields:
         type: map
@@ -10802,10 +10558,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -10827,8 +10579,6 @@ components:
       type: redis_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension
       fields:
         type: map
@@ -10897,8 +10647,6 @@ components:
       type: remotetap
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension
       fields:
         type: map
@@ -11012,8 +10760,6 @@ components:
       type: sigv4auth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension
       fields:
         type: map
@@ -11037,15 +10783,11 @@ components:
       type: skywalking_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension
     solarwindsapmsettings:
       type: solarwindsapmsettings
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension
       fields:
         type: map
@@ -11060,8 +10802,6 @@ components:
       type: sumologic
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension
       fields:
         type: map
@@ -11214,8 +10954,6 @@ components:
       type: text_encoding
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension
       fields:
         type: map
@@ -11230,8 +10968,6 @@ components:
       type: zipkin_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension
       fields:
         type: map
@@ -11244,10 +10980,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -11373,10 +11105,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -11574,10 +11302,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -11606,8 +11330,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor
       fields:
         type: map
@@ -11623,9 +11345,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       fields:
         type: map
@@ -11684,8 +11403,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/datadogsemanticsprocessor
       fields:
         type: map
@@ -11698,9 +11415,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -11715,9 +11429,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -11737,8 +11448,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor
     filter:
       type: filter
@@ -11752,10 +11461,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -12160,8 +11865,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor
       fields:
         type: map
@@ -12184,9 +11887,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -12202,9 +11902,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -12225,9 +11922,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -12251,8 +11945,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/isolationforestprocessor
       fields:
         type: map
@@ -12357,9 +12049,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       fields:
         type: map
@@ -12480,9 +12169,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       fields:
         type: map
@@ -12514,8 +12200,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor
       fields:
         type: map
@@ -12552,10 +12236,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -12583,8 +12263,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
       fields:
         type: map
@@ -12615,8 +12293,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor
       fields:
         type: map
@@ -12633,9 +12309,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       fields:
         type: map
@@ -12712,10 +12385,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -12746,9 +12415,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -12879,9 +12545,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -13006,10 +12669,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -13047,9 +12706,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       fields:
         type: map
@@ -14284,8 +13940,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor
       fields:
         type: map
@@ -14410,9 +14064,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -14618,8 +14269,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor
       fields:
         type: map
@@ -14701,9 +14350,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -15291,9 +14937,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -15388,8 +15031,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor
       fields:
         type: map
@@ -15403,8 +15044,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver
       fields:
         type: map
@@ -15514,8 +15153,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
       fields:
         type: map
@@ -15718,8 +15355,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
       fields:
         type: map
@@ -15959,8 +15594,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
       fields:
         type: map
@@ -16555,8 +16188,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver
       fields:
         type: map
@@ -16613,8 +16244,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
       fields:
         type: map
@@ -16635,8 +16264,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
       fields:
         type: map
@@ -16651,8 +16278,6 @@ components:
       stability:
         logs: alpha
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver
       fields:
         type: map
@@ -16774,8 +16399,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver
       fields:
         type: map
@@ -16792,8 +16415,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver
       fields:
         type: map
@@ -16857,8 +16478,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
       fields:
         type: map
@@ -16952,8 +16571,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
       fields:
         type: map
@@ -17000,8 +16617,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
       fields:
         type: map
@@ -17051,8 +16666,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
       fields:
         type: map
@@ -17146,8 +16759,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
       fields:
         type: map
@@ -17586,8 +17197,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
       fields:
         type: map
@@ -17615,8 +17224,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver
       fields:
         type: map
@@ -17673,8 +17280,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver
       fields:
         type: map
@@ -17715,8 +17320,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
       fields:
         type: map
@@ -17793,8 +17396,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
       fields:
         type: map
@@ -17928,8 +17529,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
       fields:
         type: map
@@ -18051,8 +17650,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
       fields:
         type: map
@@ -18250,8 +17847,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
       fields:
         type: map
@@ -18386,8 +17981,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
       fields:
         type: map
@@ -18955,8 +18548,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
       fields:
         type: map
@@ -19657,8 +19248,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver
       fields:
         type: map
@@ -19774,8 +19363,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver
       fields:
         type: map
@@ -20029,8 +19616,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver
       fields:
         type: map
@@ -20146,9 +19731,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
     filestats:
       type: filestats
@@ -20156,8 +19738,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
       fields:
         type: map
@@ -20257,8 +19837,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
       fields:
         type: map
@@ -20678,9 +20256,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       fields:
         type: map
@@ -20695,8 +20270,6 @@ components:
       stability:
         metrics: alpha
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver
       fields:
         type: map
@@ -20943,8 +20516,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver
       fields:
         type: map
@@ -21074,8 +20645,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
       fields:
         type: map
@@ -21108,8 +20677,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
       fields:
         type: map
@@ -21140,8 +20707,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver
       fields:
         type: map
@@ -21260,8 +20825,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
       fields:
         type: map
@@ -21311,8 +20874,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
       fields:
         type: map
@@ -21679,10 +21240,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -21703,9 +21260,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       fields:
         type: map
@@ -21926,8 +21480,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver
       fields:
         type: map
@@ -22093,8 +21645,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver
       fields:
         type: map
@@ -22206,8 +21756,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
       fields:
         type: map
@@ -22350,8 +21898,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
       fields:
         type: map
@@ -22467,10 +22013,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -22824,8 +22366,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
       fields:
         type: map
@@ -22888,9 +22428,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
     k8s_cluster:
       type: k8s_cluster
@@ -22900,9 +22437,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -24184,9 +23718,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -24209,8 +23740,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8slogreceiver
       fields:
         type: map
@@ -24371,9 +23900,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       fields:
         type: map
@@ -24432,9 +23958,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -24725,8 +24248,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
       fields:
         type: map
@@ -25041,9 +24562,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       fields:
         type: map
@@ -25813,8 +25331,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver
       fields:
         type: map
@@ -25977,8 +25493,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver
       fields:
         type: map
@@ -26210,8 +25724,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
       fields:
         type: map
@@ -26295,8 +25807,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
       fields:
         type: map
@@ -26702,8 +26212,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
       fields:
         type: map
@@ -27585,8 +27093,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
       fields:
         type: map
@@ -28003,8 +27509,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
     netflow:
       type: netflow
@@ -28012,8 +27516,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver
       fields:
         type: map
@@ -28038,8 +27540,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
       fields:
         type: map
@@ -28185,9 +27685,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     nsxt:
       type: nsxt
@@ -28195,8 +27692,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
       fields:
         type: map
@@ -28460,8 +27955,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver
       fields:
         type: map
@@ -28520,8 +28013,6 @@ components:
       stability:
         logs: development
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver
       fields:
         type: map
@@ -28924,8 +28415,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver
       fields:
         type: map
@@ -28953,9 +28442,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -29108,11 +28594,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -29303,8 +28784,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
       fields:
         type: map
@@ -29423,8 +28902,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
       fields:
         type: map
@@ -29612,8 +29089,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
       fields:
         type: map
@@ -30111,8 +29586,6 @@ components:
         - profiles
       stability:
         profiles: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver
       fields:
         type: map
@@ -30227,10 +29700,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -30476,8 +29945,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
       fields:
         type: map
@@ -30619,8 +30086,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
       fields:
         type: map
@@ -30740,8 +30205,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver
       fields:
         type: map
@@ -30811,8 +30274,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver
       fields:
         type: map
@@ -31019,8 +30480,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver
       fields:
         type: map
@@ -31191,8 +30650,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
       fields:
         type: map
@@ -31800,9 +31257,6 @@ components:
         logs: alpha
         metrics: beta
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -31833,8 +31287,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redfishreceiver
       fields:
         type: map
@@ -31942,8 +31394,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
       fields:
         type: map
@@ -32359,8 +31809,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
       fields:
         type: map
@@ -32547,8 +31995,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
       fields:
         type: map
@@ -32909,8 +32355,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
       fields:
         type: map
@@ -33028,8 +32472,6 @@ components:
       stability:
         metrics: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver
       fields:
         type: map
@@ -33259,8 +32701,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
       fields:
         type: map
@@ -33304,8 +32744,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
       fields:
         type: map
@@ -33542,8 +32980,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver
       fields:
         type: map
@@ -33643,8 +33079,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
       fields:
         type: map
@@ -33787,8 +33221,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver
       fields:
         type: map
@@ -34388,8 +33820,6 @@ components:
       stability:
         logs: development
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver
       fields:
         type: map
@@ -34497,8 +33927,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
       fields:
         type: map
@@ -35129,8 +34557,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
       fields:
         type: map
@@ -35222,8 +34648,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
       fields:
         type: map
@@ -35292,8 +34716,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver
       fields:
         type: map
@@ -35411,8 +34833,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
     systemd:
       type: systemd
@@ -35420,8 +34840,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver
       fields:
         type: map
@@ -35481,8 +34899,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver
       fields:
         type: map
@@ -35530,8 +34946,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
     tlscheck:
       type: tlscheck
@@ -35539,8 +34953,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
       fields:
         type: map
@@ -35608,8 +35020,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
     vcenter:
       type: vcenter
@@ -35617,8 +35027,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
       fields:
         type: map
@@ -36352,8 +35760,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
       fields:
         type: map
@@ -36375,8 +35781,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver
       fields:
         type: map
@@ -36511,8 +35915,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
     windowsperfcounters:
       type: windowsperfcounters
@@ -36520,8 +35922,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
       fields:
         type: map
@@ -36569,8 +35969,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver
       fields:
         type: map
@@ -36605,8 +36003,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver
     zipkin:
       type: zipkin
@@ -36614,10 +36010,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map
@@ -36735,8 +36127,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
       fields:
         type: map

--- a/schemas/contrib/v0.150.0.json
+++ b/schemas/contrib/v0.150.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.150.0",
   "distribution": "contrib",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:39Z",
+  "generatedAt": "2026-08-02T13:15:53Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -37,10 +33,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -89,9 +81,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector",
         "fields": {
@@ -187,10 +176,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
           "type": "map",
@@ -246,10 +231,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
@@ -385,11 +366,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "grafanacloud": {
@@ -402,9 +378,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector",
         "fields": {
@@ -436,9 +409,6 @@
             "from": "metrics",
             "to": "logs"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/metricsaslogsconnector",
         "fields": {
@@ -474,10 +444,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"
       },
       "roundrobin": {
@@ -501,10 +467,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
       },
       "routing": {
@@ -527,10 +489,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -602,10 +560,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "fields": {
@@ -715,9 +669,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector",
         "alias": "signaltometrics"
       },
@@ -747,9 +698,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector",
         "deprecated": "renamed to \"signal_to_metrics\" upstream; the old name still resolves for now",
         "aliasOf": "signal_to_metrics"
@@ -764,9 +712,6 @@
             "from": "traces",
             "to": "logs"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector",
         "fields": {
@@ -817,9 +762,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector",
         "fields": {
@@ -1038,9 +980,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector",
         "fields": {
           "type": "map",
@@ -1079,9 +1018,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter",
         "fields": {
           "type": "map",
@@ -1437,9 +1373,6 @@
           "metrics": "unmaintained",
           "traces": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -1483,9 +1416,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter",
         "fields": {
           "type": "map",
@@ -1688,9 +1618,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter",
         "fields": {
           "type": "map",
@@ -1910,9 +1837,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter",
         "fields": {
           "type": "map",
@@ -2099,9 +2023,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter",
         "fields": {
           "type": "map",
@@ -2297,9 +2218,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter",
         "fields": {
           "type": "map",
@@ -2421,9 +2339,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter",
         "alias": "azureblob",
         "fields": {
@@ -2618,9 +2533,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter",
         "deprecated": "renamed to \"azure_blob\" upstream; the old name still resolves for now",
         "aliasOf": "azure_blob",
@@ -2816,9 +2728,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter",
         "fields": {
           "type": "map",
@@ -3007,9 +2916,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter",
         "fields": {
           "type": "map",
@@ -3337,9 +3243,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter",
         "fields": {
           "type": "map",
@@ -3607,9 +3510,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter",
         "fields": {
           "type": "map",
@@ -3678,9 +3578,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter",
         "fields": {
           "type": "map",
@@ -4043,9 +3940,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter",
         "fields": {
           "type": "map",
@@ -5239,9 +5133,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
       },
       "dataset": {
@@ -5254,9 +5145,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter",
         "fields": {
           "type": "map",
@@ -5569,11 +5457,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -5613,9 +5496,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter",
         "fields": {
           "type": "map",
@@ -6044,9 +5924,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter",
         "fields": {
           "type": "map",
@@ -6590,9 +6467,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter",
         "fields": {
           "type": "map",
@@ -6930,11 +6804,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -7026,9 +6895,6 @@
           "logs": "alpha",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter",
         "alias": "googlecloudstorage",
         "fields": {
@@ -7092,9 +6958,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlesecopsexporter",
         "fields": {
           "type": "map",
@@ -7196,9 +7059,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter",
         "fields": {
           "type": "map",
@@ -7297,9 +7157,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter",
         "fields": {
           "type": "map",
@@ -7547,9 +7404,6 @@
           "logs": "alpha",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter",
         "deprecated": "renamed to \"google_cloud_storage\" upstream; the old name still resolves for now",
         "aliasOf": "google_cloud_storage",
@@ -7614,9 +7468,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter",
         "fields": {
           "type": "map",
@@ -7739,9 +7590,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter",
         "fields": {
           "type": "map",
@@ -8144,9 +7992,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter",
         "fields": {
           "type": "map",
@@ -8569,10 +8414,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -9240,10 +9081,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "fields": {
           "type": "map",
@@ -9714,9 +9551,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter",
         "fields": {
           "type": "map",
@@ -10104,9 +9938,6 @@
           "logs": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter",
         "fields": {
           "type": "map",
@@ -10474,9 +10305,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter",
         "fields": {
           "type": "map",
@@ -10839,11 +10667,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "opensearch": {
@@ -10856,9 +10679,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter",
         "fields": {
           "type": "map",
@@ -11454,10 +11274,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -11833,12 +11649,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "deprecated": "renamed to \"otlp_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_grpc",
@@ -12041,12 +11851,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "alias": "otlp",
         "fields": {
@@ -12287,12 +12091,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "alias": "otlphttp",
         "fields": {
@@ -12564,12 +12362,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "deprecated": "renamed to \"otlp_http\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_http",
@@ -12836,10 +12628,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -13203,10 +12991,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -13579,9 +13363,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter",
         "fields": {
           "type": "map",
@@ -13870,9 +13651,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter",
         "fields": {
           "type": "map",
@@ -14072,9 +13850,6 @@
           "logs": "development",
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter",
         "fields": {
           "type": "map",
@@ -14463,9 +14238,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter",
         "fields": {
           "type": "map",
@@ -14959,9 +14731,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter",
         "fields": {
           "type": "map",
@@ -15931,9 +15700,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter",
         "fields": {
           "type": "map",
@@ -16442,9 +16208,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter",
         "fields": {
           "type": "map",
@@ -16757,9 +16520,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter",
         "fields": {
           "type": "map",
@@ -17140,9 +16900,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter",
         "fields": {
           "type": "map",
@@ -17399,9 +17156,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -17442,9 +17196,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter",
         "fields": {
           "type": "map",
@@ -17837,10 +17588,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -18194,10 +17941,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -18224,9 +17967,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension",
         "fields": {
           "type": "map",
@@ -18260,9 +18000,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension",
         "fields": {
           "type": "map",
@@ -18278,9 +18015,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension",
         "alias": "awslogs_encoding",
         "fields": {
@@ -18319,9 +18053,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension",
         "fields": {
           "type": "map",
@@ -18337,9 +18068,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension",
         "deprecated": "renamed to \"aws_logs_encoding\" upstream; the old name still resolves for now",
         "aliasOf": "aws_logs_encoding",
@@ -18379,9 +18107,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy",
         "fields": {
           "type": "map",
@@ -18528,9 +18253,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension",
         "alias": "azureauth",
         "fields": {
@@ -18595,9 +18317,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension",
         "fields": {
           "type": "map",
@@ -18673,9 +18392,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension",
         "deprecated": "renamed to \"azure_auth\" upstream; the old name still resolves for now",
         "aliasOf": "azure_auth",
@@ -18741,10 +18457,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -18793,10 +18505,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -18836,9 +18544,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver",
         "fields": {
           "type": "map",
@@ -18902,9 +18607,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension",
         "alias": "cgroupruntime",
         "fields": {
@@ -18937,9 +18639,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension",
         "deprecated": "renamed to \"cgroup_runtime\" upstream; the old name still resolves for now",
         "aliasOf": "cgroup_runtime",
@@ -18973,9 +18672,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension",
         "fields": {
           "type": "map",
@@ -19420,9 +19116,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage",
         "fields": {
           "type": "map",
@@ -19441,9 +19134,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver",
         "fields": {
           "type": "map",
@@ -19565,9 +19255,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver",
         "fields": {
           "type": "map",
@@ -19688,10 +19375,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -19751,9 +19434,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension",
         "alias": "googlecloudlogentry_encoding",
         "fields": {
@@ -19773,9 +19453,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension"
       },
       "googlecloudlogentry_encoding": {
@@ -19783,9 +19460,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension",
         "deprecated": "renamed to \"google_cloud_logentry_encoding\" upstream; the old name still resolves for now",
         "aliasOf": "google_cloud_logentry_encoding",
@@ -19806,10 +19480,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -19859,11 +19529,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -20467,9 +20132,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension",
         "fields": {
           "type": "map",
@@ -21073,10 +20735,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -21092,10 +20750,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -21558,9 +21212,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension",
         "fields": {
           "type": "map",
@@ -21576,9 +21227,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling",
         "fields": {
           "type": "map",
@@ -22230,9 +21878,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension",
         "fields": {
           "type": "map",
@@ -22251,10 +21896,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector",
         "fields": {
           "type": "map",
@@ -22299,10 +21940,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -22350,9 +21987,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver",
         "fields": {
           "type": "map",
@@ -22647,10 +22281,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -22834,10 +22464,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -22918,10 +22544,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -23215,9 +22837,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension",
         "fields": {
           "type": "map",
@@ -23233,11 +22852,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -23277,9 +22891,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension",
         "fields": {
           "type": "map",
@@ -23384,9 +22995,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension",
         "fields": {
           "type": "map",
@@ -23626,9 +23234,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension",
         "fields": {
           "type": "map",
@@ -23669,9 +23274,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension"
       },
       "solarwindsapmsettings": {
@@ -23679,9 +23281,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension",
         "fields": {
           "type": "map",
@@ -23703,9 +23302,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension",
         "fields": {
           "type": "map",
@@ -24008,9 +23604,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension",
         "fields": {
           "type": "map",
@@ -24032,9 +23625,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension",
         "fields": {
           "type": "map",
@@ -24053,11 +23643,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -24260,11 +23845,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -24637,11 +24217,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -24682,9 +24257,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor",
         "fields": {
           "type": "map",
@@ -24712,10 +24284,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "fields": {
           "type": "map",
@@ -24820,10 +24388,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -24845,10 +24409,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -24878,9 +24438,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor"
       },
       "filter": {
@@ -24897,11 +24454,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -25756,9 +25308,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor",
         "fields": {
           "type": "map",
@@ -25793,10 +25342,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -25822,10 +25367,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -25862,10 +25403,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -25904,9 +25441,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/isolationforestprocessor",
         "fields": {
           "type": "map",
@@ -26068,10 +25602,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "alias": "k8sattributes",
         "fields": {
@@ -26319,10 +25849,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "deprecated": "renamed to \"k8s_attributes\" upstream; the old name still resolves for now",
         "aliasOf": "k8s_attributes",
@@ -26565,10 +26091,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "fields": {
           "type": "map",
@@ -26618,9 +26140,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor",
         "fields": {
           "type": "map",
@@ -26672,9 +26191,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor",
         "fields": {
           "type": "map",
@@ -26759,11 +26275,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -26802,9 +26313,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor",
         "alias": "metricstarttime",
         "fields": {
@@ -26833,9 +26341,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor",
         "fields": {
           "type": "map",
@@ -26891,9 +26396,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor",
         "deprecated": "renamed to \"metric_start_time\" upstream; the old name still resolves for now",
         "aliasOf": "metric_start_time",
@@ -26923,10 +26425,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "fields": {
           "type": "map",
@@ -27066,11 +26564,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -27122,10 +26615,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -27369,10 +26858,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -27626,11 +27111,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -27699,10 +27179,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "fields": {
           "type": "map",
@@ -30138,9 +29614,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor",
         "fields": {
           "type": "map",
@@ -30386,10 +29859,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -30768,9 +30237,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor",
         "fields": {
           "type": "map",
@@ -30807,9 +30273,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor",
         "fields": {
           "type": "map",
@@ -30937,10 +30400,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -32386,10 +31845,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -32545,9 +32000,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor",
         "fields": {
           "type": "map",
@@ -32569,9 +32021,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver",
         "fields": {
           "type": "map",
@@ -32930,9 +32379,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver",
         "fields": {
           "type": "map",
@@ -33424,9 +32870,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver",
         "fields": {
           "type": "map",
@@ -33962,9 +33405,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver",
         "fields": {
           "type": "map",
@@ -35462,9 +34902,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver",
         "fields": {
           "type": "map",
@@ -35567,9 +35004,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver",
         "fields": {
           "type": "map",
@@ -35606,9 +35040,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver",
         "fields": {
           "type": "map",
@@ -35631,9 +35062,6 @@
           "logs": "alpha",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver",
         "fields": {
           "type": "map",
@@ -35890,9 +35318,6 @@
           "logs": "alpha",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver",
         "fields": {
           "type": "map",
@@ -35936,9 +35361,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver",
         "fields": {
           "type": "map",
@@ -36054,9 +35476,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver",
         "fields": {
           "type": "map",
@@ -36232,9 +35651,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver",
         "alias": "azureblob",
         "fields": {
@@ -36319,9 +35735,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver",
         "alias": "azureeventhub",
         "fields": {
@@ -36435,9 +35848,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azurefunctionsreceiver",
         "fields": {
           "type": "map",
@@ -36705,9 +36115,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver",
         "alias": "azuremonitor",
         "fields": {
@@ -36861,9 +36268,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver",
         "deprecated": "renamed to \"azure_blob\" upstream; the old name still resolves for now",
         "aliasOf": "azure_blob",
@@ -36949,9 +36353,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver",
         "deprecated": "renamed to \"azure_event_hub\" upstream; the old name still resolves for now",
         "aliasOf": "azure_event_hub",
@@ -37066,9 +36467,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver",
         "deprecated": "renamed to \"azure_monitor\" upstream; the old name still resolves for now",
         "aliasOf": "azure_monitor",
@@ -37221,9 +36619,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver",
         "fields": {
           "type": "map",
@@ -37275,9 +36670,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver",
         "fields": {
           "type": "map",
@@ -37379,9 +36771,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver",
         "alias": "ciscoos",
         "fields": {
@@ -37448,9 +36837,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver",
         "deprecated": "renamed to \"cisco_os\" upstream; the old name still resolves for now",
         "aliasOf": "cisco_os",
@@ -37518,9 +36904,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver",
         "fields": {
           "type": "map",
@@ -37658,9 +37041,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver",
         "fields": {
           "type": "map",
@@ -37922,9 +37302,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver",
         "fields": {
           "type": "map",
@@ -38176,9 +37553,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver",
         "fields": {
           "type": "map",
@@ -38554,9 +37928,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver",
         "fields": {
           "type": "map",
@@ -38837,9 +38208,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver",
         "fields": {
           "type": "map",
@@ -40316,9 +39684,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver",
         "fields": {
           "type": "map",
@@ -42573,9 +41938,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver",
         "fields": {
           "type": "map",
@@ -42788,9 +42150,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver",
         "fields": {
           "type": "map",
@@ -43268,9 +42627,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver",
         "fields": {
           "type": "map",
@@ -43513,10 +42869,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver",
         "alias": "filelog",
         "fields": {
@@ -43754,10 +43106,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver",
         "deprecated": "renamed to \"file_log\" upstream; the old name still resolves for now",
         "aliasOf": "file_log",
@@ -43996,9 +43344,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver",
         "fields": {
           "type": "map",
@@ -44197,9 +43542,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver",
         "fields": {
           "type": "map",
@@ -45019,10 +44361,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "fields": {
           "type": "map",
@@ -45045,9 +44383,6 @@
           "metrics": "alpha",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver",
         "fields": {
           "type": "map",
@@ -45738,9 +45073,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver",
         "fields": {
           "type": "map",
@@ -46014,9 +45346,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver",
         "fields": {
           "type": "map",
@@ -46069,9 +45398,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver",
         "fields": {
           "type": "map",
@@ -46150,9 +45476,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver",
         "fields": {
           "type": "map",
@@ -46400,9 +45723,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver",
         "fields": {
           "type": "map",
@@ -46483,9 +45803,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver",
         "fields": {
           "type": "map",
@@ -47232,11 +46549,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -47273,10 +46585,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "alias": "httpcheck",
         "fields": {
@@ -47694,10 +47002,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "deprecated": "renamed to \"http_check\" upstream; the old name still resolves for now",
         "aliasOf": "http_check",
@@ -48116,9 +47420,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver",
         "fields": {
           "type": "map",
@@ -48444,9 +47745,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver",
         "fields": {
           "type": "map",
@@ -48644,9 +47942,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver",
         "fields": {
           "type": "map",
@@ -48963,9 +48258,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver",
         "fields": {
           "type": "map",
@@ -49208,11 +48500,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -50280,9 +49567,6 @@
         "stability": {
           "metrics": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver",
         "deprecated": "use JMX Gatherer Java program",
         "fields": {
@@ -50409,10 +49693,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver",
         "fields": {
           "type": "map",
@@ -50547,10 +49827,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -53109,10 +52385,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -53158,10 +52430,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "fields": {
           "type": "map",
@@ -53275,10 +52543,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -53883,9 +53147,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver",
         "fields": {
           "type": "map",
@@ -54786,10 +54047,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "fields": {
           "type": "map",
@@ -56196,9 +55453,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver",
         "fields": {
           "type": "map",
@@ -56521,9 +55775,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver",
         "fields": {
           "type": "map",
@@ -57313,9 +56564,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver",
         "alias": "macosunifiedlogging",
         "fields": {
@@ -57361,9 +56609,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver",
         "deprecated": "renamed to \"macos_unified_logging\" upstream; the old name still resolves for now",
         "aliasOf": "macos_unified_logging",
@@ -57410,9 +56655,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver",
         "fields": {
           "type": "map",
@@ -57564,9 +56806,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver",
         "fields": {
           "type": "map",
@@ -58796,9 +58035,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver",
         "alias": "mongodbatlas",
         "fields": {
@@ -60364,9 +59600,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver",
         "deprecated": "renamed to \"mongodb_atlas\" upstream; the old name still resolves for now",
         "aliasOf": "mongodb_atlas",
@@ -61933,9 +61166,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver",
         "fields": {
           "type": "map",
@@ -63451,9 +62681,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver",
         "alias": "namedpipe",
         "fields": {
@@ -63557,9 +62784,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver",
         "deprecated": "renamed to \"named_pipe\" upstream; the old name still resolves for now",
         "aliasOf": "named_pipe",
@@ -63664,9 +62888,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver",
         "fields": {
           "type": "map",
@@ -63711,9 +62932,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
         "fields": {
           "type": "map",
@@ -63997,10 +63215,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "nsxt": {
@@ -64011,9 +63225,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver",
         "fields": {
           "type": "map",
@@ -64511,9 +63722,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver",
         "fields": {
           "type": "map",
@@ -64616,9 +63824,6 @@
           "logs": "development",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver",
         "fields": {
           "type": "map",
@@ -65411,9 +64616,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver",
         "fields": {
           "type": "map",
@@ -65457,10 +64659,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -65933,12 +65131,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -66221,9 +65413,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver",
         "fields": {
           "type": "map",
@@ -66417,9 +65606,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver",
         "fields": {
           "type": "map",
@@ -66775,9 +65961,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
         "fields": {
           "type": "map",
@@ -68077,9 +67260,6 @@
         "stability": {
           "profiles": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver",
         "fields": {
           "type": "map",
@@ -68327,11 +67507,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -68822,9 +67997,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver",
         "alias": "prometheusremotewrite",
         "fields": {
@@ -69068,9 +68240,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver",
         "fields": {
           "type": "map",
@@ -69349,9 +68518,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver",
         "deprecated": "renamed to \"prometheus_remote_write\" upstream; the old name still resolves for now",
         "aliasOf": "prometheus_remote_write",
@@ -69600,9 +68766,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver",
         "fields": {
           "type": "map",
@@ -69718,9 +68881,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver",
         "fields": {
           "type": "map",
@@ -70111,9 +69271,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver",
         "fields": {
           "type": "map",
@@ -70440,9 +69597,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver",
         "fields": {
           "type": "map",
@@ -71578,10 +70732,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -71632,9 +70782,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redfishreceiver",
         "fields": {
           "type": "map",
@@ -71918,9 +71065,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver",
         "fields": {
           "type": "map",
@@ -72940,9 +72084,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver",
         "fields": {
           "type": "map",
@@ -73382,9 +72523,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver",
         "fields": {
           "type": "map",
@@ -74109,9 +73247,6 @@
           "logs": "deprecated",
           "metrics": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver",
         "deprecated": "Use the OTLP receiver instead. This component will be removed in a future release.",
         "fields": {
@@ -74357,9 +73492,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver",
         "fields": {
           "type": "map",
@@ -75146,9 +74278,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver",
         "fields": {
           "type": "map",
@@ -75228,9 +74357,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver",
         "fields": {
           "type": "map",
@@ -76409,9 +75535,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver",
         "fields": {
           "type": "map",
@@ -76592,9 +75715,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver",
         "fields": {
           "type": "map",
@@ -76895,9 +76015,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver",
         "fields": {
           "type": "map",
@@ -79236,9 +78353,6 @@
           "logs": "development",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver",
         "fields": {
           "type": "map",
@@ -79420,9 +78534,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver",
         "fields": {
           "type": "map",
@@ -80795,9 +79906,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver",
         "fields": {
           "type": "map",
@@ -80962,9 +80070,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver",
         "fields": {
           "type": "map",
@@ -81081,9 +80186,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver",
         "fields": {
           "type": "map",
@@ -81299,9 +80401,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver",
         "fields": {
           "type": "map",
@@ -81578,9 +80677,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver",
         "fields": {
           "type": "map",
@@ -81744,9 +80840,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver",
         "alias": "tcplog",
         "fields": {
@@ -81944,9 +81037,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver",
         "fields": {
           "type": "map",
@@ -82033,9 +81123,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver",
         "deprecated": "renamed to \"tcp_log\" upstream; the old name still resolves for now",
         "aliasOf": "tcp_log",
@@ -82234,9 +81321,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver",
         "alias": "tlscheck",
         "fields": {
@@ -82368,9 +81452,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver",
         "deprecated": "renamed to \"tls_check\" upstream; the old name still resolves for now",
         "aliasOf": "tls_check",
@@ -82503,9 +81584,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver",
         "alias": "udplog",
         "fields": {
@@ -82623,9 +81701,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver",
         "deprecated": "renamed to \"udp_log\" upstream; the old name still resolves for now",
         "aliasOf": "udp_log",
@@ -82744,9 +81819,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver",
         "fields": {
           "type": "map",
@@ -84925,9 +83997,6 @@
           "profiles": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcrreceiver",
         "fields": {
           "type": "map",
@@ -84967,9 +84036,6 @@
         "stability": {
           "metrics": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver",
         "deprecated": "There is no replacement. This component will be removed in a future release.",
         "fields": {
@@ -85009,9 +84075,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver",
         "fields": {
           "type": "map",
@@ -85281,9 +84344,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver",
         "alias": "windowseventlog",
         "fields": {
@@ -85440,9 +84500,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver",
         "deprecated": "renamed to \"windows_event_log\" upstream; the old name still resolves for now",
         "aliasOf": "windows_event_log",
@@ -85600,9 +84657,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver",
         "fields": {
           "type": "map",
@@ -85681,9 +84735,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver",
         "fields": {
           "type": "map",
@@ -85743,9 +84794,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver",
         "alias": "yanggrpc",
         "fields": {
@@ -86031,9 +85079,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver",
         "deprecated": "renamed to \"yang_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "yang_grpc",
@@ -86320,11 +85365,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",
@@ -86571,9 +85611,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver",
         "fields": {
           "type": "map",

--- a/schemas/contrib/v0.150.0.yaml
+++ b/schemas/contrib/v0.150.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.150.0
 distribution: contrib
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:39Z"
+generatedAt: "2026-08-02T13:15:53Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,9 +22,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -61,8 +55,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
       fields:
         type: map
@@ -128,9 +120,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -167,9 +156,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -263,10 +249,6 @@ components:
           to: profiles
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     grafanacloud:
       type: grafanacloud
@@ -275,8 +257,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector
       fields:
         type: map
@@ -297,8 +277,6 @@ components:
       pairs:
         - from: metrics
           to: logs
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/metricsaslogsconnector
       fields:
         type: map
@@ -320,9 +298,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
     roundrobin:
       type: roundrobin
@@ -337,9 +312,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
     routing:
       type: routing
@@ -354,9 +326,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -406,9 +375,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       fields:
         type: map
@@ -482,8 +448,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
       alias: signaltometrics
     signaltometrics:
@@ -502,8 +466,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
       deprecated: renamed to "signal_to_metrics" upstream; the old name still resolves for now
       aliasOf: signal_to_metrics
@@ -514,8 +476,6 @@ components:
       pairs:
         - from: traces
           to: logs
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector
       fields:
         type: map
@@ -549,8 +509,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
       fields:
         type: map
@@ -695,8 +653,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector
       fields:
         type: map
@@ -724,8 +680,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter
       fields:
         type: map
@@ -982,8 +936,6 @@ components:
         logs: unmaintained
         metrics: unmaintained
         traces: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
       fields:
         type: map
@@ -1015,8 +967,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
       fields:
         type: map
@@ -1164,8 +1114,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
       fields:
         type: map
@@ -1323,8 +1271,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
       fields:
         type: map
@@ -1457,8 +1403,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter
       fields:
         type: map
@@ -1601,8 +1545,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
       fields:
         type: map
@@ -1691,8 +1633,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter
       alias: azureblob
       fields:
@@ -1829,8 +1769,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter
       deprecated: renamed to "azure_blob" upstream; the old name still resolves for now
       aliasOf: azure_blob
@@ -1968,8 +1906,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter
       fields:
         type: map
@@ -2104,8 +2040,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
       fields:
         type: map
@@ -2341,8 +2275,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter
       fields:
         type: map
@@ -2536,8 +2468,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter
       fields:
         type: map
@@ -2584,8 +2514,6 @@ components:
         logs: beta
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter
       fields:
         type: map
@@ -2846,8 +2774,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
       fields:
         type: map
@@ -3697,8 +3623,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
     dataset:
       type: dataset
@@ -3708,8 +3632,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter
       fields:
         type: map
@@ -3928,10 +3850,6 @@ components:
         metrics: alpha
         profiles: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -3961,8 +3879,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter
       fields:
         type: map
@@ -4273,8 +4189,6 @@ components:
         metrics: development
         profiles: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
       fields:
         type: map
@@ -4660,8 +4574,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter
       fields:
         type: map
@@ -4907,10 +4819,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -4978,8 +4886,6 @@ components:
       stability:
         logs: alpha
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter
       alias: googlecloudstorage
       fields:
@@ -5025,8 +4931,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlesecopsexporter
       fields:
         type: map
@@ -5095,8 +4999,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
       fields:
         type: map
@@ -5169,8 +5071,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
       fields:
         type: map
@@ -5351,8 +5251,6 @@ components:
       stability:
         logs: alpha
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter
       deprecated: renamed to "google_cloud_storage" upstream; the old name still resolves for now
       aliasOf: google_cloud_storage
@@ -5399,8 +5297,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
       fields:
         type: map
@@ -5488,8 +5384,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
       fields:
         type: map
@@ -5779,8 +5673,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
       fields:
         type: map
@@ -6086,9 +5978,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -6566,9 +6455,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       fields:
         type: map
@@ -6887,8 +6773,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter
       fields:
         type: map
@@ -7167,8 +7051,6 @@ components:
       stability:
         logs: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
       fields:
         type: map
@@ -7432,8 +7314,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter
       fields:
         type: map
@@ -7696,10 +7576,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     opensearch:
       type: opensearch
@@ -7709,8 +7585,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter
       fields:
         type: map
@@ -8128,9 +8002,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -8402,11 +8273,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       deprecated: renamed to "otlp_grpc" upstream; the old name still resolves for now
       aliasOf: otlp_grpc
@@ -8548,11 +8414,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       alias: otlp
       fields:
@@ -8713,11 +8574,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       alias: otlphttp
       fields:
@@ -8899,11 +8755,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       deprecated: renamed to "otlp_http" upstream; the old name still resolves for now
       aliasOf: otlp_http
@@ -9080,9 +8931,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -9342,9 +9190,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -9613,8 +9458,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
       fields:
         type: map
@@ -9816,8 +9659,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter
       fields:
         type: map
@@ -9957,8 +9798,6 @@ components:
       stability:
         logs: development
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter
       fields:
         type: map
@@ -10237,8 +10076,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
       fields:
         type: map
@@ -10585,8 +10422,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
       fields:
         type: map
@@ -11283,8 +11118,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
       fields:
         type: map
@@ -11652,8 +11485,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter
       fields:
         type: map
@@ -11879,8 +11710,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
       fields:
         type: map
@@ -12155,8 +11984,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter
       fields:
         type: map
@@ -12341,8 +12168,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
       fields:
         type: map
@@ -12373,8 +12198,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter
       fields:
         type: map
@@ -12653,9 +12476,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -12909,9 +12729,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -12931,8 +12748,6 @@ components:
       type: asapclient
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
       fields:
         type: map
@@ -12955,8 +12770,6 @@ components:
       type: avro_log_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension
       fields:
         type: map
@@ -12967,8 +12780,6 @@ components:
       type: aws_logs_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
       alias: awslogs_encoding
       fields:
@@ -12994,8 +12805,6 @@ components:
       type: awscloudwatchmetricstreams_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension
       fields:
         type: map
@@ -13006,8 +12815,6 @@ components:
       type: awslogs_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
       deprecated: renamed to "aws_logs_encoding" upstream; the old name still resolves for now
       aliasOf: aws_logs_encoding
@@ -13034,8 +12841,6 @@ components:
       type: awsproxy
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
       fields:
         type: map
@@ -13141,8 +12946,6 @@ components:
       type: azure_auth
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension
       alias: azureauth
       fields:
@@ -13185,8 +12988,6 @@ components:
       type: azure_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
       fields:
         type: map
@@ -13234,8 +13035,6 @@ components:
       type: azureauth
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension
       deprecated: renamed to "azure_auth" upstream; the old name still resolves for now
       aliasOf: azure_auth
@@ -13279,9 +13078,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -13316,9 +13112,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -13347,8 +13140,6 @@ components:
       type: cfgarden_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver
       fields:
         type: map
@@ -13390,8 +13181,6 @@ components:
       type: cgroup_runtime
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension
       alias: cgroupruntime
       fields:
@@ -13413,8 +13202,6 @@ components:
       type: cgroupruntime
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension
       deprecated: renamed to "cgroup_runtime" upstream; the old name still resolves for now
       aliasOf: cgroup_runtime
@@ -13437,8 +13224,6 @@ components:
       type: datadog
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension
       fields:
         type: map
@@ -13746,8 +13531,6 @@ components:
       type: db_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
       fields:
         type: map
@@ -13760,8 +13543,6 @@ components:
       type: docker_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
       fields:
         type: map
@@ -13841,8 +13622,6 @@ components:
       type: ecs_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
       fields:
         type: map
@@ -13920,9 +13699,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -13962,8 +13738,6 @@ components:
       type: google_cloud_logentry_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
       alias: googlecloudlogentry_encoding
       fields:
@@ -13977,15 +13751,11 @@ components:
       type: googleclientauth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension
     googlecloudlogentry_encoding:
       type: googlecloudlogentry_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
       deprecated: renamed to "google_cloud_logentry_encoding" upstream; the old name still resolves for now
       aliasOf: google_cloud_logentry_encoding
@@ -14000,9 +13770,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -14036,10 +13803,6 @@ components:
       type: health_check
       stability:
         extension: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -14430,8 +14193,6 @@ components:
       type: healthcheckv2
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension
       fields:
         type: map
@@ -14822,9 +14583,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -14835,9 +14593,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -15166,8 +14921,6 @@ components:
       type: jaeger_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension
       fields:
         type: map
@@ -15178,8 +14931,6 @@ components:
       type: jaegerremotesampling
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
       fields:
         type: map
@@ -15640,8 +15391,6 @@ components:
       type: json_log_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension
       fields:
         type: map
@@ -15654,9 +15403,6 @@ components:
       type: k8s_leader_elector
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
       fields:
         type: map
@@ -15688,9 +15434,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -15722,8 +15465,6 @@ components:
       type: kafkatopics_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver
       fields:
         type: map
@@ -15915,9 +15656,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -16051,9 +15789,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -16112,9 +15847,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -16324,8 +16056,6 @@ components:
       type: otlp_encoding
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension
       fields:
         type: map
@@ -16336,10 +16066,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -16368,8 +16094,6 @@ components:
       type: redis_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension
       fields:
         type: map
@@ -16438,8 +16162,6 @@ components:
       type: remotetap
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension
       fields:
         type: map
@@ -16608,8 +16330,6 @@ components:
       type: sigv4auth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension
       fields:
         type: map
@@ -16637,15 +16357,11 @@ components:
       type: skywalking_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension
     solarwindsapmsettings:
       type: solarwindsapmsettings
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension
       fields:
         type: map
@@ -16660,8 +16376,6 @@ components:
       type: sumologic
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension
       fields:
         type: map
@@ -16880,8 +16594,6 @@ components:
       type: text_encoding
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension
       fields:
         type: map
@@ -16896,8 +16608,6 @@ components:
       type: zipkin_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension
       fields:
         type: map
@@ -16910,10 +16620,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -17046,10 +16752,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -17311,10 +17013,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -17343,8 +17041,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor
       fields:
         type: map
@@ -17363,9 +17059,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       fields:
         type: map
@@ -17437,9 +17130,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -17454,9 +17144,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -17478,8 +17165,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor
     filter:
       type: filter
@@ -17493,10 +17178,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -18083,8 +17764,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor
       fields:
         type: map
@@ -18110,9 +17789,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -18130,9 +17806,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -18159,9 +17832,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -18190,8 +17860,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/isolationforestprocessor
       fields:
         type: map
@@ -18300,9 +17968,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       alias: k8sattributes
       fields:
@@ -18479,9 +18144,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       deprecated: renamed to "k8s_attributes" upstream; the old name still resolves for now
       aliasOf: k8s_attributes
@@ -18653,9 +18315,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       fields:
         type: map
@@ -18688,8 +18347,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor
       fields:
         type: map
@@ -18726,8 +18383,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor
       fields:
         type: map
@@ -18789,10 +18444,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -18820,8 +18471,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor
       alias: metricstarttime
       fields:
@@ -18842,8 +18491,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
       fields:
         type: map
@@ -18883,8 +18530,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor
       deprecated: renamed to "metric_start_time" upstream; the old name still resolves for now
       aliasOf: metric_start_time
@@ -18906,9 +18551,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       fields:
         type: map
@@ -19008,10 +18650,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -19050,9 +18688,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -19216,9 +18851,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -19399,10 +19031,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -19454,9 +19082,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       fields:
         type: map
@@ -21012,8 +20637,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor
       fields:
         type: map
@@ -21189,9 +20812,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -21454,8 +21074,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor
       fields:
         type: map
@@ -21481,8 +21099,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor
       fields:
         type: map
@@ -21564,9 +21180,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -22579,9 +22192,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -22682,8 +22292,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor
       fields:
         type: map
@@ -22698,8 +22306,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver
       fields:
         type: map
@@ -22946,8 +22552,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
       fields:
         type: map
@@ -23287,8 +22891,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
       fields:
         type: map
@@ -23661,8 +23263,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
       fields:
         type: map
@@ -24688,8 +24288,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver
       fields:
         type: map
@@ -24758,8 +24356,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
       fields:
         type: map
@@ -24786,8 +24382,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
       fields:
         type: map
@@ -24804,8 +24398,6 @@ components:
       stability:
         logs: alpha
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver
       fields:
         type: map
@@ -24987,8 +24579,6 @@ components:
       stability:
         logs: alpha
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver
       fields:
         type: map
@@ -25020,8 +24610,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver
       fields:
         type: map
@@ -25101,8 +24689,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
       fields:
         type: map
@@ -25229,8 +24815,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
       alias: azureblob
       fields:
@@ -25292,8 +24876,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
       alias: azureeventhub
       fields:
@@ -25371,8 +24953,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azurefunctionsreceiver
       fields:
         type: map
@@ -25561,8 +25141,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
       alias: azuremonitor
       fields:
@@ -25666,8 +25244,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
       deprecated: renamed to "azure_blob" upstream; the old name still resolves for now
       aliasOf: azure_blob
@@ -25730,8 +25306,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
       deprecated: renamed to "azure_event_hub" upstream; the old name still resolves for now
       aliasOf: azure_event_hub
@@ -25810,8 +25384,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
       deprecated: renamed to "azure_monitor" upstream; the old name still resolves for now
       aliasOf: azure_monitor
@@ -25914,8 +25486,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
       fields:
         type: map
@@ -25952,8 +25522,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver
       fields:
         type: map
@@ -26023,8 +25591,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver
       alias: ciscoos
       fields:
@@ -26071,8 +25637,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver
       deprecated: renamed to "cisco_os" upstream; the old name still resolves for now
       aliasOf: cisco_os
@@ -26120,8 +25684,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
       fields:
         type: map
@@ -26219,8 +25781,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
       fields:
         type: map
@@ -26407,8 +25967,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
       fields:
         type: map
@@ -26585,8 +26143,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
       fields:
         type: map
@@ -26851,8 +26407,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
       fields:
         type: map
@@ -27050,8 +26604,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
       fields:
         type: map
@@ -28061,8 +27613,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
       fields:
         type: map
@@ -29614,8 +29164,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver
       fields:
         type: map
@@ -29766,8 +29314,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver
       fields:
         type: map
@@ -30099,8 +29645,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver
       fields:
         type: map
@@ -30271,9 +29815,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
       alias: filelog
       fields:
@@ -30433,9 +29974,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
       deprecated: renamed to "file_log" upstream; the old name still resolves for now
       aliasOf: file_log
@@ -30596,8 +30134,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
       fields:
         type: map
@@ -30732,8 +30268,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
       fields:
         type: map
@@ -31294,9 +30828,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       fields:
         type: map
@@ -31313,8 +30844,6 @@ components:
       stability:
         metrics: alpha
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver
       fields:
         type: map
@@ -31801,8 +31330,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver
       fields:
         type: map
@@ -31995,8 +31522,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
       fields:
         type: map
@@ -32034,8 +31559,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
       fields:
         type: map
@@ -32093,8 +31616,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver
       fields:
         type: map
@@ -32269,8 +31790,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
       fields:
         type: map
@@ -32324,8 +31843,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
       fields:
         type: map
@@ -32837,10 +32354,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -32867,9 +32380,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       alias: httpcheck
       fields:
@@ -33161,9 +32671,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       deprecated: renamed to "http_check" upstream; the old name still resolves for now
       aliasOf: http_check
@@ -33456,8 +32963,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver
       fields:
         type: map
@@ -33692,8 +33197,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver
       fields:
         type: map
@@ -33826,8 +33329,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
       fields:
         type: map
@@ -34042,8 +33543,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
       fields:
         type: map
@@ -34214,10 +33713,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -34946,8 +34441,6 @@ components:
         - metrics
       stability:
         metrics: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
       deprecated: use JMX Gatherer Java program
       fields:
@@ -35041,9 +34534,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
       fields:
         type: map
@@ -35135,9 +34625,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -36847,9 +36334,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -36882,9 +36366,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       fields:
         type: map
@@ -36963,9 +36444,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -37392,8 +36870,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
       fields:
         type: map
@@ -38025,9 +37501,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       fields:
         type: map
@@ -38975,8 +38448,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver
       fields:
         type: map
@@ -39200,8 +38671,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver
       fields:
         type: map
@@ -39737,8 +39206,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver
       alias: macosunifiedlogging
       fields:
@@ -39772,8 +39239,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver
       deprecated: renamed to "macos_unified_logging" upstream; the old name still resolves for now
       aliasOf: macos_unified_logging
@@ -39808,8 +39273,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
       fields:
         type: map
@@ -39913,8 +39376,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
       fields:
         type: map
@@ -40758,8 +40219,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
       alias: mongodbatlas
       fields:
@@ -41806,8 +41265,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
       deprecated: renamed to "mongodb_atlas" upstream; the old name still resolves for now
       aliasOf: mongodb_atlas
@@ -42855,8 +42312,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
       fields:
         type: map
@@ -43907,8 +43362,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
       alias: namedpipe
       fields:
@@ -43980,8 +43433,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
       deprecated: renamed to "named_pipe" upstream; the old name still resolves for now
       aliasOf: named_pipe
@@ -44054,8 +43505,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver
       fields:
         type: map
@@ -44088,8 +43537,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
       fields:
         type: map
@@ -44293,9 +43740,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     nsxt:
       type: nsxt
@@ -44303,8 +43747,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
       fields:
         type: map
@@ -44649,8 +44091,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver
       fields:
         type: map
@@ -44721,8 +44161,6 @@ components:
       stability:
         logs: development
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver
       fields:
         type: map
@@ -45254,8 +44692,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver
       fields:
         type: map
@@ -45287,9 +44723,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -45613,11 +45046,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -45808,8 +45236,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
       fields:
         type: map
@@ -45938,8 +45364,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
       fields:
         type: map
@@ -46180,8 +45604,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
       fields:
         type: map
@@ -47061,8 +46483,6 @@ components:
         - profiles
       stability:
         profiles: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver
       fields:
         type: map
@@ -47241,10 +46661,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -47592,8 +47008,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
       alias: prometheusremotewrite
       fields:
@@ -47765,8 +47179,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
       fields:
         type: map
@@ -47968,8 +47380,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
       deprecated: renamed to "prometheus_remote_write" upstream; the old name still resolves for now
       aliasOf: prometheus_remote_write
@@ -48146,8 +47556,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver
       fields:
         type: map
@@ -48226,8 +47634,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver
       fields:
         type: map
@@ -48502,8 +47908,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver
       fields:
         type: map
@@ -48734,8 +48138,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
       fields:
         type: map
@@ -49508,9 +48910,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -49545,8 +48944,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redfishreceiver
       fields:
         type: map
@@ -49736,8 +49133,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
       fields:
         type: map
@@ -50432,8 +49827,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
       fields:
         type: map
@@ -50742,8 +50135,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
       fields:
         type: map
@@ -51233,8 +50624,6 @@ components:
       stability:
         logs: deprecated
         metrics: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
       deprecated: Use the OTLP receiver instead. This component will be removed in a future release.
       fields:
@@ -51408,8 +50797,6 @@ components:
       stability:
         metrics: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver
       fields:
         type: map
@@ -51943,8 +51330,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
       fields:
         type: map
@@ -52004,8 +51389,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
       fields:
         type: map
@@ -52853,8 +52236,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver
       fields:
         type: map
@@ -52982,8 +52363,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
       fields:
         type: map
@@ -53196,8 +52575,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver
       fields:
         type: map
@@ -54862,8 +54239,6 @@ components:
       stability:
         logs: development
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver
       fields:
         type: map
@@ -54985,8 +54360,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
       fields:
         type: map
@@ -55914,8 +55287,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
       fields:
         type: map
@@ -56028,8 +55399,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
       fields:
         type: map
@@ -56107,8 +55476,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver
       fields:
         type: map
@@ -56261,8 +55628,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
       fields:
         type: map
@@ -56453,8 +55818,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver
       fields:
         type: map
@@ -56566,8 +55929,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
       alias: tcplog
       fields:
@@ -56706,8 +56067,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver
       fields:
         type: map
@@ -56767,8 +56126,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
       deprecated: renamed to "tcp_log" upstream; the old name still resolves for now
       aliasOf: tcp_log
@@ -56908,8 +56265,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
       alias: tlscheck
       fields:
@@ -57000,8 +56355,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
       deprecated: renamed to "tls_check" upstream; the old name still resolves for now
       aliasOf: tls_check
@@ -57093,8 +56446,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
       alias: udplog
       fields:
@@ -57175,8 +56526,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
       deprecated: renamed to "udp_log" upstream; the old name still resolves for now
       aliasOf: udp_log
@@ -57258,8 +56607,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
       fields:
         type: map
@@ -58750,8 +58097,6 @@ components:
         metrics: development
         profiles: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcrreceiver
       fields:
         type: map
@@ -58777,8 +58122,6 @@ components:
         - metrics
       stability:
         metrics: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
       deprecated: There is no replacement. This component will be removed in a future release.
       fields:
@@ -58807,8 +58150,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver
       fields:
         type: map
@@ -58996,8 +58337,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
       alias: windowseventlog
       fields:
@@ -59106,8 +58445,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
       deprecated: renamed to "windows_event_log" upstream; the old name still resolves for now
       aliasOf: windows_event_log
@@ -59217,8 +58554,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
       fields:
         type: map
@@ -59272,8 +58607,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver
       fields:
         type: map
@@ -59314,8 +58647,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver
       alias: yanggrpc
       fields:
@@ -59518,8 +58849,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver
       deprecated: renamed to "yang_grpc" upstream; the old name still resolves for now
       aliasOf: yang_grpc
@@ -59723,10 +59052,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map
@@ -59900,8 +59225,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
       fields:
         type: map

--- a/schemas/contrib/v0.157.0.json
+++ b/schemas/contrib/v0.157.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.157.0",
   "distribution": "contrib",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:07:26Z",
+  "generatedAt": "2026-08-02T13:15:54Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -37,10 +33,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -89,9 +81,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector",
         "fields": {
@@ -187,10 +176,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
           "type": "map",
@@ -246,10 +231,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
@@ -377,11 +358,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "grafanacloud": {
@@ -394,9 +370,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector",
         "fields": {
@@ -429,9 +402,6 @@
             "to": "logs"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/metricsaslogsconnector",
         "alias": "metricsaslogs",
         "fields": {
@@ -456,9 +426,6 @@
             "from": "metrics",
             "to": "logs"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/metricsaslogsconnector",
         "deprecated": "renamed to \"metrics_as_logs\" upstream; the old name still resolves for now",
@@ -496,10 +463,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector",
         "alias": "otlpjson"
       },
@@ -523,10 +486,6 @@
             "from": "logs",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector",
         "deprecated": "renamed to \"otlp_json\" upstream; the old name still resolves for now",
@@ -553,10 +512,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector",
         "alias": "roundrobin"
       },
@@ -580,10 +535,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector",
         "deprecated": "renamed to \"round_robin\" upstream; the old name still resolves for now",
@@ -609,10 +560,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -684,10 +631,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "alias": "servicegraph",
@@ -782,10 +725,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "deprecated": "renamed to \"service_graph\" upstream; the old name still resolves for now",
@@ -897,9 +836,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector",
         "alias": "signaltometrics"
       },
@@ -929,9 +865,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector",
         "deprecated": "renamed to \"signal_to_metrics\" upstream; the old name still resolves for now",
         "aliasOf": "signal_to_metrics"
@@ -946,9 +879,6 @@
             "from": "traces",
             "to": "logs"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector",
         "alias": "slowsql",
@@ -1001,9 +931,6 @@
             "to": "logs"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector",
         "deprecated": "renamed to \"slow_sql\" upstream; the old name still resolves for now",
         "aliasOf": "slow_sql",
@@ -1055,9 +982,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector",
         "alias": "spanmetrics",
@@ -1282,9 +1206,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector",
         "deprecated": "renamed to \"span_metrics\" upstream; the old name still resolves for now",
@@ -1521,9 +1442,6 @@
             "to": "metrics"
           }
         ],
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector",
         "fields": {
           "type": "map",
@@ -1564,9 +1482,6 @@
           "logs": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter",
         "fields": {
           "type": "map",
@@ -1925,9 +1840,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -1975,9 +1887,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter",
         "fields": {
           "type": "map",
@@ -2180,9 +2089,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter",
         "fields": {
           "type": "map",
@@ -2402,9 +2308,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter",
         "fields": {
           "type": "map",
@@ -2591,9 +2494,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter",
         "fields": {
           "type": "map",
@@ -2836,9 +2736,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter",
         "fields": {
           "type": "map",
@@ -2960,9 +2857,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter",
         "alias": "azureblob",
         "fields": {
@@ -3239,9 +3133,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter",
         "deprecated": "renamed to \"azure_blob\" upstream; the old name still resolves for now",
         "aliasOf": "azure_blob",
@@ -3519,9 +3410,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter",
         "fields": {
           "type": "map",
@@ -3710,9 +3598,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter",
         "fields": {
           "type": "map",
@@ -4067,9 +3952,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter",
         "alias": "bmchelix",
         "fields": {
@@ -4339,9 +4221,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter",
         "deprecated": "renamed to \"bmc_helix\" upstream; the old name still resolves for now",
         "aliasOf": "bmc_helix",
@@ -4614,9 +4493,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter",
         "fields": {
           "type": "map",
@@ -4687,9 +4563,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter",
         "fields": {
           "type": "map",
@@ -5059,9 +4932,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter",
         "fields": {
           "type": "map",
@@ -6290,9 +6160,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
       },
       "dataset": {
@@ -6305,9 +6172,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter",
         "fields": {
           "type": "map",
@@ -6620,11 +6484,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -6664,9 +6523,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter",
         "fields": {
           "type": "map",
@@ -7098,9 +6954,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter",
         "fields": {
           "type": "map",
@@ -7660,9 +7513,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter",
         "fields": {
           "type": "map",
@@ -8003,11 +7853,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -8108,9 +7953,6 @@
           "logs": "alpha",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter",
         "alias": "googlecloudstorage",
         "fields": {
@@ -8301,9 +8143,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter",
         "fields": {
           "type": "map",
@@ -8402,9 +8241,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter",
         "fields": {
           "type": "map",
@@ -8656,9 +8492,6 @@
           "logs": "alpha",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter",
         "deprecated": "renamed to \"google_cloud_storage\" upstream; the old name still resolves for now",
         "aliasOf": "google_cloud_storage",
@@ -8846,9 +8679,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter",
         "fields": {
           "type": "map",
@@ -8971,9 +8801,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter",
         "alias": "honeycombmarker",
         "fields": {
@@ -9376,9 +9203,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter",
         "deprecated": "renamed to \"honeycomb_marker\" upstream; the old name still resolves for now",
         "aliasOf": "honeycomb_marker",
@@ -9786,9 +9610,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter",
         "fields": {
           "type": "map",
@@ -10214,10 +10035,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -10910,10 +10727,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "alias": "loadbalancing",
         "fields": {
@@ -11396,10 +11209,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "deprecated": "renamed to \"load_balancing\" upstream; the old name still resolves for now",
         "aliasOf": "load_balancing",
@@ -11881,9 +11690,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter",
         "fields": {
           "type": "map",
@@ -12274,9 +12080,6 @@
           "logs": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter",
         "fields": {
           "type": "map",
@@ -12647,9 +12450,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter",
         "fields": {
           "type": "map",
@@ -13015,11 +12815,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "opensearch": {
@@ -13032,9 +12827,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter",
         "fields": {
           "type": "map",
@@ -13644,10 +13436,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -14030,12 +13818,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "deprecated": "renamed to \"otlp_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_grpc",
@@ -14238,12 +14020,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "alias": "otlp",
         "fields": {
@@ -14566,12 +14342,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "alias": "otlphttp",
         "fields": {
@@ -14933,12 +14703,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "deprecated": "renamed to \"otlp_http\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_http",
@@ -15295,10 +15059,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -15674,10 +15434,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "alias": "prometheusremotewrite",
         "fields": {
@@ -16054,10 +15810,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "deprecated": "renamed to \"prometheus_remote_write\" upstream; the old name still resolves for now",
         "aliasOf": "prometheus_remote_write",
@@ -16439,9 +16191,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter",
         "fields": {
           "type": "map",
@@ -16730,9 +16479,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter",
         "fields": {
           "type": "map",
@@ -16935,9 +16681,6 @@
           "logs": "development",
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter",
         "fields": {
           "type": "map",
@@ -17329,9 +17072,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter",
         "fields": {
           "type": "map",
@@ -17828,9 +17568,6 @@
           "metrics": "beta",
           "traces": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter",
         "deprecated": "Traces pipeline is no longer necessary for trace correlation, trace correlation is supported via OTLP. Trace functionality will be removed from this exporter in December 2026.",
         "fields": {
@@ -18815,9 +18552,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter",
         "fields": {
           "type": "map",
@@ -19311,9 +19045,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter",
         "fields": {
           "type": "map",
@@ -19633,9 +19364,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter",
         "fields": {
           "type": "map",
@@ -20019,9 +19747,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter",
         "fields": {
           "type": "map",
@@ -20281,9 +20006,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter",
         "fields": {
           "type": "map",
@@ -20324,9 +20046,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter",
         "fields": {
           "type": "map",
@@ -20722,10 +20441,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -21082,10 +20797,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -21112,9 +20823,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension",
         "fields": {
           "type": "map",
@@ -21148,9 +20856,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension",
         "fields": {
           "type": "map",
@@ -21166,9 +20871,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension",
         "alias": "awslogs_encoding",
         "fields": {
@@ -21227,9 +20929,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension",
         "fields": {
           "type": "map",
@@ -21245,9 +20944,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension",
         "deprecated": "renamed to \"aws_logs_encoding\" upstream; the old name still resolves for now",
         "aliasOf": "aws_logs_encoding",
@@ -21307,9 +21003,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy",
         "fields": {
           "type": "map",
@@ -21459,9 +21152,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension",
         "alias": "azureauth",
         "fields": {
@@ -21537,9 +21227,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension",
         "fields": {
           "type": "map",
@@ -21615,9 +21302,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension",
         "deprecated": "renamed to \"azure_auth\" upstream; the old name still resolves for now",
         "aliasOf": "azure_auth",
@@ -21694,10 +21378,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -21746,10 +21426,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -21789,9 +21465,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver",
         "fields": {
           "type": "map",
@@ -21855,9 +21528,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension",
         "alias": "cgroupruntime",
         "fields": {
@@ -21894,9 +21564,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension",
         "deprecated": "renamed to \"cgroup_runtime\" upstream; the old name still resolves for now",
         "aliasOf": "cgroup_runtime",
@@ -21934,9 +21601,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension",
         "fields": {
           "type": "map",
@@ -22395,9 +22059,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage",
         "fields": {
           "type": "map",
@@ -22416,9 +22077,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver",
         "fields": {
           "type": "map",
@@ -22546,9 +22204,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver",
         "fields": {
           "type": "map",
@@ -22669,10 +22324,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -22735,9 +22386,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension",
         "alias": "googlecloudlogentry_encoding",
         "fields": {
@@ -22757,9 +22405,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension"
       },
       "googlecloudlogentry_encoding": {
@@ -22767,9 +22412,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension",
         "deprecated": "renamed to \"google_cloud_logentry_encoding\" upstream; the old name still resolves for now",
         "aliasOf": "google_cloud_logentry_encoding",
@@ -22790,10 +22432,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -22843,11 +22481,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -23476,9 +23109,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension",
         "fields": {
           "type": "map",
@@ -24107,10 +23737,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -24126,10 +23752,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -24607,9 +24229,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension",
         "fields": {
           "type": "map",
@@ -24625,9 +24244,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling",
         "fields": {
           "type": "map",
@@ -25301,9 +24917,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension",
         "fields": {
           "type": "map",
@@ -25322,10 +24935,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector",
         "fields": {
           "type": "map",
@@ -25370,10 +24979,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -25421,9 +25026,6 @@
         "stability": {
           "extension": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver",
         "deprecated": "Use the `kafkareceiver` with topic regex support instead. This component will be removed in a future release.",
         "fields": {
@@ -25725,9 +25327,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/mcp",
         "fields": {
           "type": "map",
@@ -25979,10 +25578,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -26169,10 +25764,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -26257,10 +25848,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -26560,9 +26147,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension",
         "fields": {
           "type": "map",
@@ -26578,9 +26162,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension",
         "fields": {
           "type": "map",
@@ -26596,11 +26177,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -26640,9 +26216,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension",
         "fields": {
           "type": "map",
@@ -26750,9 +26323,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension",
         "fields": {
           "type": "map",
@@ -27004,9 +26574,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension",
         "fields": {
           "type": "map",
@@ -27047,9 +26614,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension"
       },
       "solarwindsapmsettings": {
@@ -27057,9 +26621,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension",
         "fields": {
           "type": "map",
@@ -27081,9 +26642,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension",
         "fields": {
           "type": "map",
@@ -27389,9 +26947,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension",
         "fields": {
           "type": "map",
@@ -27413,9 +26968,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension",
         "fields": {
           "type": "map",
@@ -27434,11 +26986,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -27709,11 +27256,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -28088,9 +27630,6 @@
           "profiles": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/awsecsattributesprocessor",
         "fields": {
           "type": "map",
@@ -28134,11 +27673,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -28179,9 +27713,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cardinalityguardianprocessor",
         "fields": {
           "type": "map",
@@ -28230,9 +27761,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor",
         "fields": {
           "type": "map",
@@ -28268,10 +27796,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "alias": "cumulativetodelta",
         "fields": {
@@ -28377,10 +27901,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "deprecated": "renamed to \"cumulative_to_delta\" upstream; the old name still resolves for now",
         "aliasOf": "cumulative_to_delta",
@@ -28487,10 +28007,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -28512,10 +28028,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -28541,10 +28053,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor",
         "fields": {
           "type": "map",
@@ -28618,9 +28126,6 @@
         "stability": {
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/dynamicsamplingprocessor",
         "fields": {
           "type": "map",
@@ -28777,11 +28282,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -29632,9 +29132,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/genainormalizerprocessor",
         "fields": {
           "type": "map",
@@ -29684,9 +29181,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor",
         "fields": {
           "type": "map",
@@ -29732,10 +29226,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -29761,10 +29251,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -29801,10 +29287,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -29843,9 +29325,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/isolationforestprocessor",
         "fields": {
           "type": "map",
@@ -30007,10 +29486,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "alias": "k8sattributes",
         "fields": {
@@ -30266,10 +29741,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "deprecated": "renamed to \"k8s_attributes\" upstream; the old name still resolves for now",
         "aliasOf": "k8s_attributes",
@@ -30520,10 +29991,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "alias": "logdedup",
         "fields": {
@@ -30586,10 +30053,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "deprecated": "renamed to \"log_dedup\" upstream; the old name still resolves for now",
         "aliasOf": "log_dedup",
@@ -30653,9 +30116,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor",
         "fields": {
           "type": "map",
@@ -30711,9 +30171,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor",
         "fields": {
           "type": "map",
@@ -30798,11 +30255,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -30841,9 +30293,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor",
         "alias": "metricstarttime",
         "fields": {
@@ -30872,10 +30321,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "alias": "metricstransform",
         "fields": {
@@ -31014,9 +30459,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor",
         "fields": {
           "type": "map",
@@ -31072,9 +30514,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor",
         "deprecated": "renamed to \"metric_start_time\" upstream; the old name still resolves for now",
         "aliasOf": "metric_start_time",
@@ -31104,10 +30543,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "deprecated": "renamed to \"metrics_transform\" upstream; the old name still resolves for now",
         "aliasOf": "metrics_transform",
@@ -31249,11 +30684,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -31305,10 +30735,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -31552,10 +30978,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -31821,11 +31243,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -31894,10 +31311,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "alias": "resourcedetection",
         "fields": {
@@ -34400,10 +33813,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "deprecated": "renamed to \"resource_detection\" upstream; the old name still resolves for now",
         "aliasOf": "resource_detection",
@@ -36905,9 +36314,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor",
         "fields": {
           "type": "map",
@@ -37189,10 +36595,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -37571,9 +36973,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor",
         "alias": "spanpruning",
         "fields": {
@@ -37665,9 +37064,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor",
         "deprecated": "renamed to \"span_pruning\" upstream; the old name still resolves for now",
         "aliasOf": "span_pruning",
@@ -37764,9 +37160,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor",
         "fields": {
           "type": "map",
@@ -37894,10 +37287,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -40039,10 +39428,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -40198,9 +39583,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor",
         "fields": {
           "type": "map",
@@ -40222,9 +39604,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver",
         "fields": {
           "type": "map",
@@ -40583,9 +39962,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectoryinvreceiver"
       },
       "aerospike": {
@@ -40596,9 +39972,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver",
         "fields": {
           "type": "map",
@@ -41093,9 +40466,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver",
         "fields": {
           "type": "map",
@@ -41634,9 +41004,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver",
         "alias": "apachespark",
         "fields": {
@@ -43138,9 +42505,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver",
         "deprecated": "renamed to \"apache_spark\" upstream; the old name still resolves for now",
         "aliasOf": "apache_spark",
@@ -44645,9 +44009,6 @@
           "logs": "alpha",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver",
         "alias": "awscloudwatch",
         "fields": {
@@ -44841,9 +44202,6 @@
           "logs": "alpha",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver",
         "fields": {
           "type": "map",
@@ -44929,9 +44287,6 @@
           "logs": "alpha",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver",
         "deprecated": "renamed to \"aws_cloudwatch\" upstream; the old name still resolves for now",
         "aliasOf": "aws_cloudwatch",
@@ -45124,9 +44479,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver",
         "fields": {
           "type": "map",
@@ -45163,9 +44515,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver",
         "fields": {
           "type": "map",
@@ -45188,9 +44537,6 @@
           "logs": "alpha",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver",
         "fields": {
           "type": "map",
@@ -45461,9 +44807,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver",
         "fields": {
           "type": "map",
@@ -45582,9 +44925,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver",
         "fields": {
           "type": "map",
@@ -45763,9 +45103,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver",
         "alias": "azureblob",
         "fields": {
@@ -45858,9 +45195,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver",
         "alias": "azureeventhub",
         "fields": {
@@ -45982,9 +45316,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azurefunctionsreceiver",
         "fields": {
           "type": "map",
@@ -46284,9 +45615,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver",
         "alias": "azuremonitor",
         "fields": {
@@ -46440,9 +45768,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver",
         "deprecated": "renamed to \"azure_blob\" upstream; the old name still resolves for now",
         "aliasOf": "azure_blob",
@@ -46536,9 +45861,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver",
         "deprecated": "renamed to \"azure_event_hub\" upstream; the old name still resolves for now",
         "aliasOf": "azure_event_hub",
@@ -46661,9 +45983,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver",
         "deprecated": "renamed to \"azure_monitor\" upstream; the old name still resolves for now",
         "aliasOf": "azure_monitor",
@@ -46816,9 +46135,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver",
         "fields": {
           "type": "map",
@@ -46870,9 +46186,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver",
         "fields": {
           "type": "map",
@@ -47078,9 +46391,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver",
         "alias": "ciscoos",
         "fields": {
@@ -47155,9 +46465,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver",
         "deprecated": "renamed to \"cisco_os\" upstream; the old name still resolves for now",
         "aliasOf": "cisco_os",
@@ -47235,9 +46542,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver",
         "alias": "cloudfoundry",
         "fields": {
@@ -47503,9 +46807,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver",
         "fields": {
           "type": "map",
@@ -47646,9 +46947,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver",
         "deprecated": "renamed to \"cloud_foundry\" upstream; the old name still resolves for now",
         "aliasOf": "cloud_foundry",
@@ -47915,9 +47213,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver",
         "fields": {
           "type": "map",
@@ -48181,9 +47476,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver",
         "fields": {
           "type": "map",
@@ -48642,9 +47934,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver",
         "fields": {
           "type": "map",
@@ -48955,9 +48244,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver",
         "fields": {
           "type": "map",
@@ -50437,9 +49723,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver",
         "fields": {
           "type": "map",
@@ -52697,9 +51980,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver",
         "alias": "envoyals",
         "fields": {
@@ -52916,9 +52196,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver",
         "deprecated": "renamed to \"envoy_als\" upstream; the old name still resolves for now",
         "aliasOf": "envoy_als",
@@ -53136,9 +52413,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver",
         "fields": {
           "type": "map",
@@ -53619,9 +52893,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver",
         "fields": {
           "type": "map",
@@ -53876,10 +53147,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver",
         "alias": "filelog",
         "fields": {
@@ -54120,9 +53387,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver",
         "alias": "filestats",
         "fields": {
@@ -54333,10 +53597,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver",
         "deprecated": "renamed to \"file_log\" upstream; the old name still resolves for now",
         "aliasOf": "file_log",
@@ -54578,9 +53838,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver",
         "deprecated": "renamed to \"file_stats\" upstream; the old name still resolves for now",
         "aliasOf": "file_stats",
@@ -54792,9 +54049,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver",
         "alias": "flinkmetrics",
         "fields": {
@@ -55618,9 +54872,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver",
         "deprecated": "renamed to \"flink_metrics\" upstream; the old name still resolves for now",
         "aliasOf": "flink_metrics",
@@ -56445,10 +55696,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "alias": "fluentforward",
         "fields": {
@@ -56470,10 +55717,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "deprecated": "renamed to \"fluent_forward\" upstream; the old name still resolves for now",
         "aliasOf": "fluent_forward",
@@ -56498,9 +55741,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver",
         "fields": {
           "type": "map",
@@ -57203,9 +56443,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver",
         "fields": {
           "type": "map",
@@ -57491,9 +56728,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver",
         "alias": "googlecloudspanner",
         "fields": {
@@ -57575,9 +56809,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver",
         "fields": {
           "type": "map",
@@ -57638,9 +56869,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver",
         "fields": {
           "type": "map",
@@ -57723,9 +56951,6 @@
         "stability": {
           "logs": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver",
         "fields": {
           "type": "map",
@@ -57985,9 +57210,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver",
         "deprecated": "renamed to \"google_cloud_spanner\" upstream; the old name still resolves for now",
         "aliasOf": "google_cloud_spanner",
@@ -58070,9 +57292,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver",
         "fields": {
           "type": "map",
@@ -58822,11 +58041,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "alias": "hostmetrics",
         "fields": {
@@ -58883,11 +58097,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "deprecated": "renamed to \"host_metrics\" upstream; the old name still resolves for now",
         "aliasOf": "host_metrics",
@@ -58943,10 +58152,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "alias": "httpcheck",
         "fields": {
@@ -59617,10 +58822,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "deprecated": "renamed to \"http_check\" upstream; the old name still resolves for now",
         "aliasOf": "http_check",
@@ -60292,9 +59493,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver",
         "fields": {
           "type": "map",
@@ -60623,9 +59821,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver",
         "fields": {
           "type": "map",
@@ -60823,9 +60018,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver",
         "fields": {
           "type": "map",
@@ -61142,9 +60334,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver",
         "fields": {
           "type": "map",
@@ -61399,11 +60588,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -62501,10 +61685,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver",
         "fields": {
           "type": "map",
@@ -62642,10 +61822,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -65583,10 +64759,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -65641,10 +64813,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "alias": "k8sobjects",
         "fields": {
@@ -65763,10 +64931,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "deprecated": "renamed to \"k8s_objects\" upstream; the old name still resolves for now",
         "aliasOf": "k8s_objects",
@@ -65892,10 +65056,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -66516,9 +65676,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver",
         "alias": "kafkametrics",
         "fields": {
@@ -67426,9 +66583,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver",
         "deprecated": "renamed to \"kafka_metrics\" upstream; the old name still resolves for now",
         "aliasOf": "kafka_metrics",
@@ -68337,10 +67491,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "alias": "kubeletstats",
         "fields": {
@@ -69943,10 +69093,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "deprecated": "renamed to \"kubelet_stats\" upstream; the old name still resolves for now",
         "aliasOf": "kubelet_stats",
@@ -71552,9 +70698,6 @@
           "logs": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver",
         "fields": {
           "type": "map",
@@ -71889,9 +71032,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver",
         "fields": {
           "type": "map",
@@ -72704,9 +71844,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver",
         "alias": "macosunifiedlogging",
         "fields": {
@@ -72752,9 +71889,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver",
         "deprecated": "renamed to \"macos_unified_logging\" upstream; the old name still resolves for now",
         "aliasOf": "macos_unified_logging",
@@ -72801,9 +71935,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver",
         "fields": {
           "type": "map",
@@ -73058,9 +72189,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver",
         "fields": {
           "type": "map",
@@ -74424,9 +73552,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver",
         "alias": "mongodbatlas",
         "fields": {
@@ -77036,9 +76161,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver",
         "deprecated": "renamed to \"mongodb_atlas\" upstream; the old name still resolves for now",
         "aliasOf": "mongodb_atlas",
@@ -79649,9 +78771,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver",
         "fields": {
           "type": "map",
@@ -81566,9 +80685,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver",
         "alias": "namedpipe",
         "fields": {
@@ -81672,9 +80788,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver",
         "deprecated": "renamed to \"named_pipe\" upstream; the old name still resolves for now",
         "aliasOf": "named_pipe",
@@ -81779,9 +80892,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver",
         "fields": {
           "type": "map",
@@ -81826,9 +80936,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
         "fields": {
           "type": "map",
@@ -82135,10 +81242,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "nsxt": {
@@ -82149,9 +81252,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver",
         "fields": {
           "type": "map",
@@ -82733,9 +81833,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver",
         "fields": {
           "type": "map",
@@ -82838,9 +81935,6 @@
           "logs": "development",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver",
         "fields": {
           "type": "map",
@@ -85244,9 +84338,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver",
         "fields": {
           "type": "map",
@@ -85290,10 +84381,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -85769,12 +84856,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -86057,9 +85138,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver",
         "alias": "otlpjsonfile",
         "fields": {
@@ -86263,9 +85341,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver",
         "deprecated": "renamed to \"otlp_json_file\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_json_file",
@@ -86464,9 +85539,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver",
         "fields": {
           "type": "map",
@@ -86822,9 +85894,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver",
         "fields": {
           "type": "map",
@@ -88893,9 +87962,6 @@
         "stability": {
           "profiles": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver",
         "fields": {
           "type": "map",
@@ -89432,11 +88498,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -91127,9 +90188,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver",
         "alias": "prometheusremotewrite",
         "fields": {
@@ -91385,9 +90443,6 @@
         "stability": {
           "metrics": "unmaintained"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver",
         "fields": {
           "type": "map",
@@ -91669,9 +90724,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver",
         "deprecated": "renamed to \"prometheus_remote_write\" upstream; the old name still resolves for now",
         "aliasOf": "prometheus_remote_write",
@@ -91932,9 +90984,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver",
         "fields": {
           "type": "map",
@@ -92050,9 +91099,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver",
         "fields": {
           "type": "map",
@@ -92446,9 +91492,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver",
         "fields": {
           "type": "map",
@@ -92778,9 +91821,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver",
         "fields": {
           "type": "map",
@@ -94015,10 +93055,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -94072,9 +93108,6 @@
         "stability": {
           "metrics": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redfishreceiver",
         "fields": {
           "type": "map",
@@ -94650,9 +93683,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver",
         "fields": {
           "type": "map",
@@ -95675,9 +94705,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver",
         "fields": {
           "type": "map",
@@ -96120,9 +95147,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver",
         "fields": {
           "type": "map",
@@ -97574,9 +96598,6 @@
           "logs": "deprecated",
           "metrics": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver",
         "deprecated": "Use the OTLP receiver instead. This component will be removed in a future release.",
         "fields": {
@@ -97834,9 +96855,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver",
         "fields": {
           "type": "map",
@@ -98646,9 +97664,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver",
         "fields": {
           "type": "map",
@@ -98728,9 +97743,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver",
         "fields": {
           "type": "map",
@@ -99909,9 +98921,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver",
         "fields": {
           "type": "map",
@@ -100093,9 +99102,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver",
         "alias": "splunkenterprise",
         "fields": {
@@ -102444,9 +101450,6 @@
           "logs": "beta",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver",
         "fields": {
           "type": "map",
@@ -102759,9 +101762,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver",
         "deprecated": "renamed to \"splunk_enterprise\" upstream; the old name still resolves for now",
         "aliasOf": "splunk_enterprise",
@@ -105111,9 +104111,6 @@
           "logs": "development",
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver",
         "fields": {
           "type": "map",
@@ -105298,9 +104295,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver",
         "fields": {
           "type": "map",
@@ -107472,9 +106466,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver",
         "alias": "sshcheck",
         "fields": {
@@ -107680,9 +106671,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver",
         "deprecated": "renamed to \"ssh_check\" upstream; the old name still resolves for now",
         "aliasOf": "ssh_check",
@@ -107889,9 +106877,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver",
         "fields": {
           "type": "map",
@@ -108015,9 +107000,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver",
         "fields": {
           "type": "map",
@@ -108236,9 +107218,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver",
         "fields": {
           "type": "map",
@@ -108515,9 +107494,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver",
         "fields": {
           "type": "map",
@@ -108681,9 +107657,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver",
         "alias": "tcpcheck",
         "fields": {
@@ -108792,9 +107765,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver",
         "alias": "tcplog",
         "fields": {
@@ -108992,9 +107962,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver",
         "deprecated": "renamed to \"tcp_check\" upstream; the old name still resolves for now",
         "aliasOf": "tcp_check",
@@ -109104,9 +108071,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver",
         "deprecated": "renamed to \"tcp_log\" upstream; the old name still resolves for now",
         "aliasOf": "tcp_log",
@@ -109305,9 +108269,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver",
         "alias": "tlscheck",
         "fields": {
@@ -109461,9 +108422,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver",
         "deprecated": "renamed to \"tls_check\" upstream; the old name still resolves for now",
         "aliasOf": "tls_check",
@@ -109618,9 +108576,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver",
         "alias": "udplog",
         "fields": {
@@ -109738,9 +108693,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver",
         "deprecated": "renamed to \"udp_log\" upstream; the old name still resolves for now",
         "aliasOf": "udp_log",
@@ -109859,9 +108811,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver",
         "fields": {
           "type": "map",
@@ -112046,9 +110995,6 @@
           "profiles": "development",
           "traces": "development"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcrreceiver",
         "fields": {
           "type": "map",
@@ -112088,9 +111034,6 @@
         "stability": {
           "metrics": "deprecated"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver",
         "deprecated": "There is no replacement. This component will be removed in a future release.",
         "fields": {
@@ -112130,9 +111073,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver",
         "alias": "webhookevent",
         "fields": {
@@ -112433,9 +111373,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver",
         "deprecated": "renamed to \"webhook_event\" upstream; the old name still resolves for now",
         "aliasOf": "webhook_event",
@@ -112737,9 +111674,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver",
         "alias": "windowseventlog",
         "fields": {
@@ -112903,9 +111837,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver",
         "alias": "windowsservice",
         "fields": {
@@ -112966,9 +111897,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver",
         "deprecated": "renamed to \"windows_event_log\" upstream; the old name still resolves for now",
         "aliasOf": "windows_event_log",
@@ -113133,9 +112061,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver",
         "fields": {
           "type": "map",
@@ -113214,9 +112139,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver",
         "deprecated": "renamed to \"windows_service\" upstream; the old name still resolves for now",
         "aliasOf": "windows_service",
@@ -113278,9 +112200,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver",
         "alias": "yanggrpc",
         "fields": {
@@ -113569,9 +112488,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver",
         "deprecated": "renamed to \"yang_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "yang_grpc",
@@ -113861,11 +112777,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",
@@ -114124,9 +113035,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver",
         "fields": {
           "type": "map",

--- a/schemas/contrib/v0.157.0.yaml
+++ b/schemas/contrib/v0.157.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.157.0
 distribution: contrib
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:07:26Z"
+generatedAt: "2026-08-02T13:15:54Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,9 +22,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -61,8 +55,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
       fields:
         type: map
@@ -128,9 +120,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -167,9 +156,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -257,10 +243,6 @@ components:
           to: profiles
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     grafanacloud:
       type: grafanacloud
@@ -269,8 +251,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector
       fields:
         type: map
@@ -291,8 +271,6 @@ components:
       pairs:
         - from: metrics
           to: logs
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/metricsaslogsconnector
       alias: metricsaslogs
       fields:
@@ -309,8 +287,6 @@ components:
       pairs:
         - from: metrics
           to: logs
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/metricsaslogsconnector
       deprecated: renamed to "metrics_as_logs" upstream; the old name still resolves for now
       aliasOf: metrics_as_logs
@@ -334,9 +310,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
       alias: otlpjson
     otlpjson:
@@ -352,9 +325,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
       deprecated: renamed to "otlp_json" upstream; the old name still resolves for now
       aliasOf: otlp_json
@@ -371,9 +341,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
       alias: roundrobin
     roundrobin:
@@ -389,9 +356,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
       deprecated: renamed to "round_robin" upstream; the old name still resolves for now
       aliasOf: round_robin
@@ -408,9 +372,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -460,9 +421,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       alias: servicegraph
       fields:
@@ -528,9 +486,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       deprecated: renamed to "service_graph" upstream; the old name still resolves for now
       aliasOf: service_graph
@@ -606,8 +561,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
       alias: signaltometrics
     signaltometrics:
@@ -626,8 +579,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
       deprecated: renamed to "signal_to_metrics" upstream; the old name still resolves for now
       aliasOf: signal_to_metrics
@@ -638,8 +589,6 @@ components:
       pairs:
         - from: traces
           to: logs
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector
       alias: slowsql
       fields:
@@ -674,8 +623,6 @@ components:
       pairs:
         - from: traces
           to: logs
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector
       deprecated: renamed to "slow_sql" upstream; the old name still resolves for now
       aliasOf: slow_sql
@@ -711,8 +658,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
       alias: spanmetrics
       fields:
@@ -863,8 +808,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
       deprecated: renamed to "span_metrics" upstream; the old name still resolves for now
       aliasOf: span_metrics
@@ -1022,8 +965,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector
       fields:
         type: map
@@ -1053,8 +994,6 @@ components:
       stability:
         logs: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter
       fields:
         type: map
@@ -1313,8 +1252,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
       fields:
         type: map
@@ -1349,8 +1286,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
       fields:
         type: map
@@ -1498,8 +1433,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
       fields:
         type: map
@@ -1657,8 +1590,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
       fields:
         type: map
@@ -1791,8 +1722,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter
       fields:
         type: map
@@ -1968,8 +1897,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
       fields:
         type: map
@@ -2058,8 +1985,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter
       alias: azureblob
       fields:
@@ -2256,8 +2181,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter
       deprecated: renamed to "azure_blob" upstream; the old name still resolves for now
       aliasOf: azure_blob
@@ -2455,8 +2378,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter
       fields:
         type: map
@@ -2591,8 +2512,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
       fields:
         type: map
@@ -2846,8 +2765,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter
       alias: bmchelix
       fields:
@@ -3042,8 +2959,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter
       deprecated: renamed to "bmc_helix" upstream; the old name still resolves for now
       aliasOf: bmc_helix
@@ -3241,8 +3156,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter
       fields:
         type: map
@@ -3291,8 +3204,6 @@ components:
         metrics: alpha
         profiles: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter
       fields:
         type: map
@@ -3558,8 +3469,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
       fields:
         type: map
@@ -4434,8 +4343,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
     dataset:
       type: dataset
@@ -4445,8 +4352,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter
       fields:
         type: map
@@ -4665,10 +4570,6 @@ components:
         metrics: alpha
         profiles: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -4698,8 +4599,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter
       fields:
         type: map
@@ -5012,8 +4911,6 @@ components:
         metrics: development
         profiles: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
       fields:
         type: map
@@ -5410,8 +5307,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter
       fields:
         type: map
@@ -5659,10 +5554,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -5736,8 +5627,6 @@ components:
       stability:
         logs: alpha
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter
       alias: googlecloudstorage
       fields:
@@ -5877,8 +5766,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
       fields:
         type: map
@@ -5951,8 +5838,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
       fields:
         type: map
@@ -6136,8 +6021,6 @@ components:
       stability:
         logs: alpha
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter
       deprecated: renamed to "google_cloud_storage" upstream; the old name still resolves for now
       aliasOf: google_cloud_storage
@@ -6274,8 +6157,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
       fields:
         type: map
@@ -6363,8 +6244,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
       alias: honeycombmarker
       fields:
@@ -6653,8 +6532,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
       deprecated: renamed to "honeycomb_marker" upstream; the old name still resolves for now
       aliasOf: honeycomb_marker
@@ -6948,8 +6825,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
       fields:
         type: map
@@ -7257,9 +7132,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -7755,9 +7627,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       alias: loadbalancing
       fields:
@@ -8085,9 +7954,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       deprecated: renamed to "load_balancing" upstream; the old name still resolves for now
       aliasOf: load_balancing
@@ -8414,8 +8280,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter
       fields:
         type: map
@@ -8696,8 +8560,6 @@ components:
       stability:
         logs: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
       fields:
         type: map
@@ -8963,8 +8825,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter
       fields:
         type: map
@@ -9229,10 +9089,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     opensearch:
       type: opensearch
@@ -9242,8 +9098,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter
       fields:
         type: map
@@ -9671,9 +9525,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -9950,11 +9801,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       deprecated: renamed to "otlp_grpc" upstream; the old name still resolves for now
       aliasOf: otlp_grpc
@@ -10096,11 +9942,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       alias: otlp
       fields:
@@ -10334,11 +10175,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       alias: otlphttp
       fields:
@@ -10602,11 +10438,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       deprecated: renamed to "otlp_http" upstream; the old name still resolves for now
       aliasOf: otlp_http
@@ -10865,9 +10696,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -11135,9 +10963,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       alias: prometheusremotewrite
       fields:
@@ -11408,9 +11233,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       deprecated: renamed to "prometheus_remote_write" upstream; the old name still resolves for now
       aliasOf: prometheus_remote_write
@@ -11686,8 +11508,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
       fields:
         type: map
@@ -11889,8 +11709,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter
       fields:
         type: map
@@ -12032,8 +11850,6 @@ components:
       stability:
         logs: development
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter
       fields:
         type: map
@@ -12314,8 +12130,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
       fields:
         type: map
@@ -12664,8 +12478,6 @@ components:
         logs: beta
         metrics: beta
         traces: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
       deprecated: Traces pipeline is no longer necessary for trace correlation, trace correlation is supported via OTLP. Trace functionality will be removed from this exporter in December 2026.
       fields:
@@ -13373,8 +13185,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
       fields:
         type: map
@@ -13732,8 +13542,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter
       fields:
         type: map
@@ -13964,8 +13772,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
       fields:
         type: map
@@ -14242,8 +14048,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter
       fields:
         type: map
@@ -14430,8 +14234,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
       fields:
         type: map
@@ -14462,8 +14264,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter
       fields:
         type: map
@@ -14744,9 +14544,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -15002,9 +14799,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -15024,8 +14818,6 @@ components:
       type: asapclient
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
       fields:
         type: map
@@ -15048,8 +14840,6 @@ components:
       type: avro_log_encoding
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension
       fields:
         type: map
@@ -15060,8 +14850,6 @@ components:
       type: aws_logs_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
       alias: awslogs_encoding
       fields:
@@ -15100,8 +14888,6 @@ components:
       type: awscloudwatchmetricstreams_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension
       fields:
         type: map
@@ -15112,8 +14898,6 @@ components:
       type: awslogs_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
       deprecated: renamed to "aws_logs_encoding" upstream; the old name still resolves for now
       aliasOf: aws_logs_encoding
@@ -15153,8 +14937,6 @@ components:
       type: awsproxy
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
       fields:
         type: map
@@ -15262,8 +15044,6 @@ components:
       type: azure_auth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension
       alias: azureauth
       fields:
@@ -15313,8 +15093,6 @@ components:
       type: azure_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
       fields:
         type: map
@@ -15362,8 +15140,6 @@ components:
       type: azureauth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension
       deprecated: renamed to "azure_auth" upstream; the old name still resolves for now
       aliasOf: azure_auth
@@ -15414,9 +15190,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -15451,9 +15224,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -15482,8 +15252,6 @@ components:
       type: cfgarden_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver
       fields:
         type: map
@@ -15525,8 +15293,6 @@ components:
       type: cgroup_runtime
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension
       alias: cgroupruntime
       fields:
@@ -15551,8 +15317,6 @@ components:
       type: cgroupruntime
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension
       deprecated: renamed to "cgroup_runtime" upstream; the old name still resolves for now
       aliasOf: cgroup_runtime
@@ -15578,8 +15342,6 @@ components:
       type: datadog
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension
       fields:
         type: map
@@ -15896,8 +15658,6 @@ components:
       type: db_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
       fields:
         type: map
@@ -15910,8 +15670,6 @@ components:
       type: docker_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
       fields:
         type: map
@@ -15995,8 +15753,6 @@ components:
       type: ecs_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
       fields:
         type: map
@@ -16074,9 +15830,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -16118,8 +15871,6 @@ components:
       type: google_cloud_logentry_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
       alias: googlecloudlogentry_encoding
       fields:
@@ -16133,15 +15884,11 @@ components:
       type: googleclientauth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension
     googlecloudlogentry_encoding:
       type: googlecloudlogentry_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
       deprecated: renamed to "google_cloud_logentry_encoding" upstream; the old name still resolves for now
       aliasOf: google_cloud_logentry_encoding
@@ -16156,9 +15903,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -16192,10 +15936,6 @@ components:
       type: health_check
       stability:
         extension: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -16602,8 +16342,6 @@ components:
       type: healthcheckv2
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension
       fields:
         type: map
@@ -17010,9 +16748,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -17023,9 +16758,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -17364,8 +17096,6 @@ components:
       type: jaeger_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension
       fields:
         type: map
@@ -17376,8 +17106,6 @@ components:
       type: jaegerremotesampling
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
       fields:
         type: map
@@ -17853,8 +17581,6 @@ components:
       type: json_log_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension
       fields:
         type: map
@@ -17867,9 +17593,6 @@ components:
       type: k8s_leader_elector
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
       fields:
         type: map
@@ -17901,9 +17624,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -17935,8 +17655,6 @@ components:
       type: kafkatopics_observer
       stability:
         extension: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver
       deprecated: Use the `kafkareceiver` with topic regex support instead. This component will be removed in a future release.
       fields:
@@ -18133,8 +17851,6 @@ components:
       type: mcp
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/mcp
       fields:
         type: map
@@ -18311,9 +18027,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -18449,9 +18162,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -18513,9 +18223,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -18729,8 +18436,6 @@ components:
       type: otlp_encoding
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension
       fields:
         type: map
@@ -18741,8 +18446,6 @@ components:
       type: pebble_tail_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension
       fields:
         type: map
@@ -18753,10 +18456,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -18785,8 +18484,6 @@ components:
       type: redis_storage
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension
       fields:
         type: map
@@ -18857,8 +18554,6 @@ components:
       type: remotetap
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension
       fields:
         type: map
@@ -19035,8 +18730,6 @@ components:
       type: sigv4auth
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension
       fields:
         type: map
@@ -19064,15 +18757,11 @@ components:
       type: skywalking_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension
     solarwindsapmsettings:
       type: solarwindsapmsettings
       stability:
         extension: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension
       fields:
         type: map
@@ -19087,8 +18776,6 @@ components:
       type: sumologic
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension
       fields:
         type: map
@@ -19309,8 +18996,6 @@ components:
       type: text_encoding
       stability:
         extension: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension
       fields:
         type: map
@@ -19325,8 +19010,6 @@ components:
       type: zipkin_encoding
       stability:
         extension: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension
       fields:
         type: map
@@ -19339,10 +19022,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -19533,10 +19212,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -19800,8 +19475,6 @@ components:
         metrics: development
         profiles: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/awsecsattributesprocessor
       fields:
         type: map
@@ -19831,10 +19504,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -19863,8 +19532,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cardinalityguardianprocessor
       fields:
         type: map
@@ -19897,8 +19564,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor
       fields:
         type: map
@@ -19922,9 +19587,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       alias: cumulativetodelta
       fields:
@@ -19997,9 +19659,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       deprecated: renamed to "cumulative_to_delta" upstream; the old name still resolves for now
       aliasOf: cumulative_to_delta
@@ -20073,9 +19732,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -20090,9 +19746,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -20110,9 +19763,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor
       fields:
         type: map
@@ -20161,8 +19811,6 @@ components:
         - traces
       stability:
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dynamicsamplingprocessor
       fields:
         type: map
@@ -20265,10 +19913,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -20851,8 +20495,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/genainormalizerprocessor
       fields:
         type: map
@@ -20887,8 +20529,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor
       fields:
         type: map
@@ -20922,9 +20562,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -20942,9 +20579,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -20971,9 +20605,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -21002,8 +20633,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/isolationforestprocessor
       fields:
         type: map
@@ -21112,9 +20741,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       alias: k8sattributes
       fields:
@@ -21297,9 +20923,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       deprecated: renamed to "k8s_attributes" upstream; the old name still resolves for now
       aliasOf: k8s_attributes
@@ -21477,9 +21100,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       alias: logdedup
       fields:
@@ -21521,9 +21141,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       deprecated: renamed to "log_dedup" upstream; the old name still resolves for now
       aliasOf: log_dedup
@@ -21566,8 +21183,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor
       fields:
         type: map
@@ -21608,8 +21223,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor
       fields:
         type: map
@@ -21671,10 +21284,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -21702,8 +21311,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor
       alias: metricstarttime
       fields:
@@ -21724,9 +21331,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       alias: metricstransform
       fields:
@@ -21825,8 +21429,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
       fields:
         type: map
@@ -21866,8 +21468,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor
       deprecated: renamed to "metric_start_time" upstream; the old name still resolves for now
       aliasOf: metric_start_time
@@ -21889,9 +21489,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       deprecated: renamed to "metrics_transform" upstream; the old name still resolves for now
       aliasOf: metrics_transform
@@ -21993,10 +21590,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -22035,9 +21628,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -22201,9 +21791,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -22392,10 +21979,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -22447,9 +22030,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       alias: resourcedetection
       fields:
@@ -24049,9 +23629,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       deprecated: renamed to "resource_detection" upstream; the old name still resolves for now
       aliasOf: resource_detection
@@ -25650,8 +25227,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor
       fields:
         type: map
@@ -25853,9 +25428,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -26118,8 +25690,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor
       alias: spanpruning
       fields:
@@ -26180,8 +25750,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanpruningprocessor
       deprecated: renamed to "span_pruning" upstream; the old name still resolves for now
       aliasOf: span_pruning
@@ -26247,8 +25815,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor
       fields:
         type: map
@@ -26330,9 +25896,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -27834,9 +27397,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -27937,8 +27497,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor
       fields:
         type: map
@@ -27953,8 +27511,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver
       fields:
         type: map
@@ -28201,8 +27757,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectoryinvreceiver
     aerospike:
       type: aerospike
@@ -28210,8 +27764,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
       fields:
         type: map
@@ -28553,8 +28105,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
       fields:
         type: map
@@ -28929,8 +28479,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
       alias: apachespark
       fields:
@@ -29959,8 +29507,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
       deprecated: renamed to "apache_spark" upstream; the old name still resolves for now
       aliasOf: apache_spark
@@ -30992,8 +30538,6 @@ components:
       stability:
         logs: alpha
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver
       alias: awscloudwatch
       fields:
@@ -31125,8 +30669,6 @@ components:
       stability:
         logs: alpha
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver
       fields:
         type: map
@@ -31187,8 +30729,6 @@ components:
       stability:
         logs: alpha
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver
       deprecated: renamed to "aws_cloudwatch" upstream; the old name still resolves for now
       aliasOf: aws_cloudwatch
@@ -31319,8 +30859,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
       fields:
         type: map
@@ -31347,8 +30885,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
       fields:
         type: map
@@ -31365,8 +30901,6 @@ components:
       stability:
         logs: alpha
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver
       fields:
         type: map
@@ -31558,8 +31092,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver
       fields:
         type: map
@@ -31641,8 +31173,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
       fields:
         type: map
@@ -31771,8 +31301,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
       alias: azureblob
       fields:
@@ -31840,8 +31368,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
       alias: azureeventhub
       fields:
@@ -31925,8 +31451,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azurefunctionsreceiver
       fields:
         type: map
@@ -32136,8 +31660,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
       alias: azuremonitor
       fields:
@@ -32241,8 +31763,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
       deprecated: renamed to "azure_blob" upstream; the old name still resolves for now
       aliasOf: azure_blob
@@ -32311,8 +31831,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
       deprecated: renamed to "azure_event_hub" upstream; the old name still resolves for now
       aliasOf: azure_event_hub
@@ -32397,8 +31915,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
       deprecated: renamed to "azure_monitor" upstream; the old name still resolves for now
       aliasOf: azure_monitor
@@ -32501,8 +32017,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
       fields:
         type: map
@@ -32539,8 +32053,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver
       fields:
         type: map
@@ -32683,8 +32195,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver
       alias: ciscoos
       fields:
@@ -32737,8 +32247,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver
       deprecated: renamed to "cisco_os" upstream; the old name still resolves for now
       aliasOf: cisco_os
@@ -32794,8 +32302,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
       alias: cloudfoundry
       fields:
@@ -32985,8 +32491,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
       fields:
         type: map
@@ -33086,8 +32590,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
       deprecated: renamed to "cloud_foundry" upstream; the old name still resolves for now
       aliasOf: cloud_foundry
@@ -33278,8 +32780,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
       fields:
         type: map
@@ -33464,8 +32964,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
       fields:
         type: map
@@ -33788,8 +33286,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
       fields:
         type: map
@@ -34008,8 +33504,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
       fields:
         type: map
@@ -35021,8 +34515,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
       fields:
         type: map
@@ -36576,8 +36068,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver
       alias: envoyals
       fields:
@@ -36731,8 +36221,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver
       deprecated: renamed to "envoy_als" upstream; the old name still resolves for now
       aliasOf: envoy_als
@@ -36887,8 +36375,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver
       fields:
         type: map
@@ -37222,8 +36708,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver
       fields:
         type: map
@@ -37402,9 +36886,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
       alias: filelog
       fields:
@@ -37566,8 +37047,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
       alias: filestats
       fields:
@@ -37710,9 +37189,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
       deprecated: renamed to "file_log" upstream; the old name still resolves for now
       aliasOf: file_log
@@ -37875,8 +37351,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
       deprecated: renamed to "file_stats" upstream; the old name still resolves for now
       aliasOf: file_stats
@@ -38020,8 +37494,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
       alias: flinkmetrics
       fields:
@@ -38585,8 +38057,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
       deprecated: renamed to "flink_metrics" upstream; the old name still resolves for now
       aliasOf: flink_metrics
@@ -39151,9 +38621,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       alias: fluentforward
       fields:
@@ -39169,9 +38636,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       deprecated: renamed to "fluent_forward" upstream; the old name still resolves for now
       aliasOf: fluent_forward
@@ -39190,8 +38654,6 @@ components:
       stability:
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver
       fields:
         type: map
@@ -39686,8 +39148,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver
       fields:
         type: map
@@ -39888,8 +39348,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
       alias: googlecloudspanner
       fields:
@@ -39944,8 +39402,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
       fields:
         type: map
@@ -39989,8 +39445,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
       fields:
         type: map
@@ -40051,8 +39505,6 @@ components:
         - logs
       stability:
         logs: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver
       fields:
         type: map
@@ -40235,8 +39687,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
       deprecated: renamed to "google_cloud_spanner" upstream; the old name still resolves for now
       aliasOf: google_cloud_spanner
@@ -40292,8 +39742,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
       fields:
         type: map
@@ -40807,10 +40255,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       alias: hostmetrics
       fields:
@@ -40855,10 +40299,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       deprecated: renamed to "host_metrics" upstream; the old name still resolves for now
       aliasOf: host_metrics
@@ -40902,9 +40342,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       alias: httpcheck
       fields:
@@ -41376,9 +40813,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       deprecated: renamed to "http_check" upstream; the old name still resolves for now
       aliasOf: http_check
@@ -41851,8 +41285,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver
       fields:
         type: map
@@ -42089,8 +41521,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver
       fields:
         type: map
@@ -42223,8 +41653,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
       fields:
         type: map
@@ -42439,8 +41867,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
       fields:
         type: map
@@ -42619,10 +42045,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -43371,9 +42793,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
       fields:
         type: map
@@ -43467,9 +42886,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -45435,9 +44851,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -45477,9 +44890,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       alias: k8sobjects
       fields:
@@ -45560,9 +44970,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       deprecated: renamed to "k8s_objects" upstream; the old name still resolves for now
       aliasOf: k8s_objects
@@ -45650,9 +45057,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -46090,8 +45494,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
       alias: kafkametrics
       fields:
@@ -46728,8 +46130,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
       deprecated: renamed to "kafka_metrics" upstream; the old name still resolves for now
       aliasOf: kafka_metrics
@@ -47367,9 +46767,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       alias: kubeletstats
       fields:
@@ -48452,9 +47849,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       deprecated: renamed to "kubelet_stats" upstream; the old name still resolves for now
       aliasOf: kubelet_stats
@@ -49540,8 +48934,6 @@ components:
       stability:
         logs: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver
       fields:
         type: map
@@ -49773,8 +49165,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver
       fields:
         type: map
@@ -50325,8 +49715,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver
       alias: macosunifiedlogging
       fields:
@@ -50360,8 +49748,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver
       deprecated: renamed to "macos_unified_logging" upstream; the old name still resolves for now
       aliasOf: macos_unified_logging
@@ -50396,8 +49782,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
       fields:
         type: map
@@ -50574,8 +49958,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
       fields:
         type: map
@@ -51508,8 +50890,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
       alias: mongodbatlas
       fields:
@@ -53287,8 +52667,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
       deprecated: renamed to "mongodb_atlas" upstream; the old name still resolves for now
       aliasOf: mongodb_atlas
@@ -55067,8 +54445,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
       fields:
         type: map
@@ -56376,8 +55752,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
       alias: namedpipe
       fields:
@@ -56449,8 +55823,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
       deprecated: renamed to "named_pipe" upstream; the old name still resolves for now
       aliasOf: named_pipe
@@ -56523,8 +55895,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver
       fields:
         type: map
@@ -56557,8 +55927,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
       fields:
         type: map
@@ -56778,9 +56146,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     nsxt:
       type: nsxt
@@ -56788,8 +56153,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
       fields:
         type: map
@@ -57193,8 +56556,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver
       fields:
         type: map
@@ -57265,8 +56626,6 @@ components:
       stability:
         logs: development
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver
       fields:
         type: map
@@ -58867,8 +58226,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver
       fields:
         type: map
@@ -58900,9 +58257,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -59228,11 +58582,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -59423,8 +58772,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
       alias: otlpjsonfile
       fields:
@@ -59562,8 +58909,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
       deprecated: renamed to "otlp_json_file" upstream; the old name still resolves for now
       aliasOf: otlp_json_file
@@ -59696,8 +59041,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
       fields:
         type: map
@@ -59938,8 +59281,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
       fields:
         type: map
@@ -61343,8 +60684,6 @@ components:
         - profiles
       stability:
         profiles: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver
       fields:
         type: map
@@ -61726,10 +61065,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -62944,8 +62279,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
       alias: prometheusremotewrite
       fields:
@@ -63125,8 +62458,6 @@ components:
         - metrics
       stability:
         metrics: unmaintained
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
       fields:
         type: map
@@ -63330,8 +62661,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
       deprecated: renamed to "prometheus_remote_write" upstream; the old name still resolves for now
       aliasOf: prometheus_remote_write
@@ -63516,8 +62845,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver
       fields:
         type: map
@@ -63596,8 +62923,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver
       fields:
         type: map
@@ -63874,8 +63199,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver
       fields:
         type: map
@@ -64108,8 +63431,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
       fields:
         type: map
@@ -64944,9 +64265,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -64983,8 +64301,6 @@ components:
         - metrics
       stability:
         metrics: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redfishreceiver
       fields:
         type: map
@@ -65394,8 +64710,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
       fields:
         type: map
@@ -66092,8 +65406,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
       fields:
         type: map
@@ -66404,8 +65716,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
       fields:
         type: map
@@ -67411,8 +66721,6 @@ components:
       stability:
         logs: deprecated
         metrics: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
       deprecated: Use the OTLP receiver instead. This component will be removed in a future release.
       fields:
@@ -67594,8 +66902,6 @@ components:
       stability:
         metrics: development
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver
       fields:
         type: map
@@ -68144,8 +67450,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
       fields:
         type: map
@@ -68205,8 +67509,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
       fields:
         type: map
@@ -69054,8 +68356,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver
       fields:
         type: map
@@ -69183,8 +68483,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver
       alias: splunkenterprise
       fields:
@@ -70856,8 +70154,6 @@ components:
       stability:
         logs: beta
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
       fields:
         type: map
@@ -71078,8 +70374,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver
       deprecated: renamed to "splunk_enterprise" upstream; the old name still resolves for now
       aliasOf: splunk_enterprise
@@ -72752,8 +72046,6 @@ components:
       stability:
         logs: development
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver
       fields:
         type: map
@@ -72877,8 +72169,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
       fields:
         type: map
@@ -74334,8 +73624,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
       alias: sshcheck
       fields:
@@ -74477,8 +73765,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
       deprecated: renamed to "ssh_check" upstream; the old name still resolves for now
       aliasOf: ssh_check
@@ -74621,8 +73907,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
       fields:
         type: map
@@ -74705,8 +73989,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver
       fields:
         type: map
@@ -74861,8 +74143,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
       fields:
         type: map
@@ -75053,8 +74333,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver
       fields:
         type: map
@@ -75166,8 +74444,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver
       alias: tcpcheck
       fields:
@@ -75243,8 +74519,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
       alias: tcplog
       fields:
@@ -75383,8 +74657,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver
       deprecated: renamed to "tcp_check" upstream; the old name still resolves for now
       aliasOf: tcp_check
@@ -75461,8 +74733,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
       deprecated: renamed to "tcp_log" upstream; the old name still resolves for now
       aliasOf: tcp_log
@@ -75602,8 +74872,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
       alias: tlscheck
       fields:
@@ -75710,8 +74978,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
       deprecated: renamed to "tls_check" upstream; the old name still resolves for now
       aliasOf: tls_check
@@ -75819,8 +75085,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
       alias: udplog
       fields:
@@ -75901,8 +75165,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
       deprecated: renamed to "udp_log" upstream; the old name still resolves for now
       aliasOf: udp_log
@@ -75984,8 +75246,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
       fields:
         type: map
@@ -77480,8 +76740,6 @@ components:
         metrics: development
         profiles: development
         traces: development
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcrreceiver
       fields:
         type: map
@@ -77507,8 +76765,6 @@ components:
         - metrics
       stability:
         metrics: deprecated
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
       deprecated: There is no replacement. This component will be removed in a future release.
       fields:
@@ -77537,8 +76793,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver
       alias: webhookevent
       fields:
@@ -77748,8 +77002,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver
       deprecated: renamed to "webhook_event" upstream; the old name still resolves for now
       aliasOf: webhook_event
@@ -77960,8 +77212,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
       alias: windowseventlog
       fields:
@@ -78075,8 +77325,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver
       alias: windowsservice
       fields:
@@ -78118,8 +77366,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
       deprecated: renamed to "windows_event_log" upstream; the old name still resolves for now
       aliasOf: windows_event_log
@@ -78234,8 +77480,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
       fields:
         type: map
@@ -78289,8 +77533,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver
       deprecated: renamed to "windows_service" upstream; the old name still resolves for now
       aliasOf: windows_service
@@ -78333,8 +77575,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver
       alias: yanggrpc
       fields:
@@ -78539,8 +77779,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver
       deprecated: renamed to "yang_grpc" upstream; the old name still resolves for now
       aliasOf: yang_grpc
@@ -78746,10 +77984,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map
@@ -78931,8 +78165,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
       fields:
         type: map

--- a/schemas/core/v0.110.0.json
+++ b/schemas/core/v0.110.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.110.0",
   "distribution": "core",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:37Z",
+  "generatedAt": "2026-08-02T13:15:51Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -33,11 +29,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       }
     },
@@ -54,11 +45,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -98,10 +84,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/exporterhelper"
       },
       "file": {
@@ -116,10 +98,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -189,10 +167,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -453,10 +427,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/loggingexporter",
         "fields": {
           "type": "map",
@@ -489,11 +459,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "opencensus": {
@@ -506,10 +471,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter",
         "fields": {
           "type": "map",
@@ -673,11 +634,6 @@
           "metrics": "stable",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -876,11 +832,6 @@
           "metrics": "stable",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -1061,10 +1012,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -1230,10 +1177,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -1452,10 +1395,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -1629,10 +1568,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -1796,9 +1731,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "core"
-        ],
         "module": "go.opentelemetry.io/collector/extension/memorylimiterextension",
         "fields": {
           "type": "map",
@@ -1826,10 +1758,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -1862,11 +1790,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -2011,10 +1934,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -2322,11 +2241,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -2371,10 +2285,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -2966,11 +2876,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -3011,10 +2916,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -3058,10 +2959,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/processor/processorhelper"
       },
       "resource": {
@@ -3076,10 +2973,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -3127,10 +3020,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -3449,10 +3338,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -3483,10 +3368,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -3921,10 +3802,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -4170,10 +4047,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "opencensus": {
@@ -4186,10 +4059,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver",
         "fields": {
           "type": "map",
@@ -4342,11 +4211,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -4623,10 +4487,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -4784,10 +4644,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/receiverhelper"
       },
       "scraperhelper": {
@@ -4802,10 +4658,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/scraperhelper"
       },
       "zipkin": {
@@ -4816,10 +4668,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/core/v0.110.0.yaml
+++ b/schemas/core/v0.110.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.110.0
 distribution: core
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:37Z"
+generatedAt: "2026-08-02T13:15:51Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -22,10 +19,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
   exporter:
     debug:
@@ -38,10 +31,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -71,9 +60,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/exporter/exporterhelper
     file:
       type: file
@@ -85,9 +71,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -135,9 +118,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -309,9 +289,6 @@ components:
         logs: deprecated
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/exporter/loggingexporter
       fields:
         type: map
@@ -335,10 +312,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     opencensus:
       type: opencensus
@@ -348,9 +321,6 @@ components:
       stability:
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter
       fields:
         type: map
@@ -460,10 +430,6 @@ components:
         logs: beta
         metrics: stable
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -601,10 +567,6 @@ components:
         logs: beta
         metrics: stable
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -724,9 +686,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -835,9 +794,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -981,9 +937,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -1098,9 +1051,6 @@ components:
       type: health_check
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -1207,8 +1157,6 @@ components:
       type: memory_limiter
       stability:
         extension: development
-      distributions:
-        - core
       module: go.opentelemetry.io/collector/extension/memorylimiterextension
       fields:
         type: map
@@ -1227,9 +1175,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -1251,10 +1196,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -1350,9 +1291,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -1550,10 +1488,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -1586,9 +1520,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -1965,10 +1896,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -1998,9 +1925,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -2031,9 +1955,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/processor/processorhelper
     resource:
       type: resource
@@ -2045,9 +1966,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -2079,9 +1997,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -2284,9 +2199,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -2307,9 +2219,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -2594,9 +2503,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -2757,9 +2663,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     opencensus:
       type: opencensus
@@ -2769,9 +2672,6 @@ components:
       stability:
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
       fields:
         type: map
@@ -2873,10 +2773,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -3061,9 +2957,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -3170,9 +3063,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/receiverhelper
     scraperhelper:
       type: scraperhelper
@@ -3184,9 +3074,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/scraperhelper
     zipkin:
       type: zipkin
@@ -3194,9 +3081,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/core/v0.120.0.json
+++ b/schemas/core/v0.120.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.120.0",
   "distribution": "core",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:37Z",
+  "generatedAt": "2026-08-02T13:15:51Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -33,11 +29,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       }
     },
@@ -56,11 +47,6 @@
           "profiles": "development",
           "traces": "development"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -102,11 +88,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -176,10 +157,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -451,11 +428,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "opencensus": {
@@ -468,10 +440,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter",
         "fields": {
           "type": "map",
@@ -648,12 +616,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -854,12 +816,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -1059,10 +1015,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -1236,10 +1188,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -1477,10 +1425,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -1673,11 +1617,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -1849,9 +1788,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "core"
-        ],
         "module": "go.opentelemetry.io/collector/extension/memorylimiterextension",
         "fields": {
           "type": "map",
@@ -1879,11 +1815,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -1919,9 +1850,6 @@
         "stability": {
           "profiles": "development"
         },
-        "distributions": [
-          "core"
-        ],
         "module": "go.opentelemetry.io/collector/extension/xextension"
       },
       "zpages": {
@@ -1929,11 +1857,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -2086,11 +2009,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -2398,11 +2316,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -2447,11 +2360,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -3043,11 +2951,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -3088,11 +2991,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -3136,11 +3034,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -3188,10 +3081,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -3513,11 +3402,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -3548,11 +3432,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -4011,10 +3890,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -4268,10 +4143,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "opencensus": {
@@ -4284,11 +4155,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver",
         "fields": {
           "type": "map",
@@ -4449,12 +4315,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -4731,11 +4591,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -4905,11 +4760,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/core/v0.120.0.yaml
+++ b/schemas/core/v0.120.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.120.0
 distribution: core
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:37Z"
+generatedAt: "2026-08-02T13:15:51Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -22,10 +19,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
   exporter:
     debug:
@@ -40,10 +33,6 @@ components:
         metrics: development
         profiles: development
         traces: development
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -75,10 +64,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -126,9 +111,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -307,10 +289,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     opencensus:
       type: opencensus
@@ -320,9 +298,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter
       fields:
         type: map
@@ -441,11 +416,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -585,11 +555,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -721,9 +686,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -837,9 +799,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -995,9 +954,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -1124,10 +1080,6 @@ components:
       type: health_check
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -1239,8 +1191,6 @@ components:
       type: memory_limiter
       stability:
         extension: development
-      distributions:
-        - core
       module: go.opentelemetry.io/collector/extension/memorylimiterextension
       fields:
         type: map
@@ -1259,10 +1209,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -1286,17 +1232,11 @@ components:
         - profiles
       stability:
         profiles: development
-      distributions:
-        - core
       module: go.opentelemetry.io/collector/extension/xextension
     zpages:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -1397,10 +1337,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -1598,10 +1534,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -1634,10 +1566,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -2014,10 +1942,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -2047,10 +1971,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -2081,10 +2001,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -2116,9 +2032,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -2323,10 +2236,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -2347,10 +2256,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -2650,9 +2555,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -2818,9 +2720,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     opencensus:
       type: opencensus
@@ -2830,10 +2729,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
       fields:
         type: map
@@ -2940,11 +2835,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -3129,10 +3019,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -3245,10 +3131,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/core/v0.130.0.json
+++ b/schemas/core/v0.130.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.130.0",
   "distribution": "core",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:38Z",
+  "generatedAt": "2026-08-02T13:15:52Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -33,11 +29,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       }
     },
@@ -56,11 +47,6 @@
           "profiles": "development",
           "traces": "development"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -102,11 +88,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -176,10 +157,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -627,11 +604,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "opencensus": {
@@ -644,10 +616,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter",
         "deprecated": "Use OTLP exporter (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)",
         "fields": {
@@ -881,12 +849,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -1087,12 +1049,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -1348,10 +1304,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -1556,10 +1508,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -1824,10 +1772,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -2076,11 +2020,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -2283,9 +2222,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "core"
-        ],
         "module": "go.opentelemetry.io/collector/extension/memorylimiterextension",
         "fields": {
           "type": "map",
@@ -2319,11 +2255,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -2359,9 +2290,6 @@
         "stability": {
           "profiles": "development"
         },
-        "distributions": [
-          "core"
-        ],
         "module": "go.opentelemetry.io/collector/extension/xextension"
       },
       "zpages": {
@@ -2369,11 +2297,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -2565,11 +2488,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -2877,11 +2795,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -2926,11 +2839,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -3524,11 +3432,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -3569,11 +3472,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -3619,11 +3517,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -3671,10 +3564,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -3996,11 +3885,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -4031,11 +3915,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -4587,10 +4466,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -5003,10 +4878,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "opencensus": {
@@ -5019,11 +4890,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver",
         "deprecated": "Use OTLP receiver (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)",
         "fields": {
@@ -5216,12 +5082,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -5498,11 +5358,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -5878,11 +5733,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/core/v0.130.0.yaml
+++ b/schemas/core/v0.130.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.130.0
 distribution: core
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:38Z"
+generatedAt: "2026-08-02T13:15:52Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -22,10 +19,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
   exporter:
     debug:
@@ -40,10 +33,6 @@ components:
         metrics: development
         profiles: development
         traces: development
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -75,10 +64,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -126,9 +111,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -421,10 +403,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     opencensus:
       type: opencensus
@@ -434,9 +412,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter
       deprecated: Use OTLP exporter (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)
       fields:
@@ -593,11 +568,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -737,11 +707,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -910,9 +875,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -1046,9 +1008,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -1222,9 +1181,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -1388,10 +1344,6 @@ components:
       type: health_check
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -1523,8 +1475,6 @@ components:
       type: memory_limiter
       stability:
         extension: development
-      distributions:
-        - core
       module: go.opentelemetry.io/collector/extension/memorylimiterextension
       fields:
         type: map
@@ -1547,10 +1497,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -1574,17 +1520,11 @@ components:
         - profiles
       stability:
         profiles: development
-      distributions:
-        - core
       module: go.opentelemetry.io/collector/extension/xextension
     zpages:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -1710,10 +1650,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -1911,10 +1847,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -1947,10 +1879,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -2329,10 +2257,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -2362,10 +2286,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -2398,10 +2318,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -2433,9 +2349,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -2640,10 +2553,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -2664,10 +2573,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -3027,9 +2932,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -3298,9 +3200,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     opencensus:
       type: opencensus
@@ -3310,10 +3209,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
       deprecated: Use OTLP receiver (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)
       fields:
@@ -3441,11 +3336,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -3630,10 +3520,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -3879,10 +3765,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/core/v0.140.0.json
+++ b/schemas/core/v0.140.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.140.0",
   "distribution": "core",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:39Z",
+  "generatedAt": "2026-08-02T13:15:53Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -38,11 +34,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       }
     },
@@ -61,11 +52,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -107,11 +93,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -183,10 +164,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -663,11 +640,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "otlp": {
@@ -684,12 +656,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -890,12 +856,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -1154,10 +1114,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -1411,10 +1367,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -1682,10 +1634,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -1934,11 +1882,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -2141,9 +2084,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "core"
-        ],
         "module": "go.opentelemetry.io/collector/extension/memorylimiterextension",
         "fields": {
           "type": "map",
@@ -2177,11 +2117,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -2217,9 +2152,6 @@
         "stability": {
           "profiles": "development"
         },
-        "distributions": [
-          "core"
-        ],
         "module": "go.opentelemetry.io/collector/extension/xextension"
       },
       "zpages": {
@@ -2227,11 +2159,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -2423,11 +2350,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -2735,11 +2657,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -2786,11 +2703,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -3429,11 +3341,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -3474,11 +3381,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -3524,11 +3426,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -3576,10 +3473,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -3901,11 +3794,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -3936,11 +3824,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -4491,10 +4374,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -4948,10 +4827,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "otlp": {
@@ -4968,12 +4843,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -5250,11 +5119,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -5630,11 +5494,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/core/v0.140.0.yaml
+++ b/schemas/core/v0.140.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.140.0
 distribution: core
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:39Z"
+generatedAt: "2026-08-02T13:15:53Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,10 +22,6 @@ components:
           to: profiles
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
   exporter:
     debug:
@@ -43,10 +36,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -78,10 +67,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -131,9 +116,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -445,10 +427,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     otlp:
       type: otlp
@@ -462,11 +440,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -606,11 +579,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -781,9 +749,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -950,9 +915,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -1128,9 +1090,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -1294,10 +1253,6 @@ components:
       type: health_check
       stability:
         extension: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -1429,8 +1384,6 @@ components:
       type: memory_limiter
       stability:
         extension: development
-      distributions:
-        - core
       module: go.opentelemetry.io/collector/extension/memorylimiterextension
       fields:
         type: map
@@ -1453,10 +1406,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -1480,17 +1429,11 @@ components:
         - profiles
       stability:
         profiles: development
-      distributions:
-        - core
       module: go.opentelemetry.io/collector/extension/xextension
     zpages:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -1616,10 +1559,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -1817,10 +1756,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -1855,10 +1790,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -2265,10 +2196,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -2298,10 +2225,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -2334,10 +2257,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -2369,9 +2288,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -2576,10 +2492,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -2600,10 +2512,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -2963,9 +2871,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -3260,9 +3165,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     otlp:
       type: otlp
@@ -3276,11 +3178,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -3465,10 +3362,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -3714,10 +3607,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/core/v0.150.0.json
+++ b/schemas/core/v0.150.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.150.0",
   "distribution": "core",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:39Z",
+  "generatedAt": "2026-08-02T13:15:53Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -38,11 +34,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       }
     },
@@ -61,11 +52,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -107,11 +93,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -207,10 +188,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -880,11 +857,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "otlp": {
@@ -901,12 +873,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "deprecated": "renamed to \"otlp_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_grpc",
@@ -1109,12 +1075,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "alias": "otlp",
         "fields": {
@@ -1355,12 +1315,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "alias": "otlphttp",
         "fields": {
@@ -1632,12 +1586,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "deprecated": "renamed to \"otlp_http\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_http",
@@ -1904,10 +1852,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -2271,10 +2215,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "fields": {
           "type": "map",
@@ -2643,10 +2583,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -3000,11 +2936,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -3608,9 +3539,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "core"
-        ],
         "module": "go.opentelemetry.io/collector/extension/memorylimiterextension",
         "fields": {
           "type": "map",
@@ -3644,11 +3572,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -3688,11 +3611,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -3895,11 +3813,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -4272,11 +4185,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -4323,11 +4231,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -5184,11 +5087,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -5229,11 +5127,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -5287,11 +5180,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -5354,10 +5242,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -5740,11 +5624,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -5781,11 +5660,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -6859,10 +6733,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -7473,10 +7343,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "otlp": {
@@ -7493,12 +7359,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -7775,11 +7635,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -8270,11 +8125,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/core/v0.150.0.yaml
+++ b/schemas/core/v0.150.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.150.0
 distribution: core
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:39Z"
+generatedAt: "2026-08-02T13:15:53Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,10 +22,6 @@ components:
           to: profiles
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
   exporter:
     debug:
@@ -43,10 +36,6 @@ components:
         metrics: alpha
         profiles: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -78,10 +67,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -153,9 +138,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -635,10 +617,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     otlp:
       type: otlp
@@ -652,11 +630,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       deprecated: renamed to "otlp_grpc" upstream; the old name still resolves for now
       aliasOf: otlp_grpc
@@ -798,11 +771,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       alias: otlp
       fields:
@@ -963,11 +931,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       alias: otlphttp
       fields:
@@ -1149,11 +1112,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       deprecated: renamed to "otlp_http" upstream; the old name still resolves for now
       aliasOf: otlp_http
@@ -1330,9 +1288,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -1592,9 +1547,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       fields:
         type: map
@@ -1859,9 +1811,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -2115,10 +2064,6 @@ components:
       type: health_check
       stability:
         extension: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -2509,8 +2454,6 @@ components:
       type: memory_limiter
       stability:
         extension: development
-      distributions:
-        - core
       module: go.opentelemetry.io/collector/extension/memorylimiterextension
       fields:
         type: map
@@ -2533,10 +2476,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -2565,10 +2504,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -2701,10 +2636,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -2966,10 +2897,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -3004,10 +2931,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -3596,10 +3519,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -3629,10 +3548,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -3673,10 +3588,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -3722,9 +3633,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -3990,10 +3898,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -4020,10 +3924,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -4758,9 +4658,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -5193,9 +5090,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     otlp:
       type: otlp
@@ -5209,11 +5103,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -5398,10 +5287,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -5749,10 +5634,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/core/v0.157.0.json
+++ b/schemas/core/v0.157.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.157.0",
   "distribution": "core",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:07:26Z",
+  "generatedAt": "2026-08-02T13:15:54Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -38,11 +34,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       }
     },
@@ -61,11 +52,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -107,11 +93,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -216,10 +197,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter",
         "fields": {
           "type": "map",
@@ -914,11 +891,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "otlp": {
@@ -935,12 +907,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "deprecated": "renamed to \"otlp_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_grpc",
@@ -1143,12 +1109,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "alias": "otlp",
         "fields": {
@@ -1471,12 +1431,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "alias": "otlphttp",
         "fields": {
@@ -1838,12 +1792,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "deprecated": "renamed to \"otlp_http\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_http",
@@ -2200,10 +2148,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter",
         "fields": {
           "type": "map",
@@ -2579,10 +2523,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "alias": "prometheusremotewrite",
         "fields": {
@@ -2959,10 +2899,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",
         "deprecated": "renamed to \"prometheus_remote_write\" upstream; the old name still resolves for now",
         "aliasOf": "prometheus_remote_write",
@@ -3340,10 +3276,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter",
         "fields": {
           "type": "map",
@@ -3700,11 +3632,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -4333,9 +4260,6 @@
         "stability": {
           "extension": "development"
         },
-        "distributions": [
-          "core"
-        ],
         "module": "go.opentelemetry.io/collector/extension/memorylimiterextension",
         "fields": {
           "type": "map",
@@ -4385,11 +4309,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -4429,11 +4348,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -4704,11 +4618,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -5081,11 +4990,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -5132,11 +5036,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -5993,11 +5892,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -6038,11 +5932,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -6096,11 +5985,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -6163,10 +6047,6 @@
         "stability": {
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor",
         "fields": {
           "type": "map",
@@ -6549,11 +6429,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "alias": "hostmetrics",
         "fields": {
@@ -6610,11 +6485,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "deprecated": "renamed to \"host_metrics\" upstream; the old name still resolves for now",
         "aliasOf": "host_metrics",
@@ -6670,11 +6540,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -7778,10 +7643,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver",
         "fields": {
           "type": "map",
@@ -8408,10 +8269,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/nopreceiver"
       },
       "otlp": {
@@ -8428,12 +8285,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -8710,11 +8561,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -10405,11 +10251,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/core/v0.157.0.yaml
+++ b/schemas/core/v0.157.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.157.0
 distribution: core
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:07:26Z"
+generatedAt: "2026-08-02T13:15:54Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,10 +22,6 @@ components:
           to: profiles
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
   exporter:
     debug:
@@ -43,10 +36,6 @@ components:
         metrics: alpha
         profiles: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -78,10 +67,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -159,9 +144,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
       fields:
         type: map
@@ -659,10 +641,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     otlp:
       type: otlp
@@ -676,11 +654,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       deprecated: renamed to "otlp_grpc" upstream; the old name still resolves for now
       aliasOf: otlp_grpc
@@ -822,11 +795,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       alias: otlp
       fields:
@@ -1060,11 +1028,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       alias: otlphttp
       fields:
@@ -1328,11 +1291,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       deprecated: renamed to "otlp_http" upstream; the old name still resolves for now
       aliasOf: otlp_http
@@ -1591,9 +1549,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
       fields:
         type: map
@@ -1861,9 +1816,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       alias: prometheusremotewrite
       fields:
@@ -2134,9 +2086,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
       deprecated: renamed to "prometheus_remote_write" upstream; the old name still resolves for now
       aliasOf: prometheus_remote_write
@@ -2408,9 +2357,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       fields:
         type: map
@@ -2666,10 +2612,6 @@ components:
       type: health_check
       stability:
         extension: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -3076,8 +3018,6 @@ components:
       type: memory_limiter
       stability:
         extension: development
-      distributions:
-        - core
       module: go.opentelemetry.io/collector/extension/memorylimiterextension
       fields:
         type: map
@@ -3114,10 +3054,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -3146,10 +3082,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -3340,10 +3272,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -3605,10 +3533,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -3643,10 +3567,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -4235,10 +4155,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -4268,10 +4184,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -4312,10 +4224,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -4361,9 +4269,6 @@ components:
         - traces
       stability:
         traces: alpha
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
       fields:
         type: map
@@ -4629,10 +4534,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       alias: hostmetrics
       fields:
@@ -4677,10 +4578,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       deprecated: renamed to "host_metrics" upstream; the old name still resolves for now
       aliasOf: host_metrics
@@ -4724,10 +4621,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -5482,9 +5375,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
       fields:
         type: map
@@ -5928,9 +5818,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
       module: go.opentelemetry.io/collector/receiver/nopreceiver
     otlp:
       type: otlp
@@ -5944,11 +5831,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -6133,10 +6015,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -7351,10 +7229,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/k8s/v0.110.0.json
+++ b/schemas/k8s/v0.110.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.110.0",
   "distribution": "k8s",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:37Z",
+  "generatedAt": "2026-08-02T13:15:51Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -33,11 +29,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       }
     },
@@ -54,11 +45,6 @@
           "metrics": "development",
           "traces": "development"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -98,11 +84,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "otlp": {
@@ -117,11 +98,6 @@
           "metrics": "stable",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -320,11 +296,6 @@
           "metrics": "stable",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -504,11 +475,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -653,11 +619,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -702,11 +663,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -753,11 +709,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",

--- a/schemas/k8s/v0.110.0.yaml
+++ b/schemas/k8s/v0.110.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.110.0
 distribution: k8s
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:37Z"
+generatedAt: "2026-08-02T13:15:51Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -22,10 +19,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
   exporter:
     debug:
@@ -38,10 +31,6 @@ components:
         logs: development
         metrics: development
         traces: development
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -71,10 +60,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     otlp:
       type: otlp
@@ -86,10 +71,6 @@ components:
         logs: beta
         metrics: stable
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -227,10 +208,6 @@ components:
         logs: beta
         metrics: stable
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -349,10 +326,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -448,10 +421,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -484,10 +453,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -522,10 +487,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map

--- a/schemas/k8s/v0.120.0.json
+++ b/schemas/k8s/v0.120.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.120.0",
   "distribution": "k8s",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:37Z",
+  "generatedAt": "2026-08-02T13:15:51Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -32,10 +28,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -79,10 +71,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
@@ -136,10 +124,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
           "type": "map",
@@ -191,11 +175,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "otlpjson": {
@@ -218,10 +197,6 @@
             "from": "logs",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"
       },
@@ -246,10 +221,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
       },
       "routing": {
@@ -272,10 +243,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -334,10 +301,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "fields": {
@@ -415,11 +378,6 @@
           "profiles": "development",
           "traces": "development"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -461,11 +419,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -535,10 +488,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "fields": {
           "type": "map",
@@ -871,11 +820,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "otelarrow": {
@@ -890,10 +834,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -1135,12 +1075,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -1341,12 +1275,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -1545,10 +1473,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -1571,10 +1495,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -1609,10 +1529,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -1634,10 +1550,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -1694,10 +1606,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -1735,11 +1643,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -1911,10 +1814,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -1930,10 +1829,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -2215,10 +2110,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -2252,10 +2143,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -2361,10 +2248,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -2395,10 +2278,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -2600,11 +2479,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -2637,11 +2511,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -2794,11 +2663,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -3106,11 +2970,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -3151,10 +3010,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "fields": {
           "type": "map",
@@ -3246,10 +3101,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -3271,10 +3122,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -3302,11 +3149,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -3898,10 +3740,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -3925,10 +3763,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -3959,10 +3793,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -3998,10 +3828,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "fields": {
           "type": "map",
@@ -4191,10 +4017,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "fields": {
           "type": "map",
@@ -4247,11 +4069,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -4290,10 +4107,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "fields": {
           "type": "map",
@@ -4410,11 +4223,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -4458,10 +4266,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -4519,10 +4323,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -4677,11 +4477,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -4735,10 +4530,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "fields": {
           "type": "map",
@@ -6048,10 +5839,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -6797,10 +6584,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -6920,10 +6703,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
       },
       "fluentforward": {
@@ -6934,10 +6713,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "fields": {
           "type": "map",
@@ -6958,11 +6733,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -6993,10 +6763,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "fields": {
           "type": "map",
@@ -7199,11 +6965,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -7658,10 +7419,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
       },
       "k8s_cluster": {
@@ -7674,10 +7431,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -9577,10 +9330,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -9610,10 +9359,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "fields": {
           "type": "map",
@@ -9683,10 +9428,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "fields": {
           "type": "map",
@@ -10899,11 +10640,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver",
         "fields": {
           "type": "map",
@@ -11062,10 +10798,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -11267,12 +10999,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -11549,11 +11275,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -11727,10 +11448,6 @@
           "metrics": "beta",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -11772,11 +11489,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/k8s/v0.120.0.yaml
+++ b/schemas/k8s/v0.120.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.120.0
 distribution: k8s
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:37Z"
+generatedAt: "2026-08-02T13:15:51Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -22,9 +19,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -54,9 +48,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -89,9 +80,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -124,10 +112,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     otlpjson:
       type: otlpjson
@@ -142,9 +126,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
     roundrobin:
       type: roundrobin
@@ -159,9 +140,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
     routing:
       type: routing
@@ -176,9 +154,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -216,9 +191,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       fields:
         type: map
@@ -270,10 +242,6 @@ components:
         metrics: development
         profiles: development
         traces: development
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -305,10 +273,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -356,9 +320,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       fields:
         type: map
@@ -577,10 +538,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     otelarrow:
       type: otelarrow
@@ -592,9 +549,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -755,11 +709,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -899,11 +848,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -1034,9 +978,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -1052,9 +993,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -1077,9 +1015,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -1094,9 +1029,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -1134,9 +1066,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -1161,10 +1090,6 @@ components:
       type: health_check
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -1276,9 +1201,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -1289,9 +1211,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -1475,9 +1394,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -1500,9 +1416,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -1572,9 +1485,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -1595,9 +1505,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -1730,10 +1637,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -1755,10 +1658,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -1859,10 +1758,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -2060,10 +1955,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -2092,9 +1983,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       fields:
         type: map
@@ -2153,9 +2041,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -2170,9 +2055,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -2192,10 +2074,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -2572,9 +2450,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -2590,9 +2465,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -2613,9 +2485,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -2641,9 +2510,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       fields:
         type: map
@@ -2764,9 +2630,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       fields:
         type: map
@@ -2802,10 +2665,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -2833,9 +2692,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       fields:
         type: map
@@ -2912,10 +2768,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -2946,9 +2798,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -2987,9 +2836,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -3092,10 +2938,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -3133,9 +2975,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       fields:
         type: map
@@ -3959,9 +3798,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -4435,9 +4271,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -4513,9 +4346,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
     fluentforward:
       type: fluentforward
@@ -4523,9 +4353,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       fields:
         type: map
@@ -4540,10 +4367,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -4564,9 +4387,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       fields:
         type: map
@@ -4698,10 +4518,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -4997,9 +4813,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
     k8s_cluster:
       type: k8s_cluster
@@ -5009,9 +4822,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -6200,9 +6010,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -6222,9 +6029,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       fields:
         type: map
@@ -6270,9 +6074,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       fields:
         type: map
@@ -7034,10 +6835,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
       fields:
         type: map
@@ -7142,9 +6939,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -7277,11 +7071,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -7466,10 +7255,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -7586,9 +7371,6 @@ components:
         logs: alpha
         metrics: beta
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -7616,10 +7398,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/k8s/v0.130.0.json
+++ b/schemas/k8s/v0.130.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.130.0",
   "distribution": "k8s",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:38Z",
+  "generatedAt": "2026-08-02T13:15:52Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -37,10 +33,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -88,10 +80,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
@@ -145,10 +133,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
           "type": "map",
@@ -200,11 +184,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "otlpjson": {
@@ -227,10 +206,6 @@
             "from": "logs",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"
       },
@@ -255,10 +230,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
       },
       "routing": {
@@ -281,10 +252,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -343,10 +310,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "fields": {
@@ -429,11 +392,6 @@
           "profiles": "development",
           "traces": "development"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -475,11 +433,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -549,10 +502,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "fields": {
           "type": "map",
@@ -957,11 +906,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "otelarrow": {
@@ -976,10 +920,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -1260,12 +1200,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -1466,12 +1400,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -1726,10 +1654,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -1752,10 +1676,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -1790,10 +1710,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -1826,10 +1742,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -1886,10 +1798,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -1930,11 +1838,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -2137,10 +2040,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -2156,10 +2055,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -2503,10 +2398,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -2548,10 +2439,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -2674,10 +2561,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -2711,10 +2594,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -2956,11 +2835,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -2993,11 +2867,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -3189,11 +3058,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -3501,11 +3365,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -3546,10 +3405,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "fields": {
           "type": "map",
@@ -3641,10 +3496,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -3666,10 +3517,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -3697,11 +3544,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -4293,10 +4135,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -4320,10 +4158,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -4354,10 +4188,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -4393,10 +4223,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "fields": {
           "type": "map",
@@ -4583,10 +4409,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "fields": {
           "type": "map",
@@ -4641,11 +4463,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -4684,10 +4501,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "fields": {
           "type": "map",
@@ -4804,11 +4617,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -4852,10 +4660,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -4924,10 +4728,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -5115,11 +4915,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -5173,10 +4968,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "fields": {
           "type": "map",
@@ -6625,10 +6416,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -7550,10 +7337,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -7705,10 +7488,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
       },
       "fluentforward": {
@@ -7719,10 +7498,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "fields": {
           "type": "map",
@@ -7743,11 +7518,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -7778,10 +7548,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "fields": {
           "type": "map",
@@ -8015,11 +7781,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -8567,10 +8328,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
       },
       "k8s_cluster": {
@@ -8583,10 +8340,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -10610,10 +10363,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -10643,10 +10392,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "fields": {
           "type": "map",
@@ -10723,10 +10468,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "fields": {
           "type": "map",
@@ -11967,11 +11708,6 @@
           "metrics": "deprecated",
           "traces": "deprecated"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver",
         "deprecated": "Use OTLP receiver (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)",
         "fields": {
@@ -12162,10 +11898,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -12398,12 +12130,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -12680,11 +12406,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -13064,10 +12785,6 @@
           "metrics": "beta",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -13113,11 +12830,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/k8s/v0.130.0.yaml
+++ b/schemas/k8s/v0.130.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.130.0
 distribution: k8s
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:38Z"
+generatedAt: "2026-08-02T13:15:52Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,9 +22,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -60,9 +54,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -95,9 +86,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -130,10 +118,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     otlpjson:
       type: otlpjson
@@ -148,9 +132,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
     roundrobin:
       type: roundrobin
@@ -165,9 +146,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
     routing:
       type: routing
@@ -182,9 +160,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -222,9 +197,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       fields:
         type: map
@@ -279,10 +251,6 @@ components:
         metrics: development
         profiles: development
         traces: development
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -314,10 +282,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -365,9 +329,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       fields:
         type: map
@@ -634,10 +595,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     otelarrow:
       type: otelarrow
@@ -649,9 +606,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -838,11 +792,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -982,11 +931,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -1154,9 +1098,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -1172,9 +1113,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -1197,9 +1135,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -1221,9 +1156,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -1261,9 +1193,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -1290,10 +1219,6 @@ components:
       type: health_check
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -1425,9 +1350,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -1438,9 +1360,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -1664,9 +1583,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -1694,9 +1610,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -1777,9 +1690,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -1802,9 +1712,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -1963,10 +1870,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -1988,10 +1891,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -2117,10 +2016,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -2318,10 +2213,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -2350,9 +2241,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       fields:
         type: map
@@ -2411,9 +2299,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -2428,9 +2313,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -2450,10 +2332,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -2830,9 +2708,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -2848,9 +2723,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -2871,9 +2743,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -2899,9 +2768,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       fields:
         type: map
@@ -3020,9 +2886,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       fields:
         type: map
@@ -3060,10 +2923,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -3091,9 +2950,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       fields:
         type: map
@@ -3170,10 +3026,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -3204,9 +3056,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -3252,9 +3101,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -3379,10 +3225,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -3420,9 +3262,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       fields:
         type: map
@@ -4334,9 +4173,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -4922,9 +4758,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -5020,9 +4853,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
     fluentforward:
       type: fluentforward
@@ -5030,9 +4860,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       fields:
         type: map
@@ -5047,10 +4874,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -5071,9 +4894,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       fields:
         type: map
@@ -5225,10 +5045,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -5584,9 +5400,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
     k8s_cluster:
       type: k8s_cluster
@@ -5596,9 +5409,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -6865,9 +6675,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -6887,9 +6694,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       fields:
         type: map
@@ -6940,9 +6744,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       fields:
         type: map
@@ -7722,10 +7523,6 @@ components:
       stability:
         metrics: deprecated
         traces: deprecated
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
       deprecated: Use OTLP receiver (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791)
       fields:
@@ -7851,9 +7648,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -8006,11 +7800,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -8195,10 +7984,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -8448,9 +8233,6 @@ components:
         logs: alpha
         metrics: beta
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -8481,10 +8263,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/k8s/v0.140.0.json
+++ b/schemas/k8s/v0.140.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.140.0",
   "distribution": "k8s",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:39Z",
+  "generatedAt": "2026-08-02T13:15:53Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -37,10 +33,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -88,10 +80,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
@@ -144,10 +132,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
@@ -251,11 +235,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "otlpjson": {
@@ -278,10 +257,6 @@
             "from": "logs",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"
       },
@@ -306,10 +281,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
       },
       "routing": {
@@ -332,10 +303,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -394,10 +361,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "fields": {
@@ -486,11 +449,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -532,11 +490,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -606,10 +559,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "fields": {
           "type": "map",
@@ -1011,11 +960,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "otelarrow": {
@@ -1030,10 +974,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -1311,12 +1251,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -1517,12 +1451,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -1780,10 +1708,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -1806,10 +1730,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -1844,10 +1764,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -1880,10 +1796,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -1943,10 +1855,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -1987,11 +1895,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -2194,10 +2097,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -2213,10 +2112,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -2560,10 +2455,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector",
         "fields": {
           "type": "map",
@@ -2597,10 +2488,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -2642,10 +2529,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -2768,10 +2651,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -2833,10 +2712,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -3078,11 +2953,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -3115,11 +2985,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -3311,11 +3176,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -3623,11 +3483,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -3668,10 +3523,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "fields": {
           "type": "map",
@@ -3763,10 +3614,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -3788,10 +3635,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -3821,11 +3664,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -4462,10 +4300,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -4489,10 +4323,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -4523,10 +4353,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -4562,10 +4388,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "fields": {
           "type": "map",
@@ -4755,10 +4577,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "fields": {
           "type": "map",
@@ -4813,11 +4631,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -4856,10 +4669,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "fields": {
           "type": "map",
@@ -4976,11 +4785,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -5024,10 +4828,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -5232,10 +5032,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -5423,11 +5219,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -5481,10 +5272,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "fields": {
           "type": "map",
@@ -7446,10 +7233,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -8374,10 +8157,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -8529,10 +8308,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
       },
       "fluentforward": {
@@ -8543,10 +8318,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "fields": {
           "type": "map",
@@ -8567,11 +8338,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -8602,10 +8368,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "fields": {
           "type": "map",
@@ -8948,11 +8710,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -9497,10 +9254,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
       },
       "k8s_cluster": {
@@ -9513,10 +9266,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -11564,10 +11313,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -11601,10 +11346,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "fields": {
           "type": "map",
@@ -11684,10 +11425,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "fields": {
           "type": "map",
@@ -12914,10 +12651,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -13150,12 +12883,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -13432,11 +13159,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -13816,10 +13538,6 @@
           "metrics": "beta",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -13865,11 +13583,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/k8s/v0.140.0.yaml
+++ b/schemas/k8s/v0.140.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.140.0
 distribution: k8s
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:39Z"
+generatedAt: "2026-08-02T13:15:53Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,9 +22,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -60,9 +54,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -95,9 +86,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -164,10 +152,6 @@ components:
           to: profiles
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     otlpjson:
       type: otlpjson
@@ -182,9 +166,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
     roundrobin:
       type: roundrobin
@@ -199,9 +180,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
     routing:
       type: routing
@@ -216,9 +194,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -256,9 +231,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       fields:
         type: map
@@ -317,10 +289,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -352,10 +320,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -403,9 +367,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       fields:
         type: map
@@ -670,10 +631,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     otelarrow:
       type: otelarrow
@@ -685,9 +642,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -872,11 +826,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -1016,11 +965,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -1190,9 +1134,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -1208,9 +1149,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -1233,9 +1171,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -1257,9 +1192,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -1299,9 +1231,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -1328,10 +1257,6 @@ components:
       type: health_check
       stability:
         extension: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -1463,9 +1388,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -1476,9 +1398,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -1702,9 +1621,6 @@ components:
       type: k8s_leader_elector
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
       fields:
         type: map
@@ -1727,9 +1643,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -1757,9 +1670,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -1840,9 +1750,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -1883,9 +1790,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -2044,10 +1948,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -2069,10 +1969,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -2198,10 +2094,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -2399,10 +2291,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -2431,9 +2319,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       fields:
         type: map
@@ -2492,9 +2377,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -2509,9 +2391,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -2533,10 +2412,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -2941,9 +2816,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -2959,9 +2831,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -2982,9 +2851,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -3010,9 +2876,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       fields:
         type: map
@@ -3133,9 +2996,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       fields:
         type: map
@@ -3173,10 +3033,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -3204,9 +3060,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       fields:
         type: map
@@ -3283,10 +3136,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -3317,9 +3166,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -3450,9 +3296,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -3577,10 +3420,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -3618,9 +3457,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       fields:
         type: map
@@ -4851,9 +4687,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -5441,9 +5274,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -5539,9 +5369,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
     fluentforward:
       type: fluentforward
@@ -5549,9 +5376,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       fields:
         type: map
@@ -5566,10 +5390,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -5590,9 +5410,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       fields:
         type: map
@@ -5813,10 +5630,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -6170,9 +5983,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
     k8s_cluster:
       type: k8s_cluster
@@ -6182,9 +5992,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -7466,9 +7273,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -7491,9 +7295,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       fields:
         type: map
@@ -7546,9 +7347,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       fields:
         type: map
@@ -8320,9 +8118,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -8475,11 +8270,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -8664,10 +8454,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -8917,9 +8703,6 @@ components:
         logs: alpha
         metrics: beta
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -8950,10 +8733,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/k8s/v0.150.0.json
+++ b/schemas/k8s/v0.150.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.150.0",
   "distribution": "k8s",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:39Z",
+  "generatedAt": "2026-08-02T13:15:53Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -37,10 +33,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -89,10 +81,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
@@ -149,10 +137,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
@@ -288,11 +272,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "otlpjson": {
@@ -315,10 +294,6 @@
             "from": "logs",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"
       },
@@ -343,10 +318,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
       },
       "routing": {
@@ -369,10 +340,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -444,10 +411,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "fields": {
@@ -547,11 +510,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -593,11 +551,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -691,10 +644,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "fields": {
           "type": "map",
@@ -1169,11 +1118,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "otelarrow": {
@@ -1188,10 +1132,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -1567,12 +1507,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "deprecated": "renamed to \"otlp_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_grpc",
@@ -1775,12 +1709,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "alias": "otlp",
         "fields": {
@@ -2021,12 +1949,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "alias": "otlphttp",
         "fields": {
@@ -2298,12 +2220,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "deprecated": "renamed to \"otlp_http\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_http",
@@ -2569,10 +2485,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -2599,10 +2511,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -2651,10 +2559,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -2694,10 +2598,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -2757,10 +2657,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -2810,11 +2706,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -3418,10 +3309,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -3437,10 +3324,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -3903,10 +3786,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector",
         "fields": {
           "type": "map",
@@ -3951,10 +3830,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -4002,10 +3877,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -4189,10 +4060,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -4273,10 +4140,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -4570,11 +4433,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -4614,11 +4472,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -4821,11 +4674,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -5198,11 +5046,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -5243,10 +5086,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "fields": {
           "type": "map",
@@ -5351,10 +5190,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -5376,10 +5211,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -5411,11 +5242,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -6270,10 +6096,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -6299,10 +6121,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -6339,10 +6157,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -6383,10 +6197,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "alias": "k8sattributes",
         "fields": {
@@ -6634,10 +6444,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "deprecated": "renamed to \"k8s_attributes\" upstream; the old name still resolves for now",
         "aliasOf": "k8s_attributes",
@@ -6880,10 +6686,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "fields": {
           "type": "map",
@@ -6939,11 +6741,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -6982,10 +6779,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "fields": {
           "type": "map",
@@ -7125,11 +6918,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -7181,10 +6969,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -7428,10 +7212,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -7685,11 +7465,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -7758,10 +7533,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "fields": {
           "type": "map",
@@ -10193,10 +9964,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -11642,10 +11409,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -11803,10 +11566,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver",
         "alias": "filelog",
         "fields": {
@@ -12044,10 +11803,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver",
         "deprecated": "renamed to \"file_log\" upstream; the old name still resolves for now",
         "aliasOf": "file_log",
@@ -12286,10 +12041,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "fields": {
           "type": "map",
@@ -12312,11 +12063,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "fields": {
           "type": "map",
@@ -12353,10 +12099,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "alias": "httpcheck",
         "fields": {
@@ -12774,10 +12516,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "deprecated": "renamed to \"http_check\" upstream; the old name still resolves for now",
         "aliasOf": "http_check",
@@ -13196,11 +12934,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -14268,10 +14001,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver",
         "fields": {
           "type": "map",
@@ -14406,10 +14135,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -16968,10 +16693,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -17017,10 +16738,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "fields": {
           "type": "map",
@@ -17128,10 +16845,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "fields": {
           "type": "map",
@@ -18540,10 +18253,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -19016,12 +18725,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -19298,11 +19001,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -19799,10 +19497,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -19853,11 +19547,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/k8s/v0.150.0.yaml
+++ b/schemas/k8s/v0.150.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.150.0
 distribution: k8s
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:39Z"
+generatedAt: "2026-08-02T13:15:53Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,9 +22,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -61,9 +55,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -100,9 +91,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -196,10 +184,6 @@ components:
           to: profiles
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     otlpjson:
       type: otlpjson
@@ -214,9 +198,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
     roundrobin:
       type: roundrobin
@@ -231,9 +212,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
     routing:
       type: routing
@@ -248,9 +226,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -300,9 +275,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       fields:
         type: map
@@ -373,10 +345,6 @@ components:
         metrics: alpha
         profiles: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -408,10 +376,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -481,9 +445,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       fields:
         type: map
@@ -806,10 +767,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     otelarrow:
       type: otelarrow
@@ -821,9 +778,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -1095,11 +1049,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       deprecated: renamed to "otlp_grpc" upstream; the old name still resolves for now
       aliasOf: otlp_grpc
@@ -1241,11 +1190,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       alias: otlp
       fields:
@@ -1406,11 +1350,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       alias: otlphttp
       fields:
@@ -1592,11 +1531,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       deprecated: renamed to "otlp_http" upstream; the old name still resolves for now
       aliasOf: otlp_http
@@ -1772,9 +1706,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -1794,9 +1725,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -1831,9 +1759,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -1862,9 +1787,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -1904,9 +1826,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -1940,10 +1859,6 @@ components:
       type: health_check
       stability:
         extension: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -2334,9 +2249,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -2347,9 +2259,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -2678,9 +2587,6 @@ components:
       type: k8s_leader_elector
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
       fields:
         type: map
@@ -2712,9 +2618,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -2746,9 +2649,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -2882,9 +2782,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -2943,9 +2840,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -3155,10 +3049,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -3187,10 +3077,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -3323,10 +3209,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -3588,10 +3470,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -3620,9 +3498,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       fields:
         type: map
@@ -3694,9 +3569,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -3711,9 +3583,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -3737,10 +3606,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -4327,9 +4192,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -4347,9 +4209,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -4376,9 +4235,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -4409,9 +4265,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       alias: k8sattributes
       fields:
@@ -4588,9 +4441,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       deprecated: renamed to "k8s_attributes" upstream; the old name still resolves for now
       aliasOf: k8s_attributes
@@ -4762,9 +4612,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       fields:
         type: map
@@ -4803,10 +4650,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -4834,9 +4677,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       fields:
         type: map
@@ -4936,10 +4776,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -4978,9 +4814,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -5144,9 +4977,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -5327,10 +5157,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -5382,9 +5208,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       fields:
         type: map
@@ -6936,9 +6759,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -7951,9 +7771,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -8055,9 +7872,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
       alias: filelog
       fields:
@@ -8217,9 +8031,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
       deprecated: renamed to "file_log" upstream; the old name still resolves for now
       aliasOf: file_log
@@ -8380,9 +8191,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       fields:
         type: map
@@ -8399,10 +8207,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       fields:
         type: map
@@ -8429,9 +8233,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       alias: httpcheck
       fields:
@@ -8723,9 +8524,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       deprecated: renamed to "http_check" upstream; the old name still resolves for now
       aliasOf: http_check
@@ -9018,10 +8816,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -9750,9 +9544,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
       fields:
         type: map
@@ -9844,9 +9635,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -11556,9 +11344,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -11591,9 +11376,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       fields:
         type: map
@@ -11666,9 +11448,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       fields:
         type: map
@@ -12618,9 +12397,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -12944,11 +12720,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -13133,10 +12904,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -13490,9 +13257,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -13527,10 +13291,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/k8s/v0.157.0.json
+++ b/schemas/k8s/v0.157.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.157.0",
   "distribution": "k8s",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:07:26Z",
+  "generatedAt": "2026-08-02T13:15:54Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -37,10 +33,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector",
         "fields": {
@@ -89,10 +81,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector",
         "fields": {
@@ -149,10 +137,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector",
         "fields": {
@@ -280,11 +264,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/connector/forwardconnector"
       },
       "otlp_json": {
@@ -307,10 +286,6 @@
             "from": "logs",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector",
         "alias": "otlpjson"
@@ -335,10 +310,6 @@
             "from": "logs",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector",
         "deprecated": "renamed to \"otlp_json\" upstream; the old name still resolves for now",
@@ -365,10 +336,6 @@
             "to": "traces"
           }
         ],
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector",
         "alias": "roundrobin"
       },
@@ -392,10 +359,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector",
         "deprecated": "renamed to \"round_robin\" upstream; the old name still resolves for now",
@@ -421,10 +384,6 @@
             "from": "traces",
             "to": "traces"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector",
         "fields": {
@@ -496,10 +455,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "alias": "servicegraph",
@@ -594,10 +549,6 @@
             "from": "traces",
             "to": "metrics"
           }
-        ],
-        "distributions": [
-          "contrib",
-          "k8s"
         ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector",
         "deprecated": "renamed to \"service_graph\" upstream; the old name still resolves for now",
@@ -699,11 +650,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/debugexporter",
         "fields": {
           "type": "map",
@@ -745,11 +691,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter",
         "fields": {
           "type": "map",
@@ -852,10 +793,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "alias": "loadbalancing",
         "fields": {
@@ -1338,10 +1275,6 @@
           "metrics": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
         "deprecated": "renamed to \"load_balancing\" upstream; the old name still resolves for now",
         "aliasOf": "load_balancing",
@@ -1827,11 +1760,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/nopexporter"
       },
       "otelarrow": {
@@ -1846,10 +1774,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter",
         "fields": {
           "type": "map",
@@ -2232,12 +2156,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "deprecated": "renamed to \"otlp_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_grpc",
@@ -2440,12 +2358,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "alias": "otlp",
         "fields": {
@@ -2768,12 +2680,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "alias": "otlphttp",
         "fields": {
@@ -3135,12 +3041,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "deprecated": "renamed to \"otlp_http\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_http",
@@ -3496,10 +3396,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension",
         "fields": {
           "type": "map",
@@ -3526,10 +3422,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension",
         "fields": {
           "type": "map",
@@ -3578,10 +3470,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension",
         "fields": {
           "type": "map",
@@ -3621,10 +3509,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage",
         "fields": {
           "type": "map",
@@ -3687,10 +3571,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension",
         "fields": {
           "type": "map",
@@ -3740,11 +3620,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension",
         "fields": {
           "type": "map",
@@ -4373,10 +4248,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver",
         "fields": {
           "type": "map",
@@ -4392,10 +4263,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension",
         "fields": {
           "type": "map",
@@ -4873,10 +4740,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector",
         "fields": {
           "type": "map",
@@ -4921,10 +4784,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver",
         "fields": {
           "type": "map",
@@ -4972,10 +4831,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension",
         "fields": {
           "type": "map",
@@ -5162,10 +5017,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension",
         "fields": {
           "type": "map",
@@ -5250,10 +5101,6 @@
         "stability": {
           "extension": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension",
         "fields": {
           "type": "map",
@@ -5553,11 +5400,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension",
         "fields": {
           "type": "map",
@@ -5597,11 +5439,6 @@
         "stability": {
           "extension": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/extension/zpagesextension",
         "fields": {
           "type": "map",
@@ -5872,11 +5709,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor",
         "fields": {
           "type": "map",
@@ -6249,11 +6081,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/batchprocessor",
         "fields": {
           "type": "map",
@@ -6294,10 +6121,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "alias": "cumulativetodelta",
         "fields": {
@@ -6403,10 +6226,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor",
         "deprecated": "renamed to \"cumulative_to_delta\" upstream; the old name still resolves for now",
         "aliasOf": "cumulative_to_delta",
@@ -6513,10 +6332,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor",
         "fields": {
           "type": "map",
@@ -6538,10 +6353,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor",
         "fields": {
           "type": "map",
@@ -6567,10 +6378,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor",
         "fields": {
           "type": "map",
@@ -6650,11 +6457,6 @@
           "profiles": "development",
           "traces": "alpha"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor",
         "fields": {
           "type": "map",
@@ -7509,10 +7311,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor",
         "fields": {
           "type": "map",
@@ -7538,10 +7336,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor",
         "fields": {
           "type": "map",
@@ -7578,10 +7372,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor",
         "fields": {
           "type": "map",
@@ -7622,10 +7412,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "alias": "k8sattributes",
         "fields": {
@@ -7881,10 +7667,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor",
         "deprecated": "renamed to \"k8s_attributes\" upstream; the old name still resolves for now",
         "aliasOf": "k8s_attributes",
@@ -8135,10 +7917,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "alias": "logdedup",
         "fields": {
@@ -8201,10 +7979,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor",
         "deprecated": "renamed to \"log_dedup\" upstream; the old name still resolves for now",
         "aliasOf": "log_dedup",
@@ -8274,11 +8048,6 @@
           "profiles": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "go.opentelemetry.io/collector/processor/memorylimiterprocessor",
         "fields": {
           "type": "map",
@@ -8317,10 +8086,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "alias": "metricstransform",
         "fields": {
@@ -8459,10 +8224,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor",
         "deprecated": "renamed to \"metrics_transform\" upstream; the old name still resolves for now",
         "aliasOf": "metrics_transform",
@@ -8604,11 +8365,6 @@
           "logs": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor",
         "fields": {
           "type": "map",
@@ -8660,10 +8416,6 @@
           "metrics": "alpha",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor",
         "fields": {
           "type": "map",
@@ -8907,10 +8659,6 @@
           "metrics": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor",
         "fields": {
           "type": "map",
@@ -9176,11 +8924,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor",
         "fields": {
           "type": "map",
@@ -9249,10 +8992,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "alias": "resourcedetection",
         "fields": {
@@ -11755,10 +11494,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor",
         "deprecated": "renamed to \"resource_detection\" upstream; the old name still resolves for now",
         "aliasOf": "resource_detection",
@@ -14256,10 +13991,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor",
         "fields": {
           "type": "map",
@@ -16401,10 +16132,6 @@
           "profiles": "development",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor",
         "fields": {
           "type": "map",
@@ -16562,10 +16289,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver",
         "alias": "filelog",
         "fields": {
@@ -16806,10 +16529,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver",
         "deprecated": "renamed to \"file_log\" upstream; the old name still resolves for now",
         "aliasOf": "file_log",
@@ -17051,10 +16770,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "alias": "fluentforward",
         "fields": {
@@ -17076,10 +16791,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver",
         "deprecated": "renamed to \"fluent_forward\" upstream; the old name still resolves for now",
         "aliasOf": "fluent_forward",
@@ -17104,11 +16815,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "alias": "hostmetrics",
         "fields": {
@@ -17165,11 +16871,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver",
         "deprecated": "renamed to \"host_metrics\" upstream; the old name still resolves for now",
         "aliasOf": "host_metrics",
@@ -17225,10 +16926,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "alias": "httpcheck",
         "fields": {
@@ -17899,10 +17596,6 @@
         "stability": {
           "metrics": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver",
         "deprecated": "renamed to \"http_check\" upstream; the old name still resolves for now",
         "aliasOf": "http_check",
@@ -18574,11 +18267,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver",
         "fields": {
           "type": "map",
@@ -19676,10 +19364,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver",
         "fields": {
           "type": "map",
@@ -19817,10 +19501,6 @@
           "logs": "development",
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver",
         "fields": {
           "type": "map",
@@ -22758,10 +22438,6 @@
         "stability": {
           "logs": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver",
         "fields": {
           "type": "map",
@@ -22816,10 +22492,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "alias": "k8sobjects",
         "fields": {
@@ -22938,10 +22610,6 @@
         "stability": {
           "logs": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver",
         "deprecated": "renamed to \"k8s_objects\" upstream; the old name still resolves for now",
         "aliasOf": "k8s_objects",
@@ -23061,10 +22729,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "alias": "kubeletstats",
         "fields": {
@@ -24667,10 +24331,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
         "deprecated": "renamed to \"kubelet_stats\" upstream; the old name still resolves for now",
         "aliasOf": "kubelet_stats",
@@ -26278,10 +25938,6 @@
           "metrics": "beta",
           "traces": "beta"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver",
         "fields": {
           "type": "map",
@@ -26757,12 +26413,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",
@@ -27039,11 +26689,6 @@
         "stability": {
           "metrics": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
         "fields": {
           "type": "map",
@@ -28740,10 +28385,6 @@
           "profiles": "alpha",
           "traces": "alpha"
         },
-        "distributions": [
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator",
         "fields": {
           "type": "map",
@@ -28797,11 +28438,6 @@
         "stability": {
           "traces": "beta"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s"
-        ],
         "module": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver",
         "fields": {
           "type": "map",

--- a/schemas/k8s/v0.157.0.yaml
+++ b/schemas/k8s/v0.157.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.157.0
 distribution: k8s
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:07:26Z"
+generatedAt: "2026-08-02T13:15:54Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -25,9 +22,6 @@ components:
           to: metrics
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
       fields:
         type: map
@@ -61,9 +55,6 @@ components:
           to: logs
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
       fields:
         type: map
@@ -100,9 +91,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
       fields:
         type: map
@@ -190,10 +178,6 @@ components:
           to: profiles
         - from: traces
           to: traces
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/connector/forwardconnector
     otlp_json:
       type: otlp_json
@@ -208,9 +192,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
       alias: otlpjson
     otlpjson:
@@ -226,9 +207,6 @@ components:
           to: metrics
         - from: logs
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
       deprecated: renamed to "otlp_json" upstream; the old name still resolves for now
       aliasOf: otlp_json
@@ -245,9 +223,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
       alias: roundrobin
     roundrobin:
@@ -263,9 +238,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
       deprecated: renamed to "round_robin" upstream; the old name still resolves for now
       aliasOf: round_robin
@@ -282,9 +254,6 @@ components:
           to: metrics
         - from: traces
           to: traces
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
       fields:
         type: map
@@ -334,9 +303,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       alias: servicegraph
       fields:
@@ -402,9 +368,6 @@ components:
       pairs:
         - from: traces
           to: metrics
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
       deprecated: renamed to "service_graph" upstream; the old name still resolves for now
       aliasOf: service_graph
@@ -477,10 +440,6 @@ components:
         metrics: alpha
         profiles: alpha
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/debugexporter
       fields:
         type: map
@@ -512,10 +471,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
       fields:
         type: map
@@ -591,9 +546,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       alias: loadbalancing
       fields:
@@ -921,9 +873,6 @@ components:
         logs: beta
         metrics: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
       deprecated: renamed to "load_balancing" upstream; the old name still resolves for now
       aliasOf: load_balancing
@@ -1254,10 +1203,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/exporter/nopexporter
     otelarrow:
       type: otelarrow
@@ -1269,9 +1214,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
       fields:
         type: map
@@ -1548,11 +1490,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       deprecated: renamed to "otlp_grpc" upstream; the old name still resolves for now
       aliasOf: otlp_grpc
@@ -1694,11 +1631,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       alias: otlp
       fields:
@@ -1932,11 +1864,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       alias: otlphttp
       fields:
@@ -2200,11 +2127,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       deprecated: renamed to "otlp_http" upstream; the old name still resolves for now
       aliasOf: otlp_http
@@ -2462,9 +2384,6 @@ components:
       type: ack
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
       fields:
         type: map
@@ -2484,9 +2403,6 @@ components:
       type: basicauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
       fields:
         type: map
@@ -2521,9 +2437,6 @@ components:
       type: bearertokenauth
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
       fields:
         type: map
@@ -2552,9 +2465,6 @@ components:
       type: file_storage
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
       fields:
         type: map
@@ -2596,9 +2506,6 @@ components:
       type: headers_setter
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
       fields:
         type: map
@@ -2632,10 +2539,6 @@ components:
       type: health_check
       stability:
         extension: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       fields:
         type: map
@@ -3042,9 +2945,6 @@ components:
       type: host_observer
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
       fields:
         type: map
@@ -3055,9 +2955,6 @@ components:
       type: http_forwarder
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
       fields:
         type: map
@@ -3396,9 +3293,6 @@ components:
       type: k8s_leader_elector
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
       fields:
         type: map
@@ -3430,9 +3324,6 @@ components:
       type: k8s_observer
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       fields:
         type: map
@@ -3464,9 +3355,6 @@ components:
       type: oauth2client
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       fields:
         type: map
@@ -3602,9 +3490,6 @@ components:
       type: oidc
       stability:
         extension: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       fields:
         type: map
@@ -3666,9 +3551,6 @@ components:
       type: opamp
       stability:
         extension: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
       fields:
         type: map
@@ -3882,10 +3764,6 @@ components:
       type: pprof
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       fields:
         type: map
@@ -3914,10 +3792,6 @@ components:
       type: zpages
       stability:
         extension: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/extension/zpagesextension
       fields:
         type: map
@@ -4108,10 +3982,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
       fields:
         type: map
@@ -4373,10 +4243,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/batchprocessor
       fields:
         type: map
@@ -4405,9 +4271,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       alias: cumulativetodelta
       fields:
@@ -4480,9 +4343,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
       deprecated: renamed to "cumulative_to_delta" upstream; the old name still resolves for now
       aliasOf: cumulative_to_delta
@@ -4556,9 +4416,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
       fields:
         type: map
@@ -4573,9 +4430,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
       fields:
         type: map
@@ -4593,9 +4447,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor
       fields:
         type: map
@@ -4650,10 +4501,6 @@ components:
         metrics: alpha
         profiles: development
         traces: alpha
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
       fields:
         type: map
@@ -5240,9 +5087,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
       fields:
         type: map
@@ -5260,9 +5104,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
       fields:
         type: map
@@ -5289,9 +5130,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
       fields:
         type: map
@@ -5322,9 +5160,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       alias: k8sattributes
       fields:
@@ -5507,9 +5342,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
       deprecated: renamed to "k8s_attributes" upstream; the old name still resolves for now
       aliasOf: k8s_attributes
@@ -5687,9 +5519,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       alias: logdedup
       fields:
@@ -5731,9 +5560,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
       deprecated: renamed to "log_dedup" upstream; the old name still resolves for now
       aliasOf: log_dedup
@@ -5782,10 +5608,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: go.opentelemetry.io/collector/processor/memorylimiterprocessor
       fields:
         type: map
@@ -5813,9 +5635,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       alias: metricstransform
       fields:
@@ -5914,9 +5733,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
       deprecated: renamed to "metrics_transform" upstream; the old name still resolves for now
       aliasOf: metrics_transform
@@ -6018,10 +5834,6 @@ components:
       stability:
         logs: alpha
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
       fields:
         type: map
@@ -6060,9 +5872,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
       fields:
         type: map
@@ -6226,9 +6035,6 @@ components:
         logs: alpha
         metrics: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
       fields:
         type: map
@@ -6417,10 +6223,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
       fields:
         type: map
@@ -6472,9 +6274,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       alias: resourcedetection
       fields:
@@ -8074,9 +7873,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
       deprecated: renamed to "resource_detection" upstream; the old name still resolves for now
       aliasOf: resource_detection
@@ -9671,9 +9467,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
       fields:
         type: map
@@ -11175,9 +10968,6 @@ components:
         metrics: beta
         profiles: development
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
       fields:
         type: map
@@ -11279,9 +11069,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
       alias: filelog
       fields:
@@ -11443,9 +11230,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
       deprecated: renamed to "file_log" upstream; the old name still resolves for now
       aliasOf: file_log
@@ -11608,9 +11392,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       alias: fluentforward
       fields:
@@ -11626,9 +11407,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
       deprecated: renamed to "fluent_forward" upstream; the old name still resolves for now
       aliasOf: fluent_forward
@@ -11647,10 +11425,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       alias: hostmetrics
       fields:
@@ -11695,10 +11469,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
       deprecated: renamed to "host_metrics" upstream; the old name still resolves for now
       aliasOf: host_metrics
@@ -11742,9 +11512,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       alias: httpcheck
       fields:
@@ -12216,9 +11983,6 @@ components:
         - metrics
       stability:
         metrics: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
       deprecated: renamed to "http_check" upstream; the old name still resolves for now
       aliasOf: http_check
@@ -12691,10 +12455,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
       fields:
         type: map
@@ -13443,9 +13203,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
       fields:
         type: map
@@ -13539,9 +13296,6 @@ components:
       stability:
         logs: development
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
       fields:
         type: map
@@ -15507,9 +15261,6 @@ components:
         - logs
       stability:
         logs: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
       fields:
         type: map
@@ -15549,9 +15300,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       alias: k8sobjects
       fields:
@@ -15632,9 +15380,6 @@ components:
         - logs
       stability:
         logs: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
       deprecated: renamed to "k8s_objects" upstream; the old name still resolves for now
       aliasOf: k8s_objects
@@ -15716,9 +15461,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       alias: kubeletstats
       fields:
@@ -16801,9 +16543,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
       deprecated: renamed to "kubelet_stats" upstream; the old name still resolves for now
       aliasOf: kubelet_stats
@@ -17891,9 +17630,6 @@ components:
         logs: beta
         metrics: beta
         traces: beta
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
       fields:
         type: map
@@ -18219,11 +17955,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map
@@ -18408,10 +18139,6 @@ components:
         - metrics
       stability:
         metrics: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       fields:
         type: map
@@ -19632,9 +19359,6 @@ components:
         metrics: beta
         profiles: alpha
         traces: alpha
-      distributions:
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
       fields:
         type: map
@@ -19671,10 +19395,6 @@ components:
         - traces
       stability:
         traces: beta
-      distributions:
-        - core
-        - contrib
-        - k8s
       module: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
       fields:
         type: map

--- a/schemas/otlp/v0.120.0.json
+++ b/schemas/otlp/v0.120.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.120.0",
   "distribution": "otlp",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:37Z",
+  "generatedAt": "2026-08-02T13:15:51Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -26,12 +22,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -232,12 +222,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -445,12 +429,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",

--- a/schemas/otlp/v0.120.0.yaml
+++ b/schemas/otlp/v0.120.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.120.0
 distribution: otlp
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:37Z"
+generatedAt: "2026-08-02T13:15:51Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -21,11 +18,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -165,11 +157,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -308,11 +295,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map

--- a/schemas/otlp/v0.130.0.json
+++ b/schemas/otlp/v0.130.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.130.0",
   "distribution": "otlp",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:38Z",
+  "generatedAt": "2026-08-02T13:15:52Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -26,12 +22,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -232,12 +222,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -501,12 +485,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",

--- a/schemas/otlp/v0.130.0.yaml
+++ b/schemas/otlp/v0.130.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.130.0
 distribution: otlp
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:38Z"
+generatedAt: "2026-08-02T13:15:52Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -21,11 +18,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -165,11 +157,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -345,11 +332,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map

--- a/schemas/otlp/v0.140.0.json
+++ b/schemas/otlp/v0.140.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.140.0",
   "distribution": "otlp",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:39Z",
+  "generatedAt": "2026-08-02T13:15:53Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -26,12 +22,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "fields": {
           "type": "map",
@@ -232,12 +222,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "fields": {
           "type": "map",
@@ -504,12 +488,6 @@
           "profiles": "development",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",

--- a/schemas/otlp/v0.140.0.yaml
+++ b/schemas/otlp/v0.140.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.140.0
 distribution: otlp
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:39Z"
+generatedAt: "2026-08-02T13:15:53Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -21,11 +18,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       fields:
         type: map
@@ -165,11 +157,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       fields:
         type: map
@@ -347,11 +334,6 @@ components:
         metrics: stable
         profiles: development
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map

--- a/schemas/otlp/v0.150.0.json
+++ b/schemas/otlp/v0.150.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.150.0",
   "distribution": "otlp",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:05:39Z",
+  "generatedAt": "2026-08-02T13:15:53Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -26,12 +22,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "deprecated": "renamed to \"otlp_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_grpc",
@@ -234,12 +224,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "alias": "otlp",
         "fields": {
@@ -480,12 +464,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "alias": "otlphttp",
         "fields": {
@@ -757,12 +735,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "deprecated": "renamed to \"otlp_http\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_http",
@@ -1037,12 +1009,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",

--- a/schemas/otlp/v0.150.0.yaml
+++ b/schemas/otlp/v0.150.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.150.0
 distribution: otlp
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:05:39Z"
+generatedAt: "2026-08-02T13:15:53Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -21,11 +18,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       deprecated: renamed to "otlp_grpc" upstream; the old name still resolves for now
       aliasOf: otlp_grpc
@@ -167,11 +159,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       alias: otlp
       fields:
@@ -332,11 +319,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       alias: otlphttp
       fields:
@@ -518,11 +500,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       deprecated: renamed to "otlp_http" upstream; the old name still resolves for now
       aliasOf: otlp_http
@@ -706,11 +683,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map

--- a/schemas/otlp/v0.157.0.json
+++ b/schemas/otlp/v0.157.0.json
@@ -1,11 +1,7 @@
 {
   "collectorVersion": "v0.157.0",
   "distribution": "otlp",
-  "distributions": [
-    "core",
-    "contrib"
-  ],
-  "generatedAt": "2026-08-02T13:07:26Z",
+  "generatedAt": "2026-08-02T13:15:54Z",
   "sources": {
     "contrib": "github.com/open-telemetry/opentelemetry-collector-contrib",
     "core": "go.opentelemetry.io/collector"
@@ -26,12 +22,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "deprecated": "renamed to \"otlp_grpc\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_grpc",
@@ -234,12 +224,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlpexporter",
         "alias": "otlp",
         "fields": {
@@ -562,12 +546,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "alias": "otlphttp",
         "fields": {
@@ -929,12 +907,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/exporter/otlphttpexporter",
         "deprecated": "renamed to \"otlp_http\" upstream; the old name still resolves for now",
         "aliasOf": "otlp_http",
@@ -1299,12 +1271,6 @@
           "profiles": "alpha",
           "traces": "stable"
         },
-        "distributions": [
-          "core",
-          "contrib",
-          "k8s",
-          "otlp"
-        ],
         "module": "go.opentelemetry.io/collector/receiver/otlpreceiver",
         "fields": {
           "type": "map",

--- a/schemas/otlp/v0.157.0.yaml
+++ b/schemas/otlp/v0.157.0.yaml
@@ -1,9 +1,6 @@
 collectorVersion: v0.157.0
 distribution: otlp
-distributions:
-  - core
-  - contrib
-generatedAt: "2026-08-02T13:07:26Z"
+generatedAt: "2026-08-02T13:15:54Z"
 sources:
   contrib: github.com/open-telemetry/opentelemetry-collector-contrib
   core: go.opentelemetry.io/collector
@@ -21,11 +18,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       deprecated: renamed to "otlp_grpc" upstream; the old name still resolves for now
       aliasOf: otlp_grpc
@@ -167,11 +159,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlpexporter
       alias: otlp
       fields:
@@ -405,11 +392,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       alias: otlphttp
       fields:
@@ -673,11 +655,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/exporter/otlphttpexporter
       deprecated: renamed to "otlp_http" upstream; the old name still resolves for now
       aliasOf: otlp_http
@@ -943,11 +920,6 @@ components:
         metrics: stable
         profiles: alpha
         traces: stable
-      distributions:
-        - core
-        - contrib
-        - k8s
-        - otlp
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
       fields:
         type: map

--- a/tools/schemagen/main.go
+++ b/tools/schemagen/main.go
@@ -247,7 +247,13 @@ func filterDistribution(cat *schema.Schema, dist string) *schema.Schema {
 				out.Components[kind] = map[string]*schema.Component{}
 			}
 
-			out.Components[kind][typ] = comp
+			// The written component drops the distribution list: the
+			// directory it lands in already says which binary ships it. The
+			// copy matters because the merged catalogue is filtered once per
+			// distribution and still needs the list.
+			written := *comp
+			written.Distributions = nil
+			out.Components[kind][typ] = &written
 		}
 	}
 
@@ -362,7 +368,6 @@ func build(client *http.Client, version, cacheDir string) (*schema.Schema, error
 			return nil, err
 		}
 
-		cat.Distributions = append(cat.Distributions, src.name)
 		cat.Sources[src.name] = src.module
 		logf("  %s: %d components\n", src.name, n)
 	}


### PR DESCRIPTION
Two defects, both turned up by your question about why components carry a `distributions` field.

## `list versions` answered the wrong question

Asked for `core`, it replied `core+contrib`:

```
$ otelcol-config-lint list versions --distribution core
v0.157.0  32 components  core+contrib (latest)     # before
v0.157.0  32 components  core (latest)             # after
```

It printed `Schema.Distributions` — which upstream *repositories* were harvested — rather than `Schema.Distribution`, the binary the file describes. Two near-identical names for different things, and the listing reached for the wrong one.

`Schema.Distributions` is **removed rather than renamed**: it was assembled one line away from `Sources` and held exactly its keys, so it never said anything `Sources` did not.

```go
cat.Distributions = append(cat.Distributions, src.name)   // deleted
cat.Sources[src.name] = src.module                        // already had it
```

## Components no longer carry a distribution list

It is what schemagen splits a release on, but once split the **directory names the distribution**, so the field could only restate the path or contradict it — a component in `schemas/core/` tagged `[core, contrib, k8s]`.

Nothing read it. The runtime answer to "where does this ship?" comes from `DistributionIndex`, which reads the sibling files. It could not serve the `--distribution` hint either, since that question is about a component *absent* from the file, and a field on the present ones cannot answer it.

The written component is a copy with the list cleared — the merged catalogue is filtered once per distribution and still needs it during generation.

## Effect

`73 insertions, 13,794 deletions` — almost entirely the redundant field leaving 50 schema files. The registry drops 35MB → 34MB, which was never the argument; a field that can silently disagree with the directory holding it is worth more gone than kept.

`go test ./...` and `golangci-lint run` clean. Field coverage unchanged (v0.157.0 310/323, v0.150.0 274/285), `testdata/valid` still lints clean, and all three distributions now report themselves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)