### PR TITLE
fix(schemagen): take the release from what the components are pinned at

### DIFF
--- a/pkg/cmd/schemagen/builder.go
+++ b/pkg/cmd/schemagen/builder.go
@@ -125,15 +125,50 @@ func readManifest(path, name string) (*manifest, error) {
 }
 
 // collectorVersion is the upstream release the distribution is built from,
-// which is what the schema is filed under. A manifest that only carries its own
-// version is taken at its word: for the upstream release manifests the two are
-// the same number.
+// which is what the schema is filed under and what a config is checked against.
+//
+// dist.version is asked last because it is the distribution's own number, not
+// the collector's: a vendor's build has a version of its own, and even
+// upstream's release manifests lag -- at the v0.150.0 tag they still read
+// 0.149.0 while every component is pinned at v0.150.0. What the components are
+// pinned at is the release, so that is the better answer.
 func (m *manifest) collectorVersion() string {
 	if m.Dist.OtelColVersion != "" {
 		return schema.Normalize(m.Dist.OtelColVersion)
 	}
 
+	if pinned := m.pinnedVersion(); pinned != "" {
+		return schema.Normalize(pinned)
+	}
+
 	return schema.Normalize(m.Dist.Version)
+}
+
+// pinnedVersion is the release the collector's own components are pinned at:
+// the most common one among them. Only the 0.x line is counted, since the
+// modules that reached 1.0 -- pdata, component, config -- carry a version of
+// their own that is not the release.
+func (m *manifest) pinnedVersion() string {
+	counts := map[string]int{}
+
+	best, seen := "", 0
+
+	for _, decl := range m.components() {
+		if !strings.HasPrefix(decl.module, coreModuleRoot+"/") ||
+			!strings.HasPrefix(decl.version, "v0.") {
+			continue
+		}
+
+		counts[decl.version]++
+
+		// Ties keep the version already chosen, which the ordering of
+		// components() makes deterministic.
+		if counts[decl.version] > seen {
+			best, seen = decl.version, counts[decl.version]
+		}
+	}
+
+	return best
 }
 
 // components lists every declared component, in kind order.

--- a/pkg/cmd/schemagen/fields.go
+++ b/pkg/cmd/schemagen/fields.go
@@ -95,11 +95,15 @@ func repositoryPath(importPath string) (string, bool) {
 	return "", false
 }
 
+// coreModuleRoot is the module prefix of the collector itself, whose release is
+// the one a config is written against.
+const coreModuleRoot = "go.opentelemetry.io/collector"
+
 // repositoryRoots are the module prefixes of the repositories whose published
 // schemas reference each other repository-absolutely.
 func repositoryRoots() []string {
 	return []string{
-		"go.opentelemetry.io/collector",
+		coreModuleRoot,
 		"github.com/open-telemetry/opentelemetry-collector-contrib",
 	}
 }

--- a/pkg/cmd/schemagen/schemagen_test.go
+++ b/pkg/cmd/schemagen/schemagen_test.go
@@ -220,6 +220,55 @@ replaces:
 	}
 }
 
+// TestCollectorVersion covers where the release a schema is filed under comes
+// from. Upstream's own release manifests carry a dist.version that lags the tag
+// -- 0.149.0 at the v0.150.0 tag -- so what the collector's components are
+// pinned at decides, and dist.otelcol_version overrides everything when set.
+func TestCollectorVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		dist string
+		want string
+	}{
+		"pinned components win over a lagging dist.version": {
+			dist: "  name: custom\n  version: 0.149.0",
+			want: "collectorVersion: v0.150.0",
+		},
+		"otelcol_version wins over both": {
+			dist: "  name: custom\n  version: 0.149.0\n  otelcol_version: 0.157.0",
+			want: "collectorVersion: v0.157.0",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			dir := module(t, root, "go.opentelemetry.io/collector/receiver/otlpreceiver", map[string]string{
+				"metadata.yaml": "type: otlp\nstatus:\n  class: receiver\n" +
+					"  stability:\n    beta: [traces]\n",
+			})
+
+			path := filepath.Join(root, "manifest.yaml")
+			writeFile(t, path, fmt.Sprintf(`
+dist:
+%s
+receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.150.0
+replaces:
+  - go.opentelemetry.io/collector/receiver/otlpreceiver => %s
+`, tt.dist, dir))
+
+			code, stdout, stderr := run(t, "--builder", path, "--cache", t.TempDir())
+
+			require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+			assert.Contains(t, stdout, tt.want)
+		})
+	}
+}
+
 // TestTextualType covers a setting whose Go type is a number but whose config
 // spelling is a word: configtelemetry.Level is an int32 with an UnmarshalText
 // method, and the debug exporter's "verbosity: detailed" is not an integer.


### PR DESCRIPTION
Regenerating the older registry versions turned this up. Upstream's release
manifests carry a `dist.version` that lags their own tag: at the `v0.150.0` tag
all four `distributions/*/manifest.yaml` still read

```yaml
dist:
  version: 0.149.0
```

while every component in them is pinned at `v0.150.0`. schemagen filed the
schema under `v0.149.0` — a release that has no schemas, under a name nothing
would ask for.

`dist.version` is now asked last, because it is the *distribution's* number and
not the collector's: a vendor's build has a version of its own. The release is
taken from what the collector's own components are pinned at, counting only the
0.x line so the modules that reached 1.0 (`pdata`, `component`, `config`, all
`v1.56.0` here) do not answer for it. `dist.otelcol_version` still wins when a
manifest sets it.

Verified against the real v0.150.0 manifests: `collectorVersion: v0.150.0`,
29 components for core. v0.157.0 is unaffected — its `dist.version` and its
pinned components agree, so it filed correctly before and still does.

`go test -race ./...`, `golangci-lint run` (0 issues) and `gofmt -l` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)