### PR TITLE
feat(ci): generate schemas for new collector releases every week

### DIFF
--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -1,32 +1,139 @@
 name: schemas
 
-# Generates the schemas for one collector release and opens a pull request
-# against the schema registry. Schemas are data, not code, so they land as a
-# reviewable commit there rather than being pushed straight to main.
+# Generates the schemas for a collector release and opens a pull request against
+# the schema registry. Schemas are data, not code, so they land as a reviewable
+# commit there rather than being pushed straight to main.
 #
 # What each distribution ships is read from the builder manifests upstream
 # releases it with, so the schemas describe the binaries as built.
+#
+# The weekly run is what keeps the registry current. A release with no schema is
+# not a gap the linter reports: "--collector-version v0.158.0" quietly falls back
+# to the newest release it does have and checks the config against the wrong
+# component set, so the registry has to keep up on its own rather than when
+# somebody remembers.
 on:
+  schedule:
+    # Upstream tags roughly every other week, on no fixed day; weekly picks each
+    # release up within a few days of it appearing.
+    - cron: "17 6 * * 1"
   workflow_dispatch:
     inputs:
       version:
-        description: Collector release, e.g. v0.158.0
-        required: true
+        description: Collector release, e.g. v0.158.0. Empty generates whatever the registry is behind on.
+        required: false
         type: string
 
 permissions:
   contents: read
 
+env:
+  REGISTRY: minuk-dev/otelcol-config-schemas
+  # The published registry, read to work out which releases it is behind on.
+  # Reading main directly keeps discovery to a couple of requests; the generate
+  # job checks the repository out properly.
+  INDEX_URL: https://raw.githubusercontent.com/minuk-dev/otelcol-config-schemas/main/index.json
+  # How many missing releases one run generates. A run opens a pull request per
+  # release, so this is also how many arrive at once; a longer backlog is caught
+  # up over the following weeks, or by dispatching a version by hand.
+  MAX_RELEASES: 3
+  # Retention. Every release is a few megabytes across four distributions and
+  # two formats, and upstream tags every other week, so the registry is kept to
+  # a window: the newest RETAIN releases, plus every RETAIN_EVERY-th minor for
+  # good, so a config pinned to a round release keeps resolving long after its
+  # neighbours are gone.
+  RETAIN: 24
+  RETAIN_EVERY: 10
+
 jobs:
-  generate:
+  # Which releases the registry is behind on. It is a job of its own so the
+  # expensive half -- resolving four distributions' module graphs -- runs only
+  # when there is something to generate, and so a run that finds nothing new is
+  # a clean no-op rather than an empty pull request.
+  discover:
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.pick.outputs.versions }}
+    steps:
+      - name: Pick the releases to generate
+        id: pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          # A dispatched version is generated as asked, present or not: asking
+          # for one by hand is how a schema is corrected in place.
+          if [ -n "${INPUT_VERSION}" ]; then
+            printf 'versions=["%s"]\n' "${INPUT_VERSION}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # Upstream's release tags. opentelemetry-collector-releases is tagged
+          # once per collector release and carries every distribution's
+          # manifest, so there is one tag to wait for rather than several that
+          # may not appear together. Its cmd/* tags are not collector releases.
+          gh api 'repos/open-telemetry/opentelemetry-collector-releases/releases?per_page=100' \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' |
+            grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -u > tags.txt
+
+          # The newest release the registry serves. contrib is written by every
+          # run and is the distribution a config is checked against by default,
+          # so it is what "up to date" is measured against.
+          curl -fsSL "${INDEX_URL}" > index.json
+          have="$(jq -r '.distributions.contrib[]' index.json | sort -V | tail -1)"
+          echo "the registry is at ${have}"
+
+          # Everything tagged after it, oldest first. Only releases newer than
+          # the registry's newest are generated: a gap further back is a
+          # retention decision, not something to backfill, and each schema is
+          # summarised against the release before it, so generating them in
+          # order is what makes those summaries describe one release each.
+          printf '%s\n' "${have}" >> tags.txt
+          missing="$(sort -V -u tags.txt | sed -n "/^${have}\$/,\$p" | tail -n +2 | head -n "${MAX_RELEASES}")"
+
+          # The releases repository is tagged after core and contrib are, so a
+          # tag there already implies both. Checking anyway costs two requests
+          # a release and keeps a half-empty schema out of the registry if
+          # upstream ever changes the order.
+          ready=""
+          for version in ${missing}; do
+            for repo in opentelemetry-collector opentelemetry-collector-contrib; do
+              if ! gh api "repos/open-telemetry/${repo}/git/ref/tags/${version}" >/dev/null 2>&1; then
+                echo "${version}: ${repo} is not tagged yet, leaving it for a later run"
+                continue 2
+              fi
+            done
+            ready="${ready}${version}"$'\n'
+          done
+
+          versions="$(printf '%s' "${ready}" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+          echo "generating ${versions}"
+          echo "versions=${versions}" >> "${GITHUB_OUTPUT}"
+
+  generate:
+    needs: discover
+    # An empty matrix fails the job rather than skipping it, and nothing new is
+    # the ordinary weekly outcome.
+    if: needs.discover.outputs.versions != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      # One pull request per release keeps each diff readable, and a release
+      # that cannot be resolved should not discard the ones after it.
+      fail-fast: false
+      # Each run reads the registry as it stands on main, so releases are
+      # generated one at a time and in order.
+      max-parallel: 1
+      matrix:
+        version: ${{ fromJSON(needs.discover.outputs.versions) }}
     steps:
       - name: Checkout the linter
         uses: actions/checkout@v7
       - name: Checkout the schema registry
         uses: actions/checkout@v7
         with:
-          repository: minuk-dev/otelcol-config-schemas
+          repository: ${{ env.REGISTRY }}
           path: schemas-repo
           # A token with write access to the registry; the default one is
           # scoped to this repository only.
@@ -36,7 +143,7 @@ jobs:
         with:
           repository: open-telemetry/opentelemetry-collector-releases
           path: releases
-          ref: ${{ inputs.version }}
+          ref: ${{ matrix.version }}
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
@@ -54,37 +161,68 @@ jobs:
           # otelcol-contrib, and what a config is linted against is core and
           # contrib.
           go run ./cmd/schemagen --registry schemas-repo \
+            --summary summary.md \
+            --retain "${RETAIN}" --retain-every "${RETAIN_EVERY}" \
             --builder core=releases/distributions/otelcol/manifest.yaml \
             --builder contrib=releases/distributions/otelcol-contrib/manifest.yaml \
             --builder k8s=releases/distributions/otelcol-k8s/manifest.yaml \
             --builder otlp=releases/distributions/otelcol-otlp/manifest.yaml
       - name: Check the generated schemas lint
+        # Only the release just written: the others were checked when they were
+        # generated, and re-reading everything the registry holds is work that
+        # grows with the registry.
         run: |
-          jq -r '.distributions | to_entries[] | .key as $d | .value[] | "\($d) \(.)"' \
+          jq -r --arg version '${{ matrix.version }}' \
+            '.distributions | to_entries[] | select(.value | index($version)) | .key' \
             schemas-repo/index.json |
-          while read -r distribution version; do
+          while read -r distribution; do
             go run ./cmd/otelcol-config-lint run \
               --schema-location schemas-repo --distribution "${distribution}" \
-              --collector-version "${version}" --min-severity error \
+              --collector-version '${{ matrix.version }}' --min-severity error \
               --ignore-missing-schemas testdata/valid
           done
+      - name: Write the pull request body
+        # The diff is several megabytes of generated YAML, so what a reviewer
+        # reads is the summary schemagen produced beside it: the components this
+        # release adds, drops, renames and moves across the beta line.
+        env:
+          VERSION: ${{ matrix.version }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "Generated by [\`cmd/schemagen\`](https://github.com/minuk-dev/otelcol-config-lint/tree/main/cmd/schemagen)"
+            echo "in [run ${RUN_ID}](${RUN_URL}), for \`${VERSION}\`, out of the builder manifests"
+            echo '`opentelemetry-collector-releases` ships at that tag.'
+            echo
+            echo "Every generated file was linted against \`testdata/valid\` before this was"
+            echo "opened, in each distribution it covers."
+            echo
+            echo "## What this release changes"
+            echo
+            cat summary.md
+            echo
+            echo "---"
+            echo
+            echo "Do not edit these by hand; they are regenerated from upstream."
+          } > pr-body.md
       - name: Open a pull request
         uses: peter-evans/create-pull-request@v8
         with:
           path: schemas-repo
           token: ${{ secrets.SCHEMAS_TOKEN }}
-          branch: schemas/${{ inputs.version }}
-          title: "Add schemas for ${{ inputs.version }}"
+          branch: schemas/${{ matrix.version }}
+          title: "Add schemas for ${{ matrix.version }}"
+          # A release that adds components and removes none is safe to merge on
+          # sight; the labels are what an automerge rule in the registry keys
+          # off, the way one would for a dependency bump.
+          labels: |
+            schemas
+            automated
           commit-message: |
-            Add schemas for ${{ inputs.version }}
+            Add schemas for ${{ matrix.version }}
 
             Generated by cmd/schemagen in otelcol-config-lint.
-          body: |
-            Generated by [`cmd/schemagen`](https://github.com/minuk-dev/otelcol-config-lint/tree/main/cmd/schemagen)
-            from run ${{ github.run_id }}, for `${{ inputs.version }}`, out of the
-            builder manifests `opentelemetry-collector-releases` ships.
-
-            Every generated file was linted against `testdata/valid` before this
-            was opened, in each distribution it covers.
-
-            Do not edit these by hand; they are regenerated from upstream.
+          body-path: pr-body.md

--- a/README.md
+++ b/README.md
@@ -269,6 +269,47 @@ so from v0.157.0 the OTLP gRPC exporter is `otlp_grpc` with `otlp` kept as a
 deprecated alias. Both resolve, and using the old name reports
 `deprecated-component`.
 
+### Keeping the registry current
+
+Nobody has to remember. The [`schemas`](.github/workflows/schemas.yaml) workflow
+runs weekly, reads upstream's release tags, and for each one the registry does
+not have yet generates the schemas and opens a pull request against
+`otelcol-config-schemas`, one per release. A release with no schema is not a gap
+the linter reports — `--collector-version v0.158.0` falls back to the newest
+release it does have and checks the config against the wrong component set — so
+the registry has to keep up on its own. Dispatch the workflow with a version to
+generate one by hand, present or not.
+
+The generated diff is several megabytes of YAML, so the pull request leads with
+what actually changed. `--summary` writes it: the components the release adds,
+drops and renames, and the ones that crossed the beta line, which is what
+`component-stability` reports on and so what changes the findings an unchanged
+config gets.
+
+```sh
+go run ./cmd/schemagen --builder acme=./builder.yaml --registry ./schemas \
+  --summary -
+```
+
+```
+### contrib: `v0.157.0` → `v0.158.0`
+
+4 added, 1 renamed, 2 across the beta line; 327 components in total.
+
+**Added**
+
+- receiver `faro`
+…
+```
+
+A registry grows without bound — one file per release per distribution, in two
+formats — so `--retain n` keeps only the newest `n` releases of each
+distribution, and `--retain-every n` holds on to every `n`th minor for good, so
+a config pinned to a round release keeps resolving after its neighbours are
+dropped. Neither is on by default; the scheduled workflow sets them, a local
+`make schemas` keeps everything. Pruning bounds what the registry serves and
+what a checkout costs, not the history of the repository holding it.
+
 ### Field schemas
 
 `metadata.yaml` describes components but not their settings, so those are read
@@ -313,10 +354,11 @@ make test            # go test -race with coverage
 make lint            # golangci-lint
 make build           # ./bin/otelcol-config-lint
 make build-snapshot  # every release target, the way CI builds them
-make schemas VERSIONS=v0.158.0
+make schemas         # regenerate the schemas into ../otelcol-config-schemas
 ```
 
 CI runs the tests with coverage reported on the pull request, builds every
 release target, lints this repository's own example configs, exercises the
 action against `testdata/`, and publishes binaries and container images from
-tags.
+tags. A weekly job generates the schemas for each new collector release and
+opens a pull request against the schema registry.

--- a/pkg/cmd/schemagen/retain.go
+++ b/pkg/cmd/schemagen/retain.go
@@ -1,0 +1,125 @@
+package schemagen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// prune drops the releases a registry is no longer meant to serve.
+//
+// A registry that gains a schema for every upstream release grows without
+// bound -- upstream tags roughly every other week, and one release is several
+// megabytes across the distributions and formats -- so a run that fills one on
+// a schedule needs to say how far back it keeps. The policy is two numbers: how
+// many of the newest releases to keep, and which older ones are milestones that
+// are never dropped, so a config pinned to a round version keeps resolving long
+// after the releases either side of it are gone.
+//
+// Pruning bounds what the registry serves and what a checkout costs, not the
+// history of the repository holding it; the files stay in every commit that had
+// them.
+func (o *Options) prune() error {
+	if o.retain <= 0 {
+		return nil
+	}
+
+	entries, err := os.ReadDir(o.registryDir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", o.registryDir, err)
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+
+		dir := filepath.Join(o.registryDir, e.Name())
+
+		err := o.pruneDistribution(dir)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// pruneDistribution removes the schema files of one distribution's dropped
+// releases, in every format they were written in.
+func (o *Options) pruneDistribution(dir string) error {
+	dropped := drop(versionsIn(dir), o.retain, o.retainEvery)
+
+	for _, v := range dropped {
+		for _, ext := range schema.Extensions() {
+			err := os.Remove(filepath.Join(dir, v+ext))
+			if err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove %s: %w", filepath.Join(dir, v+ext), err)
+			}
+		}
+	}
+
+	if len(dropped) > 0 {
+		o.logf("  %s: dropped %s\n", filepath.Base(dir), strings.Join(dropped, ", "))
+	}
+
+	return nil
+}
+
+// drop returns the releases the policy does not keep: everything past the keep
+// newest, minus the milestones, whose minor version is a multiple of every. A
+// zero every keeps no milestones, which is how a caller asks for a flat window.
+func drop(versions []string, keep, every int) []string {
+	sorted := append([]string(nil), versions...)
+	sort.Slice(sorted, func(a, b int) bool { return schema.Compare(sorted[a], sorted[b]) > 0 })
+
+	var out []string
+
+	for i, v := range sorted {
+		if i < keep || isMilestone(v, every) {
+			continue
+		}
+
+		out = append(out, v)
+	}
+
+	return out
+}
+
+// isMilestone reports whether a release is one the policy keeps regardless of
+// its age. A version whose minor cannot be read is treated as a milestone: it
+// is not a release this tool wrote, so it is not this tool's to delete.
+func isMilestone(version string, every int) bool {
+	if every <= 0 {
+		return false
+	}
+
+	minor, ok := minorOf(version)
+	if !ok {
+		return true
+	}
+
+	return minor%every == 0
+}
+
+// minorOf returns the Y of a "vX.Y.Z" release.
+func minorOf(version string) (int, bool) {
+	parts := strings.Split(strings.TrimPrefix(schema.Normalize(version), "v"), ".")
+
+	const minorIndex = 1
+	if len(parts) <= minorIndex {
+		return 0, false
+	}
+
+	n, err := strconv.Atoi(parts[minorIndex])
+	if err != nil {
+		return 0, false
+	}
+
+	return n, true
+}

--- a/pkg/cmd/schemagen/schemagen.go
+++ b/pkg/cmd/schemagen/schemagen.go
@@ -28,13 +28,19 @@ import (
 // These carry the messages; the exported errors below are what callers match
 // on.
 var (
-	errNoManifests   = errors.New("no builder manifests specified")
-	errNoFormats     = errors.New("no schema formats specified")
-	errUnknownFormat = errors.New("unknown schema format")
-	errSkipped       = errors.New("could not be generated")
-	errTwoOutputs    = errors.New("--out and --registry name two different places to write")
-	errManyToOneFile = errors.New("several manifests write several schemas, which needs --registry")
+	errNoManifests    = errors.New("no builder manifests specified")
+	errNoFormats      = errors.New("no schema formats specified")
+	errUnknownFormat  = errors.New("unknown schema format")
+	errSkipped        = errors.New("could not be generated")
+	errTwoOutputs     = errors.New("--out and --registry name two different places to write")
+	errManyToOneFile  = errors.New("several manifests write several schemas, which needs --registry")
+	errNoPrevious     = errors.New("--summary has nothing to compare against without --registry")
+	errNothingToPrune = errors.New("--retain has nothing to prune without --registry")
 )
+
+// defaultRetainEvery keeps every tenth minor release for good, which is the
+// spacing the published registry was seeded at.
+const defaultRetainEvery = 10
 
 // Errors reported for bad flag values. Each one is a usage error, so ExitCode
 // maps it to ExitUsage the way a bad flag is mapped.
@@ -48,6 +54,11 @@ var (
 	ErrTwoOutputs error = usageError{errTwoOutputs}
 	// ErrManyToOneFile reports several manifests written to a single file.
 	ErrManyToOneFile error = usageError{errManyToOneFile}
+	// ErrNoPrevious reports --summary given without a registry to read the
+	// previously served release out of.
+	ErrNoPrevious error = usageError{errNoPrevious}
+	// ErrNothingToPrune reports --retain given without a registry to apply it to.
+	ErrNothingToPrune error = usageError{errNothingToPrune}
 )
 
 // Exit codes: the command either produced schemas or it did not.
@@ -93,6 +104,9 @@ type Options struct {
 	outFile     string
 	registryDir string
 	formats     string
+	summaryFile string
+	retain      int
+	retainEvery int
 	cacheDir    string
 	timeout     time.Duration
 
@@ -100,6 +114,9 @@ type Options struct {
 	// so they go to different streams: "--out -" has to be pipeable.
 	out      io.Writer
 	progress io.Writer
+	// diffs is what each generated distribution changes against the release
+	// the registry served before it, collected for --summary.
+	diffs []*schema.Diff
 }
 
 // NewCommand builds the schemagen command. A nil opts is allowed, in which case
@@ -172,6 +189,15 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 		"registry directory to write <distribution>/<version>.<format> into,\n"+
 			"alongside the index.json listing them")
 	flags.StringVar(&o.formats, "formats", "yaml,json", "schema formats to write: yaml, json")
+	flags.StringVar(&o.summaryFile, "summary", "",
+		"file to write a Markdown summary of what the generated releases add,\n"+
+			"remove, rename and restabilise, or \"-\" for stdout; needs --registry")
+	flags.IntVar(&o.retain, "retain", 0,
+		"keep only the newest n releases of each distribution in the registry;\n"+
+			"0 keeps every release")
+	flags.IntVar(&o.retainEvery, "retain-every", defaultRetainEvery,
+		"never drop a release whose minor version is a multiple of n, however\n"+
+			"old it is; 0 keeps no milestones")
 	flags.StringVar(&o.cacheDir, "cache", defaultCacheDir(), "directory to resolve the modules in")
 	flags.DurationVar(&o.timeout, "timeout", commandTimeout, "timeout for one go command")
 }
@@ -236,10 +262,23 @@ func (o *Options) Run(cmd *cobra.Command) error {
 	}
 
 	if o.registryDir != "" {
+		// Pruning runs before the index so the index is written from what the
+		// registry is left holding, which is the whole point of rebuilding it
+		// by listing the directory.
+		err = o.prune()
+		if err != nil {
+			return err
+		}
+
 		err = o.writeIndex()
 		if err != nil {
 			return err
 		}
+	}
+
+	err = o.writeSummary()
+	if err != nil {
+		return err
 	}
 
 	// Carrying on past a manifest that failed is what keeps it from discarding
@@ -263,6 +302,12 @@ func (o *Options) checkDestination(manifests []string) error {
 		return ErrTwoOutputs
 	case o.registryDir == "" && len(manifests) > 1:
 		return ErrManyToOneFile
+	// Both read the registry back: the summary for the release it served
+	// before this run, the retention policy for the ones it still holds.
+	case o.registryDir == "" && o.summaryFile != "":
+		return ErrNoPrevious
+	case o.registryDir == "" && o.retain > 0:
+		return ErrNothingToPrune
 	case o.registryDir == "":
 		return nil
 	}
@@ -292,6 +337,10 @@ func (o *Options) generate(builder string, formats []schema.Format) error {
 	}
 
 	if o.registryDir != "" {
+		// Before the write, so the comparison is against what the registry
+		// served up to now even when a release is regenerated in place.
+		o.summarise(cat)
+
 		return o.writeRegistry(cat, formats)
 	}
 

--- a/pkg/cmd/schemagen/schemagen_test.go
+++ b/pkg/cmd/schemagen/schemagen_test.go
@@ -48,6 +48,8 @@ func TestExitCode(t *testing.T) {
 		"an empty format":  {in: schemagen.ErrNoFormats, want: schemagen.ExitUsage},
 		"two destinations": {in: schemagen.ErrTwoOutputs, want: schemagen.ExitUsage},
 		"nothing written":  {in: schemagen.ErrManyToOneFile, want: schemagen.ExitUsage},
+		"nothing to diff":  {in: schemagen.ErrNoPrevious, want: schemagen.ExitUsage},
+		"nothing to prune": {in: schemagen.ErrNothingToPrune, want: schemagen.ExitUsage},
 	}
 
 	for name, tt := range tests {

--- a/pkg/cmd/schemagen/summary.go
+++ b/pkg/cmd/schemagen/summary.go
@@ -1,0 +1,101 @@
+package schemagen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// summarise records what one generated schema changes against the newest
+// release the registry already holds for that distribution.
+//
+// It runs before the schema is written, so the comparison is against what the
+// registry served up to now even when a release is regenerated in place. A
+// distribution with nothing to compare against still gets an entry, saying how
+// large its first schema is.
+func (o *Options) summarise(cat *schema.Schema) {
+	if o.summaryFile == "" || o.registryDir == "" {
+		return
+	}
+
+	previous := previousIn(filepath.Join(o.registryDir, cat.Distribution), cat.CollectorVersion)
+
+	o.diffs = append(o.diffs, schema.DiffSchemas(previous, cat))
+}
+
+// previousIn reads the newest release a distribution directory holds that is
+// older than version, or nil when it holds none. A file that cannot be read is
+// treated as absent: a summary is a convenience, and failing the run over it
+// would throw away the schemas that did generate.
+func previousIn(dir, version string) *schema.Schema {
+	var newest string
+
+	for _, v := range versionsIn(dir) {
+		if schema.Compare(v, version) >= 0 {
+			continue
+		}
+
+		if newest == "" || schema.Compare(v, newest) > 0 {
+			newest = v
+		}
+	}
+
+	if newest == "" {
+		return nil
+	}
+
+	for _, ext := range schema.Extensions() {
+		cat, err := schema.ReadFile(filepath.Join(dir, newest+ext))
+		if err == nil {
+			return cat
+		}
+	}
+
+	return nil
+}
+
+// writeSummary renders every diff the run collected, in the order the
+// distributions were generated. The file is written even when nothing changed:
+// a reviewer reading "no component changes" learns something, and a caller
+// pasting the file into a pull request body should not have to handle a missing
+// one.
+func (o *Options) writeSummary() error {
+	if o.summaryFile == "" {
+		return nil
+	}
+
+	var b strings.Builder
+
+	for i, d := range o.diffs {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+
+		b.WriteString(d.Markdown())
+	}
+
+	if len(o.diffs) == 0 {
+		b.WriteString("No schemas were generated.\n")
+	}
+
+	if o.summaryFile == stdoutMarker {
+		_, err := fmt.Fprint(o.out, b.String())
+		if err != nil {
+			return fmt.Errorf("write summary: %w", err)
+		}
+
+		return nil
+	}
+
+	err := os.WriteFile(o.summaryFile, []byte(b.String()), filePerm)
+	if err != nil {
+		return fmt.Errorf("write summary: %w", err)
+	}
+
+	o.logf("wrote %s (%d distributions)\n", o.summaryFile, len(o.diffs))
+
+	return nil
+}

--- a/pkg/cmd/schemagen/summary_test.go
+++ b/pkg/cmd/schemagen/summary_test.go
@@ -1,0 +1,154 @@
+package schemagen_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/cmd/schemagen"
+)
+
+// seededDistribution is what the tests below file their fixtures under; it is
+// the name --builder gives the generated schema, so the run compares against
+// them.
+const seededDistribution = "custom"
+
+// seedRegistry writes a minimal schema for each version, which is what a
+// registry filled by earlier runs looks like to this one.
+func seedRegistry(t *testing.T, root string, versions ...string) {
+	t.Helper()
+
+	distribution := seededDistribution
+	dir := filepath.Join(root, distribution)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+
+	for _, v := range versions {
+		writeFile(t, filepath.Join(dir, v+".yaml"),
+			"collectorVersion: "+v+"\ndistribution: "+distribution+
+				"\ncomponents:\n  receiver:\n    legacy:\n      type: legacy\n")
+	}
+}
+
+// TestSummaryComparesAgainstTheServedRelease covers --summary: what the run
+// writes is the difference against the newest release the registry already
+// held, which is what makes the generated files reviewable.
+func TestSummaryComparesAgainstTheServedRelease(t *testing.T) {
+	t.Parallel()
+
+	registry := t.TempDir()
+	seedRegistry(t, registry, "v0.150.0")
+
+	manifest := singleComponentManifest(t, t.TempDir())
+	summary := filepath.Join(t.TempDir(), "summary.md")
+
+	code, _, stderr := run(t, "--builder", "custom="+manifest,
+		"--registry", registry, "--summary", summary, "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+
+	written := readFile(t, summary)
+	assert.Contains(t, written, "### custom: `v0.150.0` → `v0.157.0`")
+	assert.Contains(t, written, "- receiver `otlp`", "the added component is missing")
+	assert.Contains(t, written, "- receiver `legacy`", "the dropped component is missing")
+}
+
+// A distribution the registry has never carried has nothing to compare
+// against, which is reported as its size rather than as several hundred
+// additions.
+func TestSummaryOfAFirstRelease(t *testing.T) {
+	t.Parallel()
+
+	manifest := singleComponentManifest(t, t.TempDir())
+	summary := filepath.Join(t.TempDir(), "summary.md")
+
+	code, _, stderr := run(t, "--builder", "custom="+manifest,
+		"--registry", t.TempDir(), "--summary", summary, "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+	assert.Contains(t, readFile(t, summary), "### custom: new at `v0.157.0`")
+}
+
+func TestSummaryNeedsARegistry(t *testing.T) {
+	t.Parallel()
+
+	code, _, stderr := run(t, "--builder", "manifest.yaml",
+		"--summary", filepath.Join(t.TempDir(), "summary.md"))
+
+	assert.Equal(t, schemagen.ExitUsage, code)
+	assert.Contains(t, stderr, schemagen.ErrNoPrevious.Error())
+}
+
+// TestRetainDropsOlderReleases covers the retention policy: the registry is
+// left holding the window it was asked for, and the index is rebuilt from what
+// survived rather than from what was generated.
+func TestRetainDropsOlderReleases(t *testing.T) {
+	t.Parallel()
+
+	registry := t.TempDir()
+	seedRegistry(t, registry, "v0.140.0", "v0.150.0", "v0.156.0")
+
+	manifest := singleComponentManifest(t, t.TempDir())
+
+	code, _, stderr := run(t, "--builder", "custom="+manifest, "--registry", registry,
+		"--retain", "2", "--retain-every", "0", "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+
+	assert.FileExists(t, filepath.Join(registry, "custom", "v0.157.0.yaml"))
+	assert.FileExists(t, filepath.Join(registry, "custom", "v0.156.0.yaml"))
+	assert.NoFileExists(t, filepath.Join(registry, "custom", "v0.150.0.yaml"))
+	assert.NoFileExists(t, filepath.Join(registry, "custom", "v0.140.0.yaml"))
+
+	index := readFile(t, filepath.Join(registry, "index.json"))
+	assert.Contains(t, index, "v0.156.0")
+	assert.NotContains(t, index, "v0.150.0", "the index still offers a release that was dropped")
+}
+
+// A milestone is kept however old it is, so a config pinned to a round release
+// keeps resolving after the ones either side of it are gone.
+func TestRetainKeepsMilestones(t *testing.T) {
+	t.Parallel()
+
+	registry := t.TempDir()
+	seedRegistry(t, registry, "v0.140.0", "v0.150.0", "v0.156.0")
+
+	manifest := singleComponentManifest(t, t.TempDir())
+
+	code, _, stderr := run(t, "--builder", "custom="+manifest, "--registry", registry,
+		"--retain", "1", "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+
+	assert.FileExists(t, filepath.Join(registry, "custom", "v0.150.0.yaml"))
+	assert.FileExists(t, filepath.Join(registry, "custom", "v0.140.0.yaml"))
+	assert.NoFileExists(t, filepath.Join(registry, "custom", "v0.156.0.yaml"))
+}
+
+// Without --retain the registry keeps everything, which is what a local
+// regeneration wants.
+func TestRetainDefaultsToKeepingEverything(t *testing.T) {
+	t.Parallel()
+
+	registry := t.TempDir()
+	seedRegistry(t, registry, "v0.156.0")
+
+	manifest := singleComponentManifest(t, t.TempDir())
+
+	code, _, stderr := run(t, "--builder", "custom="+manifest,
+		"--registry", registry, "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+	assert.FileExists(t, filepath.Join(registry, "custom", "v0.156.0.yaml"))
+}
+
+func TestRetainNeedsARegistry(t *testing.T) {
+	t.Parallel()
+
+	code, _, stderr := run(t, "--builder", "manifest.yaml", "--retain", "5")
+
+	assert.Equal(t, schemagen.ExitUsage, code)
+	assert.Contains(t, stderr, schemagen.ErrNothingToPrune.Error())
+}

--- a/pkg/schema/diff.go
+++ b/pkg/schema/diff.go
@@ -1,0 +1,333 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+)
+
+// Diff reports what one collector release changed about a distribution's
+// component inventory, against the release before it.
+//
+// It exists so a generated schema can be reviewed as a change rather than as a
+// four megabyte file: the interesting part of a new release is the handful of
+// components that appeared, went away, were renamed or crossed the stability
+// line the rules report on, and all of that is derivable by comparing the two
+// schemas.
+type Diff struct {
+	// Distribution is the binary both schemas describe.
+	Distribution string
+	// From is the release compared against; it is empty when the distribution
+	// had no earlier schema, which makes every component an addition and is
+	// reported as such rather than as several hundred bullet points.
+	From string
+	// To is the release being introduced.
+	To string
+	// Added and Removed list components present in only one of the two. A
+	// renamed component appears in neither: it is in Renamed instead, since
+	// reporting it twice would suggest two changes where upstream made one.
+	Added   []Ref
+	Removed []Ref
+	// Renamed lists components upstream gave a new type, which it expresses by
+	// keeping the old name registered as a deprecated alias of the new one.
+	Renamed []Rename
+	// Restabilised lists components that crossed the beta line in either
+	// direction. Below beta is what component-stability reports on, so these
+	// are the changes that alter what an unchanged config is told.
+	Restabilised []StabilityChange
+	// Total is how many components the new schema carries, which is the one
+	// number worth having when From is empty.
+	Total int
+}
+
+// Ref names one component in a schema.
+type Ref struct {
+	Kind config.Kind
+	Type string
+}
+
+// Rename is a component type upstream replaced with another.
+type Rename struct {
+	Kind config.Kind
+	From string
+	To   string
+}
+
+// StabilityChange is one component's stability moving across the beta line.
+type StabilityChange struct {
+	Kind config.Kind
+	Type string
+	// Signal is the stability map's key: a signal, or "extension", or a
+	// connector's "traces_to_metrics".
+	Signal string
+	From   Stability
+	To     Stability
+}
+
+// AtLeastBeta reports whether a stability level is one a config should be built
+// on. Deprecated and unmaintained are not on the maturity ladder at all, so
+// they count as below it: a component reaching either is as much a change to
+// what a config is told as one falling back to alpha.
+func AtLeastBeta(s Stability) bool {
+	return s == Beta || s == Stable
+}
+
+// DiffSchemas compares two schemas of the same distribution. A nil from means
+// the distribution had no earlier release, which is not an error: it is the
+// first schema, and the result says so by leaving From empty.
+func DiffSchemas(previous, release *Schema) *Diff {
+	d := &Diff{
+		Distribution: release.Distribution,
+		From:         "",
+		To:           release.CollectorVersion,
+		Added:        nil,
+		Removed:      nil,
+		Renamed:      nil,
+		Restabilised: nil,
+		Total:        release.Count(),
+	}
+
+	if previous == nil {
+		return d
+	}
+
+	d.From = previous.CollectorVersion
+
+	for _, kind := range config.Kinds() {
+		old, current := previous.Components[kind], release.Components[kind]
+
+		renamed := renamesIn(kind, old, current)
+		d.Renamed = append(d.Renamed, renamed...)
+
+		// A rename shows up as an addition of the new name, and the old name
+		// survives as an alias so it is not a removal. Dropping the new name
+		// from the additions leaves one entry describing one upstream change.
+		skip := map[string]bool{}
+		for _, r := range renamed {
+			skip[r.To] = true
+		}
+
+		d.Added = append(d.Added, missingFrom(kind, old, current, skip)...)
+		d.Removed = append(d.Removed, missingFrom(kind, current, old, nil)...)
+		d.Restabilised = append(d.Restabilised, restabilisedIn(kind, old, current)...)
+	}
+
+	return d
+}
+
+// Empty reports whether the two releases ship the same components, described
+// the same way.
+func (d *Diff) Empty() bool {
+	return len(d.Added) == 0 && len(d.Removed) == 0 &&
+		len(d.Renamed) == 0 && len(d.Restabilised) == 0
+}
+
+// missingFrom lists the components of have that base does not, skipping the
+// types the caller has already accounted for.
+func missingFrom(kind config.Kind, base, have map[string]*Component, skip map[string]bool) []Ref {
+	var out []Ref
+
+	for typ := range have {
+		if _, ok := base[typ]; ok || skip[typ] {
+			continue
+		}
+
+		out = append(out, Ref{Kind: kind, Type: typ})
+	}
+
+	sort.Slice(out, func(a, b int) bool { return out[a].Type < out[b].Type })
+
+	return out
+}
+
+// renamesIn finds the component types that gained a new name in this release.
+//
+// Upstream expresses a rename by registering the component under both names and
+// marking the old one deprecated, which schemagen records as the pair of
+// Alias and AliasOf. The pair is only news the release it appears in, so one
+// that both schemas already carry is not reported.
+func renamesIn(kind config.Kind, old, current map[string]*Component) []Rename {
+	var out []Rename
+
+	before := aliasPairs(old)
+
+	for legacy, replacement := range aliasPairs(current) {
+		if was, ok := before[legacy]; ok && was == replacement {
+			continue
+		}
+
+		// Only a name the previous release already served is a rename; a
+		// component that arrives carrying both names is simply new.
+		if _, ok := old[legacy]; !ok {
+			continue
+		}
+
+		out = append(out, Rename{Kind: kind, From: legacy, To: replacement})
+	}
+
+	sort.Slice(out, func(a, b int) bool { return out[a].From < out[b].From })
+
+	return out
+}
+
+// aliasPairs maps each legacy component type to the type that replaced it. Both
+// entries of a renamed component describe the same pair, so either one is
+// enough to recognise it.
+func aliasPairs(byType map[string]*Component) map[string]string {
+	out := map[string]string{}
+
+	for typ, comp := range byType {
+		switch {
+		case comp.AliasOf != "":
+			out[typ] = comp.AliasOf
+		case comp.Alias != "":
+			out[comp.Alias] = typ
+		}
+	}
+
+	return out
+}
+
+// restabilisedIn lists the components whose stability crossed the beta line,
+// for any signal either release recorded one for.
+func restabilisedIn(kind config.Kind, old, current map[string]*Component) []StabilityChange {
+	var out []StabilityChange
+
+	for typ, comp := range current {
+		was, ok := old[typ]
+		if !ok {
+			continue // an addition, already reported as one
+		}
+
+		for _, signal := range stabilitySignals(was, comp) {
+			before, after := was.Stability[signal], comp.Stability[signal]
+			// A signal only one release records is that signal being added or
+			// dropped, which the component's own entry does not capture but
+			// which is also not a stability change.
+			if before == "" || after == "" || AtLeastBeta(before) == AtLeastBeta(after) {
+				continue
+			}
+
+			out = append(out, StabilityChange{
+				Kind: kind, Type: typ, Signal: signal, From: before, To: after,
+			})
+		}
+	}
+
+	sort.Slice(out, func(a, b int) bool {
+		if out[a].Type != out[b].Type {
+			return out[a].Type < out[b].Type
+		}
+
+		return out[a].Signal < out[b].Signal
+	})
+
+	return out
+}
+
+// stabilitySignals returns the keys either component records a level under,
+// sorted so the report reads the same way every run.
+func stabilitySignals(a, b *Component) []string {
+	seen := map[string]bool{}
+
+	var out []string
+
+	for _, comp := range []*Component{a, b} {
+		for signal := range comp.Stability {
+			if !seen[signal] {
+				seen[signal] = true
+				out = append(out, signal)
+			}
+		}
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+// maxListed caps how many entries of one kind a summary spells out. A release
+// that renumbers a whole distribution would otherwise push the summary past
+// what a pull request body can hold, and the point of the summary is the part a
+// reviewer reads.
+const maxListed = 40
+
+// Markdown renders the diff as a section of a pull request body.
+func (d *Diff) Markdown() string {
+	var b strings.Builder
+
+	if d.From == "" {
+		fmt.Fprintf(&b, "### %s: new at `%s`\n\n%d components.\n",
+			d.Distribution, d.To, d.Total)
+
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "### %s: `%s` → `%s`\n\n%s\n", d.Distribution, d.From, d.To, d.headline())
+
+	writeList(&b, "Added", len(d.Added), func(i int) string { return refLine(d.Added[i]) })
+	writeList(&b, "Removed", len(d.Removed), func(i int) string { return refLine(d.Removed[i]) })
+	writeList(&b, "Renamed", len(d.Renamed), func(i int) string {
+		r := d.Renamed[i]
+
+		return fmt.Sprintf("%s `%s` → `%s`", r.Kind, r.From, r.To)
+	})
+	writeList(&b, "Stability", len(d.Restabilised), func(i int) string {
+		c := d.Restabilised[i]
+
+		return fmt.Sprintf("%s `%s` (%s): %s → %s", c.Kind, c.Type, c.Signal, c.From, c.To)
+	})
+
+	return b.String()
+}
+
+// headline is the one line a reviewer reads when nothing below needs attention.
+func (d *Diff) headline() string {
+	if d.Empty() {
+		return fmt.Sprintf("No component changes; %d in total.", d.Total)
+	}
+
+	counts := []struct {
+		n    int
+		noun string
+	}{
+		{len(d.Added), "added"},
+		{len(d.Removed), "removed"},
+		{len(d.Renamed), "renamed"},
+		{len(d.Restabilised), "across the beta line"},
+	}
+
+	var parts []string
+
+	for _, c := range counts {
+		if c.n > 0 {
+			parts = append(parts, strconv.Itoa(c.n)+" "+c.noun)
+		}
+	}
+
+	return strings.Join(parts, ", ") + fmt.Sprintf("; %d components in total.", d.Total)
+}
+
+// refLine renders one component as a bullet's text.
+func refLine(r Ref) string { return fmt.Sprintf("%s `%s`", r.Kind, r.Type) }
+
+// writeList appends one titled bullet list, or nothing when it would be empty.
+func writeList(b *strings.Builder, title string, n int, line func(int) string) {
+	if n == 0 {
+		return
+	}
+
+	fmt.Fprintf(b, "\n**%s**\n\n", title)
+
+	shown := min(n, maxListed)
+	for i := range shown {
+		fmt.Fprintf(b, "- %s\n", line(i))
+	}
+
+	if shown < n {
+		fmt.Fprintf(b, "- … and %d more\n", n-shown)
+	}
+}

--- a/pkg/schema/diff_test.go
+++ b/pkg/schema/diff_test.go
@@ -1,0 +1,230 @@
+package schema_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// release builds a schema from a receiver-only inventory, which is enough for
+// every comparison the diff makes; the kinds are walked the same way.
+func release(version string, receivers map[string]*schema.Component) *schema.Schema {
+	return &schema.Schema{
+		CollectorVersion: version,
+		Distribution:     "contrib",
+		Components: map[config.Kind]map[string]*schema.Component{
+			config.KindReceiver: receivers,
+		},
+	}
+}
+
+func TestDiffReportsAdditionsAndRemovals(t *testing.T) {
+	t.Parallel()
+
+	from := release("v0.157.0", map[string]*schema.Component{
+		"otlp": {Type: "otlp"},
+		"gone": {Type: "gone"},
+	})
+	to := release("v0.158.0", map[string]*schema.Component{
+		"otlp":  {Type: "otlp"},
+		"fresh": {Type: "fresh"},
+	})
+
+	d := schema.DiffSchemas(from, to)
+
+	assert.Equal(t, "v0.157.0", d.From)
+	assert.Equal(t, "v0.158.0", d.To)
+	assert.Equal(t, []schema.Ref{{Kind: config.KindReceiver, Type: "fresh"}}, d.Added)
+	assert.Equal(t, []schema.Ref{{Kind: config.KindReceiver, Type: "gone"}}, d.Removed)
+	assert.False(t, d.Empty())
+}
+
+func TestDiffOfAnUnchangedReleaseIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	components := func() map[string]*schema.Component {
+		return map[string]*schema.Component{
+			"otlp": {Type: "otlp", Stability: map[string]schema.Stability{"traces": schema.Beta}},
+		}
+	}
+
+	d := schema.DiffSchemas(release("v0.157.0", components()), release("v0.158.0", components()))
+
+	assert.True(t, d.Empty())
+	assert.Contains(t, d.Markdown(), "No component changes")
+}
+
+// A rename is one upstream change, so it is reported once rather than as the
+// new name appearing and the old one being deprecated.
+func TestDiffReportsARenameOnce(t *testing.T) {
+	t.Parallel()
+
+	from := release("v0.156.0", map[string]*schema.Component{
+		"otlp": {Type: "otlp"},
+	})
+	to := release("v0.157.0", map[string]*schema.Component{
+		"otlp_grpc": {Type: "otlp_grpc", Alias: "otlp"},
+		"otlp":      {Type: "otlp", AliasOf: "otlp_grpc", Deprecated: `renamed to "otlp_grpc"`},
+	})
+
+	d := schema.DiffSchemas(from, to)
+
+	assert.Equal(t, []schema.Rename{
+		{Kind: config.KindReceiver, From: "otlp", To: "otlp_grpc"},
+	}, d.Renamed)
+	assert.Empty(t, d.Added)
+	assert.Empty(t, d.Removed)
+}
+
+// The pair survives into later releases, where it is no longer news.
+func TestDiffDoesNotRepeatAnOlderRename(t *testing.T) {
+	t.Parallel()
+
+	renamed := func() map[string]*schema.Component {
+		return map[string]*schema.Component{
+			"otlp_grpc": {Type: "otlp_grpc", Alias: "otlp"},
+			"otlp":      {Type: "otlp", AliasOf: "otlp_grpc"},
+		}
+	}
+
+	d := schema.DiffSchemas(release("v0.157.0", renamed()), release("v0.158.0", renamed()))
+
+	assert.Empty(t, d.Renamed)
+	assert.True(t, d.Empty())
+}
+
+// A component that arrives already carrying both names was not renamed here.
+func TestDiffTreatsANewAliasedComponentAsAnAddition(t *testing.T) {
+	t.Parallel()
+
+	from := release("v0.157.0", map[string]*schema.Component{})
+	to := release("v0.158.0", map[string]*schema.Component{
+		"new_thing": {Type: "new_thing", Alias: "newthing"},
+		"newthing":  {Type: "newthing", AliasOf: "new_thing"},
+	})
+
+	d := schema.DiffSchemas(from, to)
+
+	assert.Empty(t, d.Renamed)
+	assert.Equal(t, []schema.Ref{
+		{Kind: config.KindReceiver, Type: "new_thing"},
+		{Kind: config.KindReceiver, Type: "newthing"},
+	}, d.Added)
+}
+
+func TestDiffReportsOnlyStabilityCrossingBeta(t *testing.T) {
+	t.Parallel()
+
+	from := release("v0.157.0", map[string]*schema.Component{
+		"promoted": {Type: "promoted", Stability: map[string]schema.Stability{"traces": schema.Alpha}},
+		"matured":  {Type: "matured", Stability: map[string]schema.Stability{"traces": schema.Beta}},
+		"within":   {Type: "within", Stability: map[string]schema.Stability{"traces": schema.Development}},
+		"added":    {Type: "added", Stability: map[string]schema.Stability{"traces": schema.Beta}},
+	})
+	next := release("v0.158.0", map[string]*schema.Component{
+		"promoted": {Type: "promoted", Stability: map[string]schema.Stability{"traces": schema.Beta}},
+		"matured":  {Type: "matured", Stability: map[string]schema.Stability{"traces": schema.Unmaintained}},
+		"within":   {Type: "within", Stability: map[string]schema.Stability{"traces": schema.Alpha}},
+		"added": {Type: "added", Stability: map[string]schema.Stability{
+			"traces": schema.Beta, "metrics": schema.Alpha,
+		}},
+	})
+
+	d := schema.DiffSchemas(from, next)
+
+	assert.Equal(t, []schema.StabilityChange{
+		{Kind: config.KindReceiver, Type: "matured", Signal: "traces", From: schema.Beta, To: schema.Unmaintained},
+		{Kind: config.KindReceiver, Type: "promoted", Signal: "traces", From: schema.Alpha, To: schema.Beta},
+	}, d.Restabilised)
+}
+
+func TestDiffAgainstNothingReportsTheSize(t *testing.T) {
+	t.Parallel()
+
+	to := release("v0.158.0", map[string]*schema.Component{
+		"otlp": {Type: "otlp"}, "kafka": {Type: "kafka"},
+	})
+
+	d := schema.DiffSchemas(nil, to)
+
+	assert.Empty(t, d.From)
+	assert.Equal(t, 2, d.Total)
+
+	rendered := d.Markdown()
+	assert.Contains(t, rendered, "new at `v0.158.0`")
+	assert.Contains(t, rendered, "2 components")
+}
+
+func TestMarkdownListsEveryChange(t *testing.T) {
+	t.Parallel()
+
+	from := release("v0.157.0", map[string]*schema.Component{
+		"otlp": {Type: "otlp", Stability: map[string]schema.Stability{"traces": schema.Alpha}},
+		"gone": {Type: "gone"},
+	})
+	next := release("v0.158.0", map[string]*schema.Component{
+		"otlp_grpc": {Type: "otlp_grpc", Alias: "otlp",
+			Stability: map[string]schema.Stability{"traces": schema.Alpha}},
+		"otlp": {Type: "otlp", AliasOf: "otlp_grpc",
+			Stability: map[string]schema.Stability{"traces": schema.Beta}},
+		"fresh": {Type: "fresh"},
+	})
+
+	rendered := schema.DiffSchemas(from, next).Markdown()
+
+	assert.Contains(t, rendered, "### contrib: `v0.157.0` → `v0.158.0`")
+	assert.Contains(t, rendered, "- receiver `fresh`")
+	assert.Contains(t, rendered, "- receiver `gone`")
+	assert.Contains(t, rendered, "- receiver `otlp` → `otlp_grpc`")
+	assert.Contains(t, rendered, "- receiver `otlp` (traces): alpha → beta")
+	assert.Contains(t, rendered, "1 added, 1 removed, 1 renamed, 1 across the beta line")
+}
+
+// A summary is meant to be read, and a pull request body has a size limit, so a
+// release that changes hundreds of components is counted rather than listed.
+func TestMarkdownCapsALongList(t *testing.T) {
+	t.Parallel()
+
+	capped := map[string]*schema.Component{}
+	for _, name := range componentNames(100) {
+		capped[name] = &schema.Component{Type: name}
+	}
+
+	rendered := schema.DiffSchemas(
+		release("v0.157.0", map[string]*schema.Component{}),
+		release("v0.158.0", capped),
+	).Markdown()
+
+	require.Contains(t, rendered, "… and 60 more")
+	assert.Equal(t, 41, strings.Count(rendered, "- receiver `")+strings.Count(rendered, "- … and"))
+}
+
+func TestAtLeastBeta(t *testing.T) {
+	t.Parallel()
+
+	for level, want := range map[schema.Stability]bool{
+		schema.Development:  false,
+		schema.Alpha:        false,
+		schema.Beta:         true,
+		schema.Stable:       true,
+		schema.Deprecated:   false,
+		schema.Unmaintained: false,
+	} {
+		assert.Equal(t, want, schema.AtLeastBeta(level), string(level))
+	}
+}
+
+// componentNames returns n distinct type names.
+func componentNames(n int) []string {
+	out := make([]string, 0, n)
+	for i := range n {
+		out = append(out, "component"+string(rune('a'+i%26))+string(rune('a'+i/26)))
+	}
+
+	return out
+}


### PR DESCRIPTION
Closes #9.

The registry only stays current while somebody remembers to run schemagen for
each upstream release, and a release it does not have is not a gap the linter
reports: `--collector-version v0.158.0` falls back to the newest release the
registry does hold and checks the config against the wrong component set.

## The workflow

`schemas.yaml` gains a weekly schedule beside its dispatch. A `discover` job
reads upstream's release tags and the registry's `index.json` and hands
`generate` whatever the registry is behind on; `generate` is a matrix over those
versions, one pull request per release. Nothing new is a clean no-op — the
matrix job is skipped rather than opening an empty pull request.

- **Only forward.** Candidates are releases tagged *after* the registry's newest
  contrib schema. A gap further back (the registry holds v0.110, v0.120, …, v0.157)
  is a retention decision, not something to backfill, and treating it as missing
  would have the first run walk backwards through v0.145.
- **Oldest first, capped at `MAX_RELEASES: 3`.** Each schema is summarised
  against the release before it, so generating in order is what makes those
  summaries describe one release each. A longer backlog catches up over the
  following weeks or by dispatching a version by hand.
- **A dispatched version is generated as asked**, present or not: that is how a
  schema gets corrected in place.

### On "wait for both core and contrib"

This is now structural rather than a check. Since #38 a distribution is described
by the builder manifest that builds it, which lives in
`opentelemetry-collector-releases` — tagged once per collector release, after
core and contrib are, and carrying every distribution's manifest. So there is one
tag to wait for rather than two that may not appear together. I kept an explicit
check anyway (two requests per candidate) in case upstream ever changes the order.

## Making the pull request reviewable

The diff is several megabytes of generated YAML, so `schemagen --summary` writes
what a reviewer actually reads. New `pkg/schema/diff.go` compares two schemas of
one distribution; the generator has both in hand — it reads the previous release
out of the registry before writing the new one — so it falls out as one flag.

A rename is reported **once**, not as the new name appearing and the old one
being deprecated: upstream expresses a rename by registering the component under
both names, which schemagen already records as `alias`/`aliasOf`, and that is one
upstream change. A pair both releases carry is not news and is not repeated.

Stability is filtered to what crosses the beta line, since that is the line
`component-stability` reports on, and so the changes that alter what an unchanged
config is told. Lists are capped at 40 entries so a large release cannot push the
body past what a pull request can hold.

Run against the two real published schemas, `contrib` v0.150.0 → v0.157.0:

```
### contrib: `v0.150.0` → `v0.157.0`

8 added, 3 removed, 29 renamed, 7 across the beta line; 297 components in total.

**Added**

- receiver `aws_lambda`
- receiver `obi`
…

**Renamed**

- receiver `apachespark` → `apache_spark`
- receiver `awscloudwatch` → `aws_cloudwatch`
…

**Stability**

- receiver `prometheus_simple` (metrics): beta → unmaintained
- exporter `signalfx` (traces): beta → deprecated
- extension `azure_auth` (extension): alpha → beta
```

## Retention

`--retain n` keeps the newest n releases of a distribution; `--retain-every n`
holds on to every nth minor for good, so a config pinned to a round release keeps
resolving after its neighbours are dropped. Pruning runs before the index is
rebuilt, so the index is written from what survived. Both are off by default —
a local `make schemas` keeps everything, and only the scheduled run prunes, at
24 releases plus every tenth minor, which drops nothing from today's registry.

**One thing worth flagging.** The issue framed retention as bounding the ~1.3 MB
of *embedded* catalogs; since #36 the schemas live in a repository of their own,
so binary size is no longer affected. What is unbounded is the registry: contrib
alone is 8.4 MB per release across YAML and JSON, and upstream tags every other
week. Pruning bounds what the registry serves and what a checkout costs, but the
blobs stay in every commit that had them, so it does not bound the registry's
git history — that is the registry repository's own problem (a squash, or
dropping the JSON, which is derivable from the YAML). Happy to take a different
number, or to leave `RETAIN` at 0 and never prune, if you would rather nothing
scheduled ever deletes published data.

## Also

- The pre-PR lint step now checks only the release just written, instead of every
  schema in the registry — that was work growing with the registry.
- The pull request is labelled `schemas` / `automated`, so an automerge rule in
  the registry can key off it.
- README: a "Keeping the registry current" section, and `make schemas VERSIONS=…`
  in the development block was stale.

## Checked

`make lint` and `make test` clean. New tests cover additions, removals, renames
(reported once; not repeated on later releases; a component arriving with both
names is an addition), the beta-line filter, the first-release case and the list
cap; and, through a full generator run, the summary against a seeded registry,
retention, milestone retention and both usage errors. The discovery shell was run
against the live API and index: it picks `["v0.158.0"]` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
