### PR TITLE
fix(action): run the linter that was released, not one built on the runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,10 @@
-# The action image builds with the repository root as its context, so keep the
-# things that are not needed to compile the binary out of it.
-.git
-.github
-bin/
-dist/
-coverage.txt
-# The fixtures are read from the mounted workspace when a workflow points
-# schema-location at them, never from inside the image.
-testdata/
+# The action image is assembled from the linter image goreleaser published, so
+# the only thing its build context has to carry is the entrypoint wrapped
+# around it. The source tree is no longer part of that build; sending it would
+# only make every consumer's workflow upload it to the daemon and drop it.
+#
+# This applies to the root Dockerfile alone. The distroless image releases
+# publish is built with goreleaser's dist directory as its context, which has a
+# .dockerignore of its own -- that is, none.
+*
+!build/docker/action-entrypoint.sh

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -23,6 +23,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: 1.25
+
+      # The action's image is assembled from the linter image of the release it
+      # is pinned to, and a pull request predates that release -- on a tag the
+      # pin resolves, here it cannot. So the same image is built from this
+      # revision and the pin rewritten to it: every step below then exercises
+      # action.yml, the Dockerfile and the entrypoint as committed, against the
+      # linter as it stands on this branch rather than as it was last released.
+      - name: Build the linter image from this revision
+        run: |
+          mkdir -p dist/action
+          CGO_ENABLED=0 go build -ldflags '-s -w' \
+            -o dist/action/otelcol-config-lint ./cmd/otelcol-config-lint
+
+          # dist/action as the context, the way goreleaser builds it: the image
+          # is the binary and nothing else.
+          docker build -t otelcol-config-lint:source \
+            -f build/docker/Dockerfile dist/action
+
+          sed -i -E \
+            's|^FROM ghcr\.io/minuk-dev/otelcol-config-lint:[^ ]*|FROM otelcol-config-lint:source|' \
+            Dockerfile
+          git --no-pager diff -- Dockerfile
+
       - name: Lint the valid examples
         id: valid
         uses: ./

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,26 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      # Bump then tag: the commit being released has to pin the action's image
+      # at the release it is about to publish. If it names anything else,
+      # `uses: minuk-dev/otelcol-config-lint@v1` would run a different revision
+      # of the linter than the tag says -- and the fix, once the tag is out
+      # there, is another release. Cheaper to refuse the tag.
+      - name: The action has to be pinned at the release being cut
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          # goreleaser publishes {{ .Version }}, which carries no leading v.
+          expected="${GITHUB_REF_NAME#v}"
+          pinned="$(sed -nE 's|^FROM ghcr\.io/minuk-dev/otelcol-config-lint:([^ ]+).*|\1|p' Dockerfile)"
+
+          if [ "${pinned}" != "${expected}" ]; then
+            echo "::error title=release::${GITHUB_REF_NAME} pins the action at" \
+              "'${pinned}', expected '${expected}'." \
+              "Run 'make release-pin RELEASE=${GITHUB_REF_NAME}', commit, and tag that commit."
+            exit 1
+          fi
+
+          echo "${GITHUB_REF_NAME} pins the action at ${pinned}"
       - name: Set up Go
         uses: actions/setup-go@v7
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,31 @@
 # The image behind action.yml. It sits at the repository root because a
-# container action builds with the Dockerfile's own directory as the context,
-# and this build needs the whole source tree; build/docker/Dockerfile is the
-# separate distroless image that releases publish.
+# container action builds with the Dockerfile's own directory as the context.
 #
-# Unlike that one this image needs a shell, so the entrypoint can turn the
-# action's inputs into flags and report the counts back as step outputs.
-FROM golang:1.25-alpine AS build
-
-WORKDIR /src
-
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY . .
-RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /out/otelcol-config-lint ./cmd/otelcol-config-lint
+# Nothing is compiled here. The linter is copied out of the image goreleaser
+# published for the release this revision ships in, so a consumer's workflow
+# pulls two small images instead of fetching a Go toolchain and rebuilding the
+# binary before a single config is checked -- and what runs is the binary that
+# was released, not one built from whatever the runner checked out.
+#
+# That image is distroless and has no shell, so it cannot be the action's image
+# on its own: the entrypoint below is what turns inputs into flags and writes
+# the counts back as step outputs.
+#
+# The pin is a release, never `latest`: a workflow pinned to @v1 must not change
+# behaviour the moment the next release is cut. It names the goreleaser tag,
+# which carries no leading v.
+#
+# A tag cannot reference an image built from itself, so the pin is bumped before
+# the tag is cut, and the tag goes on the commit that carries the bump:
+#
+#     make release-pin RELEASE=v1.2.3
+#
+# The release workflow refuses a tag whose pin names anything else. Pull
+# requests predate the release they are pinned to, so
+# .github/workflows/action.yaml builds this image from source and rewrites the
+# pin to it before using the action -- the source build stays reachable, it is
+# just no longer what consumers run.
+FROM ghcr.io/minuk-dev/otelcol-config-lint:1.0.0 AS bin
 
 FROM alpine:3.22
 
@@ -22,7 +34,7 @@ FROM alpine:3.22
 # over HTTPS unless the workflow points schema-location somewhere local.
 RUN apk add --no-cache bash jq ca-certificates
 
-COPY --from=build /out/otelcol-config-lint /usr/local/bin/otelcol-config-lint
+COPY --from=bin /usr/local/bin/otelcol-config-lint /usr/local/bin/otelcol-config-lint
 COPY build/docker/action-entrypoint.sh /usr/local/bin/action-entrypoint
 
 WORKDIR /github/workspace

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILDERS ?= \
 	k8s=$(RELEASES)/distributions/otelcol-k8s/manifest.yaml \
 	otlp=$(RELEASES)/distributions/otelcol-otlp/manifest.yaml
 
-.PHONY: all build build-snapshot test lint lint-fix fmt schemas clean
+.PHONY: all build build-snapshot test lint lint-fix fmt schemas release-pin clean
 
 all: lint test build
 
@@ -43,6 +43,20 @@ lint-fix:
 
 fmt:
 	gofmt -w .
+
+# Point the action's image at the release about to be cut. A tag cannot
+# reference an image built from itself, so this runs first and the tag goes on
+# the commit it produces; the release workflow refuses a tag whose pin says
+# anything else.
+#
+#   make release-pin RELEASE=v1.2.3
+#   git commit -am 'chore(release): pin the action at v1.2.3'
+#   git tag v1.2.3 && git push origin main v1.2.3
+release-pin:
+	@test -n '$(RELEASE)' || { echo 'usage: make release-pin RELEASE=v1.2.3' >&2; exit 1; }
+	sed -i.bak -E 's|^(FROM ghcr\.io/minuk-dev/otelcol-config-lint):[^ ]*|\1:$(RELEASE:v%=%)|' Dockerfile
+	@rm -f Dockerfile.bak
+	@echo 'The action now runs $(RELEASE:v%=%); commit that and tag the commit $(RELEASE).'
 
 # Regenerate the component schemas from the distributions' builder manifests.
 schemas:

--- a/README.md
+++ b/README.md
@@ -79,10 +79,13 @@ them:
 - run: echo "${{ steps.lint.outputs.invalid }} file(s) failed"
 ```
 
-`@v1` follows the newest v1 release. Pin a full tag such as `@v1.2.3` to hold a
-workflow to one revision of the linter. The schemas are a separate registry that
-tracks its own main, so pin `schema-location` as well — at a vendored directory,
-or at a tagged URL — for a run that cannot change underneath a workflow.
+`@v1` follows the newest v1 release, and runs exactly that release's linter: the
+action wraps `ghcr.io/minuk-dev/otelcol-config-lint:<release>`, pinned at a tag
+and never `latest`, so a step is two small image pulls rather than a Go
+toolchain and a compile. Pin a full tag such as `@v1.2.3` to hold a workflow to
+one revision. The schemas are a separate registry that tracks its own main, so
+pin `schema-location` as well — at a vendored directory, or at a tagged URL —
+for a run that cannot change underneath a workflow.
 
 ## Usage
 
@@ -345,7 +348,8 @@ pkg/rule/                     the rules and the registry
 pkg/lint/                     the engine and the output formatters
 pkg/diag/                     diagnostics, severities and positions
 pkg/version/                  the linter's own version, stamped at build time
-action.yml                    the GitHub Action; Dockerfile is the image it runs
+action.yml                    the GitHub Action; Dockerfile wraps the released image it runs
+build/docker/Dockerfile       the distroless linter image releases publish
 ```
 
 ## Development
@@ -374,3 +378,15 @@ release target, lints this repository's own example configs, exercises the
 action against `testdata/`, and publishes binaries and container images from
 tags. A weekly job generates the schemas for each new collector release and
 opens a pull request against the schema registry.
+
+Releasing is bump then tag, because the action's image is pinned at the release
+it ships in and a tag cannot reference an image built from itself:
+
+```sh
+make release-pin RELEASE=v1.2.3
+git commit -am 'chore(release): pin the action at v1.2.3'
+git tag v1.2.3 && git push origin main v1.2.3
+```
+
+The release workflow refuses a tag whose pin names another release, and moves
+`v1` onto the release once it has published.

--- a/action.yml
+++ b/action.yml
@@ -96,8 +96,9 @@ outputs:
   infos:
     description: Number of infos reported.
 
-# The image is built from this repository, so the action and the linter it runs
-# are always the same revision: a workflow pinned to @v1 cannot drift.
+# The image wraps the linter image of the release it ships in -- see Dockerfile
+# -- so the action and the linter it runs are always the same release: a
+# workflow pinned to @v1 cannot drift, and nothing is compiled on the runner.
 runs:
   using: docker
   image: Dockerfile


### PR DESCRIPTION
Closes #16.

## What changed

`Dockerfile` — the image `action.yml` runs — no longer compiles anything. It copies the binary out of the image goreleaser publishes:

```dockerfile
FROM ghcr.io/minuk-dev/otelcol-config-lint:1.0.0 AS bin

FROM alpine:3.22
RUN apk add --no-cache bash jq ca-certificates
COPY --from=bin /usr/local/bin/otelcol-config-lint /usr/local/bin/otelcol-config-lint
COPY build/docker/action-entrypoint.sh /usr/local/bin/action-entrypoint
```

Same `action.yml`, same inputs and outputs, nothing to change for anyone using it — two small pulls replace a `golang:1.25-alpine` pull and a `go build` in every consumer's workflow. The published image is distroless, so the alpine layer stays: it is what maps inputs onto flags and writes the counts back as step outputs.

The pin names the goreleaser tag, which carries **no leading `v`** — the issue's sketch said `:v1.0.0`, but `.goreleaser.yaml` publishes `{{ .Version }}` (the snapshots on ghcr are `0.0.1-SNAPSHOT-…`). The pin is `1.0.0` and the release guard compares against `${GITHUB_REF_NAME#v}`.

`.dockerignore` now sends one file, since the source tree is no longer part of that build.

## Bump then tag

The safer of the two options in the issue, written down in the `Dockerfile`:

- `make release-pin RELEASE=v1.2.3` rewrites the pin; the tag goes on the commit that carries it.
- `release.yaml` refuses a tag whose pin names another release, before goreleaser publishes anything — the fix for a wrong pin, once a tag is out there, is another release.
- The existing `major-tag` job still moves `v1` after the release succeeded, so `@v1` and the pin stay consistent with what was just published.
- Never `latest`, so `@v1` cannot change behaviour the moment the next release is cut.

## CI still exercises the action

A pull request predates the release it is pinned to, so `.github/workflows/action.yaml` builds the same image from this revision — `go build`, then `build/docker/Dockerfile` with a dist-shaped context, exactly as goreleaser assembles it — and rewrites the pin to it. Every existing step is unchanged and still runs `uses: ./`, so `action.yml`, the `Dockerfile` and the entrypoint are exercised as committed, against the linter as it stands on the branch. The source build stays reachable; it is just no longer what consumers run.

## Ordering note

There is no release yet — ghcr only has `0.0.1-SNAPSHOT-*`, so `ghcr.io/minuk-dev/otelcol-config-lint:1.0.0` does not exist at merge time. Nothing breaks: no `v1` tag exists for anyone to use, and CI rewrites the pin. The first release needs no bump, since the pin already names `1.0.0` — tag `v1.0.0`, goreleaser publishes the image, `v1` moves onto it, and `uses: minuk-dev/otelcol-config-lint@v1` works from that point on.

`@main` is the one thing that would fail between merge and the first tag, and it was never a supported way to use the action.

## Checklist from the issue

- [x] Decide between bump-then-tag and run-time resolution, and write it down in the Dockerfile
- [x] Action image assembled from the goreleaser-published image, pinned to a release tag, never `latest`
- [x] Release workflow keeps the pin and the `v1` tag consistent with what it just published
- [x] `.github/workflows/action.yaml` still exercises the action on pull requests
- [x] README says which linter revision `@v1` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)