### PR TITLE
refactor(version): move Version into its own package, derived from the build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,23 +29,19 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: build --snapshot --clean
-      # -X against a symbol that does not exist is ignored by the linker
-      # without a warning, so ldflags left pointing at a package that moved
-      # ships a binary reporting "dev" and nothing notices. Read the version
-      # back out of what was just built, once per build path.
-      - name: Check the release build stamps the version
+      # The version comes from what the toolchain stamps, which needs a real
+      # repository to read: a shallow checkout, a missing .git or
+      # -buildvcs=false would leave release binaries unable to say what they
+      # are, and nothing else would notice. Read it back out of what was built.
+      - name: Check the release build knows its own version
         run: |
-          version="$(jq -r '.version' dist/metadata.json)"
           binary="$(jq -r 'first(.[] | select(.type == "Binary" and .goos == "linux" and .goarch == "amd64")).path' dist/artifacts.json)"
           got="$("${binary}" version)"
-          want="otelcol-config-lint ${version}"
-          if [ "${got}" != "${want}" ]; then
-            echo "the version stamp did not land: got \"${got}\", want \"${want}\"" >&2
-            echo 'check that the .goreleaser.yaml ldflags name the package Version lives in' >&2
+          echo "${got}"
+          if [ "${got}" = "otelcol-config-lint devel" ]; then
+            echo 'the binary carries no build information; check the checkout and -buildvcs' >&2
             exit 1
           fi
-      - name: Check the Makefile build stamps the version
-        run: make verify-version
       - name: Upload binaries
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,23 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: build --snapshot --clean
+      # -X against a symbol that does not exist is ignored by the linker
+      # without a warning, so ldflags left pointing at a package that moved
+      # ships a binary reporting "dev" and nothing notices. Read the version
+      # back out of what was just built, once per build path.
+      - name: Check the release build stamps the version
+        run: |
+          version="$(jq -r '.version' dist/metadata.json)"
+          binary="$(jq -r 'first(.[] | select(.type == "Binary" and .goos == "linux" and .goarch == "amd64")).path' dist/artifacts.json)"
+          got="$("${binary}" version)"
+          want="otelcol-config-lint ${version}"
+          if [ "${got}" != "${want}" ]; then
+            echo "the version stamp did not land: got \"${got}\", want \"${want}\"" >&2
+            echo 'check that the .goreleaser.yaml ldflags name the package Version lives in' >&2
+            exit 1
+          fi
+      - name: Check the Makefile build stamps the version
+        run: make verify-version
       - name: Upload binaries
         uses: actions/upload-artifact@v7
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,10 @@ builds:
       - arm64
     ldflags:
       - "-s -w"
-      - "-X github.com/minuk-dev/otelcol-config-lint/pkg/cmd/otelcol-config-lint.Version={{.Version}}"
+      # Keep in step with the Makefile's LDFLAGS: the linker ignores -X against
+      # a symbol that does not exist, so a stale path ships a binary reporting
+      # "dev". CI reads the version back out of a snapshot build to catch that.
+      - "-X github.com/minuk-dev/otelcol-config-lint/pkg/version.Version={{.Version}}"
 
 archives:
   - id: otelcol-config-lint

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,12 +18,12 @@ builds:
     goarch:
       - amd64
       - arm64
+    # No -X for the version. The toolchain stamps the module version and the
+    # repository state into every binary and pkg/version reads that back, so a
+    # tagged build reports its tag without anything here having to say so.
+    # -s -w strip the symbol table and DWARF, not the build info.
     ldflags:
       - "-s -w"
-      # Keep in step with the Makefile's LDFLAGS: the linker ignores -X against
-      # a symbol that does not exist, so a stale path ships a binary reporting
-      # "dev". CI reads the version back out of a snapshot build to catch that.
-      - "-X github.com/minuk-dev/otelcol-config-lint/pkg/version.Version={{.Version}}"
 
 archives:
   - id: otelcol-config-lint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY  := bin/otelcol-config-lint
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS := -X github.com/minuk-dev/otelcol-config-lint/pkg/cmd/otelcol-config-lint.Version=$(VERSION)
+LDFLAGS := -X github.com/minuk-dev/otelcol-config-lint/pkg/version.Version=$(VERSION)
 
 # A checkout of github.com/minuk-dev/otelcol-config-schemas, which is where
 # generated schemas are written.
@@ -21,12 +21,24 @@ BUILDERS ?= \
 	k8s=$(RELEASES)/distributions/otelcol-k8s/manifest.yaml \
 	otlp=$(RELEASES)/distributions/otelcol-otlp/manifest.yaml
 
-.PHONY: all build build-snapshot test lint lint-fix fmt schemas clean
+.PHONY: all build build-snapshot verify-version test lint lint-fix fmt schemas clean
 
 all: lint test build
 
 build:
 	go build -ldflags '$(LDFLAGS)' -o $(BINARY) ./cmd/otelcol-config-lint
+
+# The linker ignores -X against a symbol that does not exist, so LDFLAGS naming
+# a package that has moved fails silently and ships a binary reporting "dev".
+# Build one and read the version back out.
+verify-version: build
+	@got="$$($(BINARY) version)"; want='otelcol-config-lint $(VERSION)'; \
+	if [ "$$got" != "$$want" ]; then \
+		echo "the version stamp did not land: got \"$$got\", want \"$$want\"" >&2; \
+		echo 'check that LDFLAGS names the package Version actually lives in' >&2; \
+		exit 1; \
+	fi
+	@echo 'version stamp lands: $(VERSION)'
 
 # Build every release target locally, the way CI does before a tag.
 build-snapshot:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-BINARY  := bin/otelcol-config-lint
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS := -X github.com/minuk-dev/otelcol-config-lint/pkg/version.Version=$(VERSION)
+BINARY := bin/otelcol-config-lint
 
 # A checkout of github.com/minuk-dev/otelcol-config-schemas, which is where
 # generated schemas are written.
@@ -21,24 +19,14 @@ BUILDERS ?= \
 	k8s=$(RELEASES)/distributions/otelcol-k8s/manifest.yaml \
 	otlp=$(RELEASES)/distributions/otelcol-otlp/manifest.yaml
 
-.PHONY: all build build-snapshot verify-version test lint lint-fix fmt schemas clean
+.PHONY: all build build-snapshot test lint lint-fix fmt schemas clean
 
 all: lint test build
 
+# No -ldflags for the version: the toolchain stamps the module version and the
+# repository state into the binary, and pkg/version reads that back.
 build:
-	go build -ldflags '$(LDFLAGS)' -o $(BINARY) ./cmd/otelcol-config-lint
-
-# The linker ignores -X against a symbol that does not exist, so LDFLAGS naming
-# a package that has moved fails silently and ships a binary reporting "dev".
-# Build one and read the version back out.
-verify-version: build
-	@got="$$($(BINARY) version)"; want='otelcol-config-lint $(VERSION)'; \
-	if [ "$$got" != "$$want" ]; then \
-		echo "the version stamp did not land: got \"$$got\", want \"$$want\"" >&2; \
-		echo 'check that LDFLAGS names the package Version actually lives in' >&2; \
-		exit 1; \
-	fi
-	@echo 'version stamp lands: $(VERSION)'
+	go build -o $(BINARY) ./cmd/otelcol-config-lint
 
 # Build every release target locally, the way CI does before a tag.
 build-snapshot:

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ pkg/schema/                   schema types, version resolution and location look
 pkg/rule/                     the rules and the registry
 pkg/lint/                     the engine and the output formatters
 pkg/diag/                     diagnostics, severities and positions
+pkg/version/                  the linter's own version, stamped at build time
 action.yml                    the GitHub Action; Dockerfile is the image it runs
 ```
 
@@ -354,8 +355,15 @@ make test            # go test -race with coverage
 make lint            # golangci-lint
 make build           # ./bin/otelcol-config-lint
 make build-snapshot  # every release target, the way CI builds them
+make verify-version  # build, then read the version back out of the binary
 make schemas         # regenerate the schemas into ../otelcol-config-schemas
 ```
+
+The version lives in `pkg/version` and both build paths stamp it there with
+`-ldflags -X`. The linker ignores `-X` against a symbol that does not exist, so
+moving that package without updating `Makefile` and `.goreleaser.yaml` would
+ship a binary reporting `dev` and nothing would fail; `make verify-version`
+reads it back out, and CI does the same to the snapshot build.
 
 CI runs the tests with coverage reported on the pull request, builds every
 release target, lints this repository's own example configs, exercises the

--- a/README.md
+++ b/README.md
@@ -355,15 +355,19 @@ make test            # go test -race with coverage
 make lint            # golangci-lint
 make build           # ./bin/otelcol-config-lint
 make build-snapshot  # every release target, the way CI builds them
-make verify-version  # build, then read the version back out of the binary
 make schemas         # regenerate the schemas into ../otelcol-config-schemas
 ```
 
-The version lives in `pkg/version` and both build paths stamp it there with
-`-ldflags -X`. The linker ignores `-X` against a symbol that does not exist, so
-moving that package without updating `Makefile` and `.goreleaser.yaml` would
-ship a binary reporting `dev` and nothing would fail; `make verify-version`
-reads it back out, and CI does the same to the snapshot build.
+Nothing injects the version. The Go toolchain records the module version and
+the repository state in every binary it builds, and `pkg/version` reads that
+back, so a tagged build reports its tag because it was built from that tag:
+
+| built from | `otelcol-config-lint version` |
+| --- | --- |
+| a tag | `v1.2.3`, or `v1.2.3+dirty` from a modified tree |
+| `go install ...@v1.2.3` | `v1.2.3` |
+| a commit between tags | `b7dbdd5`, or `b7dbdd5-dirty` |
+| no repository, or `go run` | `devel` |
 
 CI runs the tests with coverage reported on the pull request, builds every
 release target, lints this repository's own example configs, exercises the

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -23,6 +23,7 @@ import (
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/termutil"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/version"
 )
 
 // Errors reported for bad flag values.
@@ -112,7 +113,7 @@ func NewCommand(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "otelcol-config-lint <command> [flags]",
 		Short:   "Validate OpenTelemetry Collector config files against a specific collector release",
-		Version: Version,
+		Version: version.Version,
 		// The subcommands print command-level errors themselves, with the tool
 		// prefix, and stay quiet about ErrFilesInvalid.
 		SilenceErrors: true,

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -113,7 +113,7 @@ func NewCommand(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "otelcol-config-lint <command> [flags]",
 		Short:   "Validate OpenTelemetry Collector config files against a specific collector release",
-		Version: version.Version,
+		Version: version.Version(),
 		// The subcommands print command-level errors themselves, with the tool
 		// prefix, and stay quiet about ErrFilesInvalid.
 		SilenceErrors: true,

--- a/pkg/cmd/otelcol-config-lint/version.go
+++ b/pkg/cmd/otelcol-config-lint/version.go
@@ -2,12 +2,9 @@ package otelcolconfiglint
 
 import (
 	"github.com/spf13/cobra"
-)
 
-// Version is the linter's own version.
-//
-//nolint:gochecknoglobals // injected at build time with -ldflags
-var Version = "dev"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/version"
+)
 
 // versionTemplate renders the built-in --version flag the same way the
 // "version" subcommand prints it, so the two never drift apart.
@@ -20,7 +17,7 @@ func newVersionCommand() *cobra.Command {
 		Short: "Print the linter version",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
-			cmd.Printf("otelcol-config-lint %s\n", Version)
+			cmd.Printf("otelcol-config-lint %s\n", version.Version)
 		},
 	}
 }

--- a/pkg/cmd/otelcol-config-lint/version.go
+++ b/pkg/cmd/otelcol-config-lint/version.go
@@ -17,7 +17,7 @@ func newVersionCommand() *cobra.Command {
 		Short: "Print the linter version",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
-			cmd.Printf("otelcol-config-lint %s\n", version.Version)
+			cmd.Printf("otelcol-config-lint %s\n", version.Version())
 		},
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,15 @@
+// Package version reports the linter's own version.
+//
+// It is a leaf package on purpose: the build stamps it with -ldflags, and
+// anything that wants the version -- the command, an HTTP User-Agent -- can
+// depend on it without depending on the command package.
+package version
+
+// Version is the linter's own version, injected at build time.
+//
+// The linker ignores -X against a symbol that does not exist, so a build that
+// gets the path wrong silently ships "dev"; `make verify-version` builds and
+// reads it back to catch that.
+//
+//nolint:gochecknoglobals // injected at build time with -ldflags
+var Version = "dev"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,15 +1,110 @@
 // Package version reports the linter's own version.
 //
-// It is a leaf package on purpose: the build stamps it with -ldflags, and
-// anything that wants the version -- the command, an HTTP User-Agent -- can
-// depend on it without depending on the command package.
+// Nothing injects it. The Go toolchain records the main module's version and
+// the state of the repository it was built from, and this reads that back: a
+// release binary reports its tag because it was built from that tag, not
+// because a build path remembered to say so. It also covers the install the
+// README recommends -- go install ...@latest, which no build path of ours can
+// reach -- so that reports the version it resolved rather than a placeholder.
 package version
 
-// Version is the linter's own version, injected at build time.
-//
-// The linker ignores -X against a symbol that does not exist, so a build that
-// gets the path wrong silently ships "dev"; `make verify-version` builds and
-// reads it back to catch that.
-//
-//nolint:gochecknoglobals // injected at build time with -ldflags
-var Version = "dev"
+import (
+	"runtime/debug"
+	"strings"
+)
+
+const (
+	// toolchainDevel is what the toolchain reports for a main module with no
+	// version of its own.
+	toolchainDevel = "(devel)"
+
+	// Devel is reported when there is no version and no commit to fall back
+	// on: `go run`, which does not stamp the repository state, a build with
+	// -buildvcs=false, or a source tree that is not a repository at all. It is
+	// deliberately not a version, so a release that reports it is a bug and
+	// the build workflow fails on it.
+	Devel = "devel"
+
+	// shortRevisionLen abbreviates a commit the way `git describe --always`
+	// does, since that is what would have named an untagged build.
+	shortRevisionLen = 7
+
+	// pseudoRevisionLen is how much of a commit a module pseudo-version
+	// carries, and so how much of one to look for in a version to recognise
+	// that the toolchain derived it rather than a person choosing it.
+	pseudoRevisionLen = 12
+
+	// dirtySuffix marks a build from a tree with uncommitted changes. The
+	// toolchain writes "+dirty" onto a version derived from a tag; this is the
+	// same thing for one derived from a bare commit, in the shape
+	// `git describe --dirty` uses.
+	dirtySuffix = "-dirty"
+)
+
+// Version reports the linter's own version: the tag a release was built from,
+// the short commit for a build between tags, or [Devel] when the binary
+// carries neither.
+func Version() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return Devel
+	}
+
+	revision, modified := vcs(info.Settings)
+
+	return render(info.Main.Version, revision, modified)
+}
+
+// vcs pulls the repository state out of the settings the toolchain stamped.
+func vcs(settings []debug.BuildSetting) (string, bool) {
+	var (
+		revision string
+		modified bool
+	)
+
+	for _, s := range settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+
+	return revision, modified
+}
+
+// render turns what the toolchain recorded into what the user sees.
+func render(moduleVersion, revision string, modified bool) string {
+	// Between tags the module version is a pseudo-version, which ends in the
+	// commit it was derived from and so says nothing the short commit does
+	// not. Anything else is a tag, or the version `go install` resolved.
+	if moduleVersion != "" && moduleVersion != toolchainDevel && !derivedFrom(moduleVersion, revision) {
+		return moduleVersion
+	}
+
+	if revision == "" {
+		return Devel
+	}
+
+	short := revision
+	if len(short) > shortRevisionLen {
+		short = short[:shortRevisionLen]
+	}
+
+	if modified {
+		short += dirtySuffix
+	}
+
+	return short
+}
+
+// derivedFrom reports whether a module version is a pseudo-version standing in
+// for the given commit rather than a tag someone chose.
+func derivedFrom(moduleVersion, revision string) bool {
+	if len(revision) < pseudoRevisionLen {
+		return false
+	}
+
+	return strings.Contains(moduleVersion, revision[:pseudoRevisionLen])
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,121 @@
+package version //nolint:testpackage // render and vcs are the parts worth pinning
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+// TestRender pins what each build the toolchain can produce reports, since the
+// version is now derived rather than injected and nothing else says what a
+// release binary prints.
+func TestRender(t *testing.T) {
+	t.Parallel()
+
+	const revision = "b7dbdd5cfc07ed516692b8b796e3f1edb63d6539"
+
+	tests := map[string]struct {
+		moduleVersion string
+		revision      string
+		modified      bool
+		want          string
+	}{
+		"a tagged build reports its tag": {
+			moduleVersion: "v1.2.3",
+			revision:      revision,
+			modified:      false,
+			want:          "v1.2.3",
+		},
+		"a tagged build from a dirty tree keeps the toolchain's marker": {
+			moduleVersion: "v1.2.3+dirty",
+			revision:      revision,
+			modified:      true,
+			want:          "v1.2.3+dirty",
+		},
+		"go install pkg@version reports what it resolved, with no repository": {
+			moduleVersion: "v1.2.3",
+			revision:      "",
+			modified:      false,
+			want:          "v1.2.3",
+		},
+		"between tags the pseudo-version gives way to the short commit": {
+			moduleVersion: "v0.0.0-20260808131440-b7dbdd5cfc07",
+			revision:      revision,
+			modified:      false,
+			want:          "b7dbdd5",
+		},
+		"an untagged dirty tree is named the way git describe names it": {
+			moduleVersion: "v0.0.0-20260808131440-b7dbdd5cfc07+dirty",
+			revision:      revision,
+			modified:      true,
+			want:          "b7dbdd5-dirty",
+		},
+		"a main module with no version of its own falls back to the commit": {
+			moduleVersion: toolchainDevel,
+			revision:      revision,
+			modified:      false,
+			want:          "b7dbdd5",
+		},
+		"neither a version nor a commit is reported as such, not as a version": {
+			moduleVersion: toolchainDevel,
+			revision:      "",
+			modified:      false,
+			want:          Devel,
+		},
+		"an empty module version is treated the same as (devel)": {
+			moduleVersion: "",
+			revision:      revision,
+			modified:      false,
+			want:          "b7dbdd5",
+		},
+		"a short revision is reported whole": {
+			moduleVersion: toolchainDevel,
+			revision:      "b7dbdd",
+			modified:      false,
+			want:          "b7dbdd",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := render(tt.moduleVersion, tt.revision, tt.modified)
+			if got != tt.want {
+				t.Errorf("render(%q, %q, %t) = %q, want %q",
+					tt.moduleVersion, tt.revision, tt.modified, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestVCSReadsTheRepositoryState pins the setting keys the toolchain writes:
+// a typo in either is silent, and would cost every untagged build its commit.
+func TestVCSReadsTheRepositoryState(t *testing.T) {
+	t.Parallel()
+
+	revision, modified := vcs([]debug.BuildSetting{
+		{Key: "-buildmode", Value: "exe"},
+		{Key: "vcs", Value: "git"},
+		{Key: "vcs.revision", Value: "b7dbdd5cfc07ed516692b8b796e3f1edb63d6539"},
+		{Key: "vcs.modified", Value: "true"},
+	})
+
+	if revision != "b7dbdd5cfc07ed516692b8b796e3f1edb63d6539" || !modified {
+		t.Errorf("vcs() = %q, %t; want the revision and modified", revision, modified)
+	}
+
+	revision, modified = vcs(nil)
+	if revision != "" || modified {
+		t.Errorf("vcs(nil) = %q, %t; want empty and unmodified", revision, modified)
+	}
+}
+
+// TestVersionSaysSomething keeps the exported entry point from returning an
+// empty string, whatever the binary under test happens to carry.
+func TestVersionSaysSomething(t *testing.T) {
+	t.Parallel()
+
+	if got := Version(); got == "" {
+		t.Error("Version() returned an empty string")
+	}
+}


### PR DESCRIPTION
Closes #20.

Two commits: the move the issue asks for, then dropping the injection entirely.

## `pkg/version` (b7dbdd5)

`Version` lived in `pkg/cmd/otelcol-config-lint`, so the ldflags target tracked wherever the CLI happened to sit — #17 moved the command out of `internal/cli` and both build paths had to move with it. It is now a leaf package: the target stops shifting, anything that wants the version (a `User-Agent` on the schema store's fetches, say) can depend on it without importing the command package, and the `//nolint:gochecknoglobals` sits in a file where a package-level var is the point.

## No injection at all (3700c27)

The issue asks for a guard against the silent failure — the linker ignores `-X` against a symbol that does not exist, so a stale path ships binaries reporting `dev` and nothing notices. Rather than guard it, this removes it.

Since Go 1.24 the toolchain records the main module's version and the repository state in every binary it builds, so there is nothing to inject: `pkg/version` reads that back with `debug.ReadBuildInfo()`. A tagged build reports its tag because it *was* built from that tag. Both `ldflags` are gone and there is no longer a path that can be wrong.

It also fixes the install the README actually recommends: `go install ...@latest` resolves a version neither the Makefile nor goreleaser ever sees, and reported `dev` for it.

| built from | `otelcol-config-lint version` |
| --- | --- |
| a tag | `v1.2.3`, or `v1.2.3+dirty` from a modified tree |
| `go install ...@v1.2.3` | `v1.2.3` |
| a commit between tags | `b7dbdd5`, or `b7dbdd5-dirty` |
| no repository, or `go run` | `devel` |

Between tags the toolchain writes a pseudo-version (`v0.0.0-20260808131440-b7dbdd5cfc07`), which ends in the commit it came from and so says nothing the commit does not; those render as the short commit with `-dirty`, which is what `git describe --always --dirty` produced before.

One check survives in `build.yaml`, guarding the new mechanism's own failure mode rather than the old one: a shallow checkout, a missing `.git` or `-buildvcs=false` would leave release binaries reporting `devel`, so the workflow fails if the snapshot binary ever does.

## Verified

Every path was run locally, including on a temporary tag. `-s -w` strips the symbol table and DWARF, not the build info, so the stripped release binaries still self-identify:

```
### go run (no VCS stamping)              otelcol-config-lint devel
### make build, untagged + dirty          otelcol-config-lint 4f79cfe-dirty
### make build, on a tag, clean           otelcol-config-lint v0.9.9-test
### goreleaser -s -w, on a tag, clean     otelcol-config-lint v0.9.9-test
```

`go test ./...` and `golangci-lint run` (0 issues) pass; `pkg/version` has a table test pinning each row above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)