### PR TITLE
fix(schemagen): let one unresolvable module not cost a distribution

### DIFF
--- a/pkg/cmd/schemagen/module.go
+++ b/pkg/cmd/schemagen/module.go
@@ -84,7 +84,15 @@ func (o *Options) resolveModules(man *manifest) (*moduleSet, error) {
 		o.logf("  go mod download: %v\n", err)
 	}
 
-	out, err := o.goCommand(work, "list", "-m", "-json", "all")
+	// -e, so a module that cannot be resolved is reported as an entry carrying
+	// an Error rather than as a failure that takes the whole listing with it.
+	// One unresolvable module in a graph of well over a thousand is ordinary:
+	// contrib reaches github.com/DataDog/datadog-agent/pkg/api, which requires
+	// a sibling at the placeholder version its own go.mod replaces, and a
+	// replacement in a dependency is not one the go command applies. Without
+	// -e that single edge yields no schema for the distribution most configs
+	// are linted against.
+	out, err := o.goCommand(work, "list", "-m", "-e", "-json", "all")
 	if err != nil && out == "" {
 		return nil, fmt.Errorf("resolve modules: %w", err)
 	}


### PR DESCRIPTION
Generating `contrib` for `v0.135.0` produced no schema at all:

```
go list -m -json all: exit status 1: github.com/DataDog/datadog-agent/pkg/util/flavor@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```

## Why it cannot be fixed from the manifest

`github.com/DataDog/datadog-agent/pkg/api` requires a sibling module at the
placeholder version `v0.0.0-00010101000000-000000000000`, which
`datadog-agent`'s own `go.mod` resolves with a `replace`. A replacement in a
*dependency* is not one the go command applies, so the edge stays unresolvable
in any graph downstream of it. Nothing in the builder manifest reaches it —
contrib's `replaces:` at that tag is two unrelated entries.

## The cost

One bad edge in a graph of **1618 modules** took every one of the other **1167
resolvable** ones with it. contrib is the distribution most configs are linted
against, so the whole release was skipped:

```
contrib=releases/distributions/otelcol-contrib/manifest.yaml: skipped (resolve modules: ...)
schemagen: 1 of 4 manifests could not be generated
```

## The fix

Pass `-e`, so an unresolvable module comes back as an entry carrying an `Error`
rather than as a failure that ends the listing. The loop reading that output
[already logs `mod.Error` and moves on][1] — that branch was close to
unreachable, since without `-e` the go command rarely gets far enough to report
one — so the handling this needs is the handling already there.

`go mod tidy` and `go mod download all` were already best effort for exactly
this reason. `go list` was the one step that still treated a partial graph as
no graph.

## Verification

Against the real v0.135.0 contrib workspace:

| | without `-e` | with `-e` |
|---|---|---|
| exit status | 1 | 0 |
| modules listed | — | 1618 |
| carrying an `Error` | — | 1 (the DataDog one) |
| resolved to a directory | — | 1168 |

`go test ./...` passes.

This unblocks the schema backfill in #56 — contrib could not be generated for
the older releases in the retention window without it.

[1]: https://github.com/minuk-dev/otelcol-config-lint/blob/main/pkg/cmd/schemagen/module.go#L111

🤖 Generated with [Claude Code](https://claude.com/claude-code)