### PR TITLE
refactor(fs): take an afero.Fs instead of touching the filesystem directly

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
             - $gostd
             - github.com/minuk-dev/otelcol-config-lint
             - github.com/samber/mo
+            - github.com/spf13/afero
             - github.com/spf13/cobra
             - gopkg.in/yaml.v3
         test:
@@ -22,6 +23,7 @@ linters:
             - $gostd
             - github.com/minuk-dev/otelcol-config-lint
             - github.com/samber/mo
+            - github.com/spf13/afero
             - github.com/spf13/cobra
             - github.com/stretchr/testify
             - gopkg.in/yaml.v3
@@ -57,6 +59,9 @@ linters:
         - anon
         - Rule$
         - Formatter$
+        # afero.Fs is how a filesystem is passed around; there is no concrete
+        # type to return instead.
+        - Fs$
     varnamelen:
       ignore-type-assert-ok: true
       ignore-map-index-ok: true
@@ -96,6 +101,10 @@ linters:
         linters:
           - dupl
           - funlen
+          # A fake filesystem has to return afero's interfaces, and wrapping an
+          # error a test is about to assert on only hides it.
+          - ireturn
+          - wrapcheck
           - maintidx
           # Fixtures contain deliberate typos and duplicate keys, because that
           # is exactly what the rules under test are meant to catch.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.4
 
 require (
 	github.com/samber/mo v1.17.0
+	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -15,4 +16,5 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/text v0.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/mo v1.17.0 h1:EbeLc7nxIdpalstxQQakLOcXxULuMRqo7PJPtY18bQg=
 github.com/samber/mo v1.17.0/go.mod h1:DlgzJ4SYhOh41nP1L9kh9rDNERuf8IqWSAs+gj2Vxag=
+github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
+github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
@@ -22,6 +24,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
+golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -110,7 +110,8 @@ type Options struct {
 // zero value is used.
 func NewCommand(opts *Options) *cobra.Command {
 	if opts == nil {
-		opts = &Options{} //nolint:exhaustruct // every field is filled in by RegisterFlags
+		//nolint:exhaustruct // RegisterFlags fills in every flag, and a nil Fs is the real filesystem
+		opts = &Options{}
 	}
 
 	// The root carries no work of its own: every mode is a subcommand, so a

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
 	"runtime"
 	"strings"
 
 	"github.com/samber/mo"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -78,6 +78,11 @@ const DefaultSettingsFile = ".otelcol-config-lint.yaml"
 // Options holds everything the command was asked to do. The fields are filled
 // in by RegisterFlags and then by the settings file, in that order.
 type Options struct {
+	// Fs is the filesystem the settings file, the config files and any local
+	// schema location are read from. A nil Fs means the real one, which is
+	// what the binary uses.
+	Fs afero.Fs
+
 	// flags
 	collectorVersion string
 	distribution     string
@@ -168,14 +173,14 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 // Prepare folds the settings file into the parsed flags and builds the schema
 // store. Flags given on the command line win over the file.
 func (o *Options) Prepare(cmd *cobra.Command) error {
-	fileSettings, err := loadSettings(o.settingsFile)
+	fileSettings, err := loadSettings(o.fs(), o.settingsFile)
 	if err != nil {
 		return err
 	}
 
 	o.applySettings(fileSettings, cmd.Flags().Changed)
 
-	o.store = schema.Store{Locations: o.schemaLocations, Distribution: o.distribution}
+	o.store = schema.Store{Locations: o.schemaLocations, Distribution: o.distribution, Fs: o.Fs}
 
 	return nil
 }
@@ -194,6 +199,16 @@ func (o *Options) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// fs returns the filesystem to read, which is the real one unless the caller
+// named another.
+func (o *Options) fs() afero.Fs {
+	if o.Fs == nil {
+		return afero.NewOsFs()
+	}
+
+	return o.Fs
 }
 
 // registerSettingsFlag declares --config. Every command honours it: the
@@ -229,7 +244,10 @@ func (o *Options) registerRuleFlags(cmd *cobra.Command) {
 
 // runLint resolves what to check and how to report it, then does the work.
 func (o *Options) runLint(cmd *cobra.Command, paths []string) error {
-	files, err := scanner.New(splitList(o.exclude)).Scan(paths)
+	sc := scanner.New(splitList(o.exclude))
+	sc.Fs = o.Fs
+
+	files, err := sc.Scan(paths)
 	if err != nil {
 		return fmt.Errorf("collect files: %w", err)
 	}
@@ -333,6 +351,7 @@ func (o *Options) newLinter(cmd *cobra.Command) (*lint.Linter, error) {
 
 	return lint.New(lint.Options{
 		Schema:               cat,
+		Fs:                   o.Fs,
 		Availability:         lint.NewVersionIndex(o.store),
 		Distributions:        lint.NewDistributionIndex(o.store, cat.CollectorVersion),
 		Severities:           severities,
@@ -425,13 +444,13 @@ type settings struct {
 
 // loadSettings reads a settings file. When path is empty the default file is
 // used if it exists, and a missing default is not an error.
-func loadSettings(path string) (*settings, error) {
+func loadSettings(fsys afero.Fs, path string) (*settings, error) {
 	required := path != ""
 	if path == "" {
 		path = DefaultSettingsFile
 	}
 
-	src, err := os.ReadFile(path)
+	src, err := afero.ReadFile(fsys, path)
 	if err != nil {
 		if !required && errors.Is(err, fs.ErrNotExist) {
 			return &settings{}, nil //nolint:exhaustruct // an absent file means every option keeps its default

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	otelcolconfiglint "github.com/minuk-dev/otelcol-config-lint/pkg/cmd/otelcol-config-lint"
 )
 
@@ -429,6 +431,47 @@ func TestAnEmptySettingsFileKeepsTheDefaults(t *testing.T) {
 
 	if out != "" {
 		t.Errorf("the default text output should stay in force, got %q", out)
+	}
+}
+
+// TestOptionsFsRunsEntirelyInMemory pins that Options.Fs governs every file the
+// command reads -- the settings file, the schema location and the configs it
+// walks to -- so an embedder can run a lint against a tree that was never
+// written to disk.
+func TestOptionsFsRunsEntirelyInMemory(t *testing.T) {
+	t.Parallel()
+
+	fsys := afero.NewMemMapFs()
+
+	memWrite(t, fsys, "/schemas/v0.157.0.json",
+		`{"collectorVersion":"v0.157.0","components":{`+
+			`"receiver":{"otlp":{"type":"otlp","signals":["traces"]}},`+
+			`"exporter":{"debug":{"type":"debug","signals":["traces"]}}}}`)
+	memWrite(t, fsys, "/etc/settings.yaml", "schemaLocations: [/schemas]\nminSeverity: error\n")
+	memWrite(t, fsys, "/configs/agent.yaml",
+		"receivers:\n  otlp:\nexporters:\n  debug:\n"+
+			"service:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      exporters: [debug]\n")
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := otelcolconfiglint.NewCommand(&otelcolconfiglint.Options{Fs: fsys})
+	cmd.SetArgs([]string{"run", "--config", "/etc/settings.yaml", "/configs"})
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	code := otelcolconfiglint.ExitCode(cmd.Execute())
+	if code != 0 {
+		t.Fatalf("exit %d, stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func memWrite(t *testing.T, fsys afero.Fs, path, content string) {
+	t.Helper()
+
+	err := afero.WriteFile(fsys, path, []byte(content), 0o600)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -3,9 +3,9 @@ package config
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
+	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
@@ -129,9 +129,14 @@ func (f *File) Component(k Kind, id ID) (Component, bool) {
 	return Component{}, false
 }
 
-// ParseFile reads and parses the config at path.
-func ParseFile(path string) (*File, error) {
-	src, err := os.ReadFile(path)
+// ParseFile reads and parses the config at path. A nil fsys reads the real
+// filesystem.
+func ParseFile(fsys afero.Fs, path string) (*File, error) {
+	if fsys == nil {
+		fsys = afero.NewOsFs()
+	}
+
+	src, err := afero.ReadFile(fsys, path)
 	if err != nil {
 		return nil, fmt.Errorf("read config: %w", err)
 	}

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -4,8 +4,9 @@ package lint
 import (
 	"errors"
 	"io"
-	"os"
 	"sync"
+
+	"github.com/spf13/afero"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
@@ -50,6 +51,8 @@ func (r Result) Message() string {
 type Options struct {
 	// Schema describes the collector release to check against.
 	Schema *schema.Schema
+	// Fs is the filesystem LintFile reads from. A nil Fs means the real one.
+	Fs afero.Fs
 	// Availability lets diagnostics mention other releases. May be nil.
 	Availability rule.Availability
 	// Distributions lets diagnostics mention other distributions. May be nil.
@@ -115,7 +118,7 @@ func (l *Linter) SeverityFor(r rule.Rule) diag.Severity {
 
 // LintFile reads and checks a single config file.
 func (l *Linter) LintFile(path string) Result {
-	src, err := os.ReadFile(path)
+	src, err := afero.ReadFile(l.fs(), path)
 	if err != nil {
 		return Result{Path: path, Status: Error, Err: err}
 	}
@@ -213,6 +216,16 @@ func (l *Linter) LintAll(paths []string, n int) <-chan Result {
 	}()
 
 	return out
+}
+
+// fs returns the filesystem to read, which is the real one unless the caller
+// named another.
+func (l *Linter) fs() afero.Fs {
+	if l.opts.Fs == nil {
+		return afero.NewOsFs()
+	}
+
+	return l.opts.Fs
 }
 
 // Summary counts results by status and diagnostics by severity.

--- a/pkg/lint/linter_test.go
+++ b/pkg/lint/linter_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/lint"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
@@ -180,6 +182,29 @@ func TestLintAllVisitsEveryFile(t *testing.T) {
 
 	if len(seen) != len(paths) {
 		t.Errorf("want %d results, got %d", len(paths), len(seen))
+	}
+}
+
+// TestLintFileReadsTheGivenFs pins that LintFile honours Options.Fs, so a
+// caller can lint a config that was never written to disk.
+func TestLintFileReadsTheGivenFs(t *testing.T) {
+	t.Parallel()
+
+	fsys := afero.NewMemMapFs()
+
+	err := afero.WriteFile(fsys, "/configs/agent.yaml", []byte(good), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l := newLinter(t, lint.Options{Fs: fsys, MinSeverity: diag.Error})
+
+	if r := l.LintFile("/configs/agent.yaml"); r.Status != lint.Valid {
+		t.Errorf("want valid, got %s: %v %+v", r.Status, r.Err, r.Diagnostics)
+	}
+
+	if r := l.LintFile("/configs/absent.yaml"); r.Status != lint.Error {
+		t.Errorf("a missing file should be an error, got %s", r.Status)
 	}
 }
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -97,7 +97,22 @@ func (s *Scanner) fs() afero.Fs {
 func (s *Scanner) walk(root string, files sets.Set[string]) error {
 	err := afero.Walk(s.fs(), root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			// A walk fails in two ways, and they do not deserve the same
+			// answer. A directory that cannot be listed arrives with its own
+			// info, and losing one would quietly shorten the file list, so it
+			// ends the scan. An entry that cannot be stat'd arrives with no
+			// info at all -- it was removed while the walk was running, or it
+			// sits in a directory that can be listed but not searched. Its
+			// name is still known, so a config file goes into the set and is
+			// reported as a file that could not be read, rather than costing
+			// every other file in the tree.
+			if info != nil || path == root {
+				return err
+			}
+
+			s.insert(path, files)
+
+			return nil
 		}
 
 		if info.IsDir() {
@@ -108,11 +123,7 @@ func (s *Scanner) walk(root string, files sets.Set[string]) error {
 			return nil
 		}
 
-		if !s.wanted(info.Name()) || s.excluded(path) {
-			return nil
-		}
-
-		files.Insert(filepath.Clean(path))
+		s.insert(path, files)
 
 		return nil
 	})
@@ -121,6 +132,17 @@ func (s *Scanner) walk(root string, files sets.Set[string]) error {
 	}
 
 	return nil
+}
+
+// insert adds a walked path to files when it is a config file the walk picks
+// up. The name is all it goes on, so it serves an entry that could not be
+// stat'd as well as one that could.
+func (s *Scanner) insert(path string, files sets.Set[string]) {
+	if !s.wanted(filepath.Base(path)) || s.excluded(path) {
+		return
+	}
+
+	files.Insert(filepath.Clean(path))
 }
 
 // skipDir reports whether a walk should stay out of a directory.

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/spf13/afero"
+
 	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
 )
 
@@ -19,6 +21,9 @@ const StdinMarker = "-"
 
 // Scanner turns paths into the files to lint.
 type Scanner struct {
+	// Fs is the filesystem the paths are read from. A nil Fs means the real
+	// one, so the zero value scans the machine the linter runs on.
+	Fs afero.Fs
 	// Exclude are glob patterns skipped during a directory walk, matched
 	// against both the full path and the base name. A pattern containing "*"
 	// also matches anywhere in the path.
@@ -35,6 +40,7 @@ type Scanner struct {
 // usual vendored directories, and skips anything matching exclude.
 func New(exclude []string) *Scanner {
 	return &Scanner{
+		Fs:         nil,
 		Exclude:    exclude,
 		Extensions: []string{".yaml", ".yml"},
 		SkipDirs:   []string{"vendor", "node_modules"},
@@ -55,7 +61,7 @@ func (s *Scanner) Scan(paths []string) (sets.Set[string], error) {
 			continue
 		}
 
-		info, err := os.Stat(path)
+		info, err := s.fs().Stat(path)
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", path, err)
 		}
@@ -77,22 +83,32 @@ func (s *Scanner) Scan(paths []string) (sets.Set[string], error) {
 	return files, nil
 }
 
+// fs returns the filesystem to read, which is the real one unless the caller
+// named another.
+func (s *Scanner) fs() afero.Fs {
+	if s.Fs == nil {
+		return afero.NewOsFs()
+	}
+
+	return s.Fs
+}
+
 // walk adds every config file under root to files.
 func (s *Scanner) walk(root string, files sets.Set[string]) error {
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	err := afero.Walk(s.fs(), root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if d.IsDir() {
-			if path != root && s.skipDir(d.Name()) {
+		if info.IsDir() {
+			if path != root && s.skipDir(info.Name()) {
 				return fs.SkipDir
 			}
 
 			return nil
 		}
 
-		if !s.wanted(d.Name()) || s.excluded(path) {
+		if !s.wanted(info.Name()) || s.excluded(path) {
 			return nil
 		}
 

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -329,6 +329,44 @@ func (b blocked) Open(name string) (afero.File, error) {
 	return b.Fs.Open(name)
 }
 
+// TestScanSurvivesAnEntryItCannotStat pins that one bad entry does not cost the
+// walk. A file can be removed between the directory read and the stat that
+// follows it, and a directory can be listable without being searchable; ending
+// the scan there would report nothing for a tree that is otherwise fine. The
+// name is still known, so the file is kept and the linter reports it as one it
+// could not read.
+func TestScanSurvivesAnEntryItCannotStat(t *testing.T) {
+	t.Parallel()
+
+	fsys := vanished{Fs: tree(t, "keep.yaml", "gone.yaml"), path: filepath.Join(root, "gone.yaml")}
+
+	files, err := newScanner(fsys, nil).Scan([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := relative(t, files)
+	if want := []string{"gone.yaml", "keep.yaml"}; !slices.Equal(got, want) {
+		t.Errorf("Scan() = %v, want %v", got, want)
+	}
+}
+
+// vanished lists one path but refuses to stat it, standing in for a file
+// removed while the walk was running.
+type vanished struct {
+	afero.Fs
+
+	path string
+}
+
+func (v vanished) Stat(name string) (os.FileInfo, error) {
+	if name == v.path {
+		return nil, &os.PathError{Op: "stat", Path: name, Err: os.ErrNotExist}
+	}
+
+	return v.Fs.Stat(name)
+}
+
 func TestScanOfNothingIsEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -367,22 +405,54 @@ func TestScannerFieldsAreHonoured(t *testing.T) {
 
 // TestNilFsReadsTheRealFilesystem pins the documented default: a Scanner that
 // was never given an Fs still walks the machine it runs on.
+//
+// It repeats what the in-memory tests cover because the two filesystems are
+// not interchangeable underneath. OsFs implements afero.Lstater and MemMapFs
+// does not, so the walk takes a different path through afero on each, and this
+// is the one the shipped binary runs.
 func TestNilFsReadsTheRealFilesystem(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 
-	err := os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte("receivers:\n"), 0o600)
+	for _, name := range []string{
+		"agent.yaml",
+		"nested/deep.yml",
+		"notes.txt",
+		".git/config.yaml",
+		"vendor/dep.yaml",
+		"gen/agent.generated.yaml",
+	} {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+
+		err := os.MkdirAll(filepath.Dir(path), 0o750)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = os.WriteFile(path, []byte("receivers:\n"), 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := scanner.New([]string{"*.generated.yaml"}).Scan([]string{dir})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	files, err := scanner.New(nil).Scan([]string{dir})
-	if err != nil {
-		t.Fatal(err)
+	got := make([]string, 0, files.Len())
+
+	for _, path := range sets.List(files) {
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got = append(got, filepath.ToSlash(rel))
 	}
 
-	if !files.Has(filepath.Join(dir, "agent.yaml")) {
-		t.Errorf("Scan() = %v, want the file on disk", sets.List(files))
+	if want := []string{"agent.yaml", "nested/deep.yml"}; !slices.Equal(got, want) {
+		t.Errorf("Scan() = %v, want %v", got, want)
 	}
 }

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -8,36 +8,56 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"github.com/minuk-dev/otelcol-config-lint/pkg/scanner"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
 )
 
-// tree writes each named file under a fresh temporary directory and returns it.
-func tree(t *testing.T, names ...string) string {
+// root is where every test tree is written. It is in-memory, so the name is
+// arbitrary and nothing on the machine running the tests is touched.
+const root = "/repo"
+
+// tree writes each named file to a fresh in-memory filesystem under root and
+// returns it.
+func tree(t *testing.T, names ...string) afero.Fs {
 	t.Helper()
 
-	root := t.TempDir()
+	fsys := afero.NewMemMapFs()
+
+	err := fsys.MkdirAll(root, 0o750)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, name := range names {
 		path := filepath.Join(root, filepath.FromSlash(name))
 
-		err := os.MkdirAll(filepath.Dir(path), 0o750)
+		err := fsys.MkdirAll(filepath.Dir(path), 0o750)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = os.WriteFile(path, []byte("receivers:\n"), 0o600)
+		err = afero.WriteFile(fsys, path, []byte("receivers:\n"), 0o600)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	return root
+	return fsys
+}
+
+// newScanner builds the default scanner pointed at an in-memory tree.
+func newScanner(fsys afero.Fs, exclude []string) *scanner.Scanner {
+	s := scanner.New(exclude)
+	s.Fs = fsys
+
+	return s
 }
 
 // relative turns the scan result back into slash-separated paths under root, so
 // the assertions read like the tree that was written.
-func relative(t *testing.T, root string, files sets.Set[string]) []string {
+func relative(t *testing.T, files sets.Set[string]) []string {
 	t.Helper()
 
 	out := make([]string, 0, files.Len())
@@ -63,14 +83,14 @@ func relative(t *testing.T, root string, files sets.Set[string]) []string {
 func TestScanWalksADirectory(t *testing.T) {
 	t.Parallel()
 
-	root := tree(t, "a.yaml", "b.yml", "nested/c.yaml", "notes.txt", "no-extension")
+	fsys := tree(t, "a.yaml", "b.yml", "nested/c.yaml", "notes.txt", "no-extension")
 
-	files, err := scanner.New(nil).Scan([]string{root})
+	files, err := newScanner(fsys, nil).Scan([]string{root})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got := relative(t, root, files)
+	got := relative(t, files)
 	if want := []string{"a.yaml", "b.yml", "nested/c.yaml"}; !slices.Equal(got, want) {
 		t.Errorf("Scan() = %v, want %v", got, want)
 	}
@@ -79,22 +99,22 @@ func TestScanWalksADirectory(t *testing.T) {
 func TestScanIsCaseInsensitiveAboutExtensions(t *testing.T) {
 	t.Parallel()
 
-	root := tree(t, "loud.YAML", "mixed.Yml")
+	fsys := tree(t, "loud.YAML", "mixed.Yml")
 
-	files, err := scanner.New(nil).Scan([]string{root})
+	files, err := newScanner(fsys, nil).Scan([]string{root})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if files.Len() != 2 {
-		t.Errorf("Scan() found %v, want both files", relative(t, root, files))
+		t.Errorf("Scan() found %v, want both files", relative(t, files))
 	}
 }
 
 func TestScanSkipsDotAndVendorDirectories(t *testing.T) {
 	t.Parallel()
 
-	root := tree(t,
+	fsys := tree(t,
 		"keep.yaml",
 		".git/config.yaml",
 		"vendor/dep.yaml",
@@ -102,12 +122,12 @@ func TestScanSkipsDotAndVendorDirectories(t *testing.T) {
 		"nested/.hidden/deep.yaml",
 	)
 
-	files, err := scanner.New(nil).Scan([]string{root})
+	files, err := newScanner(fsys, nil).Scan([]string{root})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got := relative(t, root, files)
+	got := relative(t, files)
 	if want := []string{"keep.yaml"}; !slices.Equal(got, want) {
 		t.Errorf("Scan() = %v, want %v", got, want)
 	}
@@ -118,14 +138,14 @@ func TestScanSkipsDotAndVendorDirectories(t *testing.T) {
 func TestScanEntersADotDirectoryNamedDirectly(t *testing.T) {
 	t.Parallel()
 
-	root := tree(t, ".config/app.yaml")
+	fsys := tree(t, ".config/app.yaml")
 
-	files, err := scanner.New(nil).Scan([]string{filepath.Join(root, ".config")})
+	files, err := newScanner(fsys, nil).Scan([]string{filepath.Join(root, ".config")})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got := relative(t, root, files)
+	got := relative(t, files)
 	if want := []string{".config/app.yaml"}; !slices.Equal(got, want) {
 		t.Errorf("Scan() = %v, want %v", got, want)
 	}
@@ -171,14 +191,14 @@ func TestScanExcludePatterns(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			root := tree(t, "agent.yaml", "keep.yaml", "gen/agent.generated.yaml")
+			fsys := tree(t, "agent.yaml", "keep.yaml", "gen/agent.generated.yaml")
 
-			files, err := scanner.New(tt.exclude).Scan([]string{root})
+			files, err := newScanner(fsys, tt.exclude).Scan([]string{root})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if got := relative(t, root, files); !slices.Equal(got, tt.want) {
+			if got := relative(t, files); !slices.Equal(got, tt.want) {
 				t.Errorf("Scan() = %v, want %v", got, tt.want)
 			}
 		})
@@ -190,10 +210,10 @@ func TestScanExcludePatterns(t *testing.T) {
 func TestScanKeepsAnExplicitlyNamedFile(t *testing.T) {
 	t.Parallel()
 
-	root := tree(t, "agent.yaml")
+	fsys := tree(t, "agent.yaml")
 	path := filepath.Join(root, "agent.yaml")
 
-	files, err := scanner.New([]string{"agent.yaml"}).Scan([]string{path})
+	files, err := newScanner(fsys, []string{"agent.yaml"}).Scan([]string{path})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,10 +228,10 @@ func TestScanKeepsAnExplicitlyNamedFile(t *testing.T) {
 func TestScanKeepsAnExplicitlyNamedFileWhateverItsExtension(t *testing.T) {
 	t.Parallel()
 
-	root := tree(t, "config.txt")
+	fsys := tree(t, "config.txt")
 	path := filepath.Join(root, "config.txt")
 
-	files, err := scanner.New(nil).Scan([]string{path})
+	files, err := newScanner(fsys, nil).Scan([]string{path})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,14 +244,14 @@ func TestScanKeepsAnExplicitlyNamedFileWhateverItsExtension(t *testing.T) {
 func TestScanDeduplicates(t *testing.T) {
 	t.Parallel()
 
-	root := tree(t, "agent.yaml")
+	fsys := tree(t, "agent.yaml")
 	path := filepath.Join(root, "agent.yaml")
 
 	// Named through the walk, named directly, and named directly again with a
 	// path that needs cleaning.
 	unclean := filepath.Join(root, ".", "agent.yaml")
 
-	files, err := scanner.New(nil).Scan([]string{root, path, unclean})
+	files, err := newScanner(fsys, nil).Scan([]string{root, path, unclean})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -244,9 +264,9 @@ func TestScanDeduplicates(t *testing.T) {
 func TestScanPassesStdinThrough(t *testing.T) {
 	t.Parallel()
 
-	root := tree(t, "agent.yaml")
+	fsys := tree(t, "agent.yaml")
 
-	files, err := scanner.New(nil).Scan([]string{scanner.StdinMarker, root})
+	files, err := newScanner(fsys, nil).Scan([]string{scanner.StdinMarker, root})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,16 +276,14 @@ func TestScanPassesStdinThrough(t *testing.T) {
 	}
 
 	if files.Len() != 2 {
-		t.Errorf("Scan() = %v, want the marker and the file", relative(t, root, files))
+		t.Errorf("Scan() = %v, want the marker and the file", relative(t, files))
 	}
 }
 
 func TestScanReportsAMissingPath(t *testing.T) {
 	t.Parallel()
 
-	missing := filepath.Join(t.TempDir(), "nope.yaml")
-
-	_, err := scanner.New(nil).Scan([]string{missing})
+	_, err := newScanner(tree(t), nil).Scan([]string{filepath.Join(root, "nope.yaml")})
 	if err == nil {
 		t.Fatal("want an error for a path that does not exist")
 	}
@@ -275,10 +293,46 @@ func TestScanReportsAMissingPath(t *testing.T) {
 	}
 }
 
+// TestScanReportsADirectoryItCannotRead pins that a walk failure reaches the
+// caller instead of being swallowed into a short file list. A real filesystem
+// can only produce this with a chmod, which root would not honour anyway.
+func TestScanReportsADirectoryItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	locked := filepath.Join(root, "locked")
+
+	fsys := blocked{Fs: tree(t, "keep.yaml", "locked/deep.yaml"), path: locked}
+
+	_, err := newScanner(fsys, nil).Scan([]string{root})
+	if err == nil {
+		t.Fatal("want an error for a directory the walk may not read")
+	}
+
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("the cause should survive wrapping, got %v", err)
+	}
+}
+
+// blocked refuses to open one path, standing in for a directory the process
+// does not have permission to read.
+type blocked struct {
+	afero.Fs
+
+	path string
+}
+
+func (b blocked) Open(name string) (afero.File, error) {
+	if name == b.path {
+		return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrPermission}
+	}
+
+	return b.Fs.Open(name)
+}
+
 func TestScanOfNothingIsEmpty(t *testing.T) {
 	t.Parallel()
 
-	files, err := scanner.New(nil).Scan(nil)
+	files, err := newScanner(tree(t), nil).Scan(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,9 +347,8 @@ func TestScanOfNothingIsEmpty(t *testing.T) {
 func TestScannerFieldsAreHonoured(t *testing.T) {
 	t.Parallel()
 
-	root := tree(t, "a.json", "b.yaml", "skipme/c.json")
-
 	s := &scanner.Scanner{
+		Fs:         tree(t, "a.json", "b.yaml", "skipme/c.json"),
 		Exclude:    nil,
 		Extensions: []string{".json"},
 		SkipDirs:   []string{"skipme"},
@@ -306,8 +359,30 @@ func TestScannerFieldsAreHonoured(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := relative(t, root, files)
+	got := relative(t, files)
 	if want := []string{"a.json"}; !slices.Equal(got, want) {
 		t.Errorf("Scan() = %v, want %v", got, want)
+	}
+}
+
+// TestNilFsReadsTheRealFilesystem pins the documented default: a Scanner that
+// was never given an Fs still walks the machine it runs on.
+func TestNilFsReadsTheRealFilesystem(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte("receivers:\n"), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := scanner.New(nil).Scan([]string{dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !files.Has(filepath.Join(dir, "agent.yaml")) {
+		t.Errorf("Scan() = %v, want the file on disk", sets.List(files))
 	}
 }

--- a/pkg/schema/index.go
+++ b/pkg/schema/index.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"sort"
+
+	"github.com/spf13/afero"
 )
 
 // IndexFile is the name a registry publishes its index under.
@@ -60,7 +61,12 @@ func ReadIndex(r io.Reader) (*Index, error) {
 
 // ReadIndexFile decodes a registry index from a file on disk.
 func ReadIndexFile(path string) (*Index, error) {
-	f, err := os.Open(path)
+	return readIndexFile(afero.NewOsFs(), path)
+}
+
+// readIndexFile decodes a registry index from a file on the given filesystem.
+func readIndexFile(fsys afero.Fs, path string) (*Index, error) {
+	f, err := fsys.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open index: %w", err)
 	}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -7,11 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"sort"
 	"strings"
 
+	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
@@ -271,7 +271,12 @@ func Read(r io.Reader) (*Schema, error) {
 
 // ReadFile decodes a schema from a file on disk.
 func ReadFile(path string) (*Schema, error) {
-	f, err := os.Open(path)
+	return readFile(afero.NewOsFs(), path)
+}
+
+// readFile decodes a schema from a file on the given filesystem.
+func readFile(fsys afero.Fs, path string) (*Schema, error) {
+	f, err := fsys.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open schema: %w", err)
 	}

--- a/pkg/schema/store.go
+++ b/pkg/schema/store.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/spf13/afero"
 )
 
 // Extensions returns the schema file suffixes, in preference order. The
@@ -75,6 +77,9 @@ type Store struct {
 	// HTTPClient fetches remote locations. A nil client uses a default with a
 	// 30 second timeout.
 	HTTPClient *http.Client
+	// Fs is the filesystem local locations are read from. A nil Fs means the
+	// real one. Remote locations go over HTTPClient and ignore it.
+	Fs afero.Fs
 }
 
 // Versions lists every schema the store can serve, newest first. Templated and
@@ -150,6 +155,16 @@ func (s Store) Load(version string) (*Schema, error) {
 	return nil, &UnknownVersionError{Version: version, Available: s.Versions(), Tried: tried}
 }
 
+// fs returns the filesystem to read local locations from, which is the real one
+// unless the caller named another.
+func (s Store) fs() afero.Fs {
+	if s.Fs == nil {
+		return afero.NewOsFs()
+	}
+
+	return s.Fs
+}
+
 // distribution returns the distribution to serve.
 func (s Store) distribution() string {
 	if s.Distribution == "" {
@@ -170,7 +185,7 @@ func (s Store) indexAt(loc string) *Index {
 
 		return idx
 	case locDir:
-		idx, err := ReadIndexFile(filepath.Join(loc, IndexFile))
+		idx, err := readIndexFile(s.fs(), filepath.Join(loc, IndexFile))
 		if err != nil {
 			return nil
 		}
@@ -193,12 +208,12 @@ func (s Store) versionsAt(loc string) []string {
 
 		return idx.Versions(s.distribution())
 	case locDir:
-		idx, err := ReadIndexFile(filepath.Join(loc, IndexFile))
+		idx, err := readIndexFile(s.fs(), filepath.Join(loc, IndexFile))
 		if err == nil {
 			return idx.Versions(s.distribution())
 		}
 
-		return flatVersions(loc)
+		return flatVersions(s.fs(), loc)
 	default:
 		return nil
 	}
@@ -206,11 +221,11 @@ func (s Store) versionsAt(loc string) []string {
 
 // flatVersions lists "<dir>/<version>.<ext>", the layout used before schemas
 // were split by distribution.
-func flatVersions(dir string) []string {
+func flatVersions(fsys afero.Fs, dir string) []string {
 	var out []string
 
 	for _, ext := range extensions() {
-		names, _ := filepath.Glob(filepath.Join(dir, "*"+ext))
+		names, _ := afero.Glob(fsys, filepath.Join(dir, "*"+ext))
 		for _, n := range names {
 			out = append(out, trimExt(filepath.Base(n)))
 		}
@@ -232,8 +247,8 @@ func trimExt(name string) string {
 
 // isRegistryDir reports whether a directory is a registry root: one carrying an
 // index, and so laid out by distribution.
-func isRegistryDir(dir string) bool {
-	_, err := os.Stat(filepath.Join(dir, IndexFile))
+func (s Store) isRegistryDir(dir string) bool {
+	_, err := s.fs().Stat(filepath.Join(dir, IndexFile))
 
 	return err == nil
 }
@@ -277,11 +292,11 @@ func (s Store) loadFrom(loc, version string) (*Schema, error) {
 	default:
 		// A directory holding an index is a registry root, laid out by
 		// distribution. Without one it is the flat legacy layout.
-		if isRegistryDir(loc) {
-			return s.loadFromRegistry(loc, version, readLocal)
+		if s.isRegistryDir(loc) {
+			return s.loadFromRegistry(loc, version, s.readLocal)
 		}
 
-		return loadFlat(loc, version)
+		return s.loadFlat(loc, version)
 	}
 }
 
@@ -291,7 +306,7 @@ func (s Store) loadOne(target string) (*Schema, error) {
 		return s.fetch(target)
 	}
 
-	return readLocal(target)
+	return s.readLocal(target)
 }
 
 // loadFromRegistry reads "<root>/<distribution>/<version>.<ext>", preferring
@@ -313,13 +328,13 @@ func (s Store) loadFromRegistry(root, version string, read func(string) (*Schema
 
 // loadFlat reads "<dir>/<version>.<ext>", the layout used before schemas were
 // split by distribution.
-func loadFlat(dir, version string) (*Schema, error) {
+func (s Store) loadFlat(dir, version string) (*Schema, error) {
 	for _, ext := range extensions() {
 		path := filepath.Join(dir, version+ext)
 
-		_, err := os.Stat(path)
+		_, err := s.fs().Stat(path)
 		if err == nil {
-			return ReadFile(path)
+			return readFile(s.fs(), path)
 		}
 	}
 
@@ -328,13 +343,13 @@ func loadFlat(dir, version string) (*Schema, error) {
 
 // readLocal reads a schema from disk, reporting a missing file as errNotFound
 // so a registry root can fall through to the next extension.
-func readLocal(path string) (*Schema, error) {
-	_, err := os.Stat(path)
+func (s Store) readLocal(path string) (*Schema, error) {
+	_, err := s.fs().Stat(path)
 	if err != nil {
 		return nil, errNotFound
 	}
 
-	return ReadFile(path)
+	return readFile(s.fs(), path)
 }
 
 // fetchIndex reads a remote registry's index.
@@ -451,7 +466,7 @@ func (s Store) resolve(loc, version string) string {
 	case locRemote:
 		return join(loc, s.distribution(), version+extensions()[0])
 	default:
-		if isRegistryDir(loc) {
+		if s.isRegistryDir(loc) {
 			return filepath.Join(loc, s.distribution(), version+extensions()[0])
 		}
 

--- a/pkg/schema/store_test.go
+++ b/pkg/schema/store_test.go
@@ -6,8 +6,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/spf13/afero"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
@@ -431,6 +434,58 @@ func TestDistributionPlaceholderInATemplate(t *testing.T) {
 
 	if cat.Distribution != distCore {
 		t.Errorf("unexpected schema: %+v", cat)
+	}
+}
+
+// TestStoreFsReadsAnInMemoryRegistry pins that Fs governs every local read a
+// store does: the index it enumerates from and the schema it loads. Nothing
+// here is written to disk.
+func TestStoreFsReadsAnInMemoryRegistry(t *testing.T) {
+	t.Parallel()
+
+	fsys := afero.NewMemMapFs()
+	root := filepath.FromSlash("/registry")
+
+	memWrite(t, fsys, filepath.Join(root, schema.IndexFile),
+		`{"distributions":{"core":["v0.150.0"]}}`)
+	memWrite(t, fsys, filepath.Join(root, distCore, "v0.150.0.json"),
+		`{"collectorVersion":"v0.150.0","distribution":"core","components":{}}`)
+
+	store := schema.Store{Locations: []string{root}, Distribution: distCore, Fs: fsys}
+
+	if got := store.Versions(); !slices.Equal(got, []string{"v0.150.0"}) {
+		t.Errorf("Versions() = %v, want the in-memory index", got)
+	}
+
+	cat, err := store.Load(schema.Latest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cat.CollectorVersion != "v0.150.0" {
+		t.Errorf("unexpected schema: %+v", cat)
+	}
+}
+
+// TestStoreFsIsNotTheRealFilesystem pins the other half: once an Fs is given,
+// a location that exists on disk is no longer reachable.
+func TestStoreFsIsNotTheRealFilesystem(t *testing.T) {
+	t.Parallel()
+
+	store := schema.Store{Locations: []string{repoSchemas}, Fs: afero.NewMemMapFs()}
+
+	_, err := store.Load(schema.Latest)
+	if err == nil {
+		t.Error("want an error: the committed schemas are not on the given Fs")
+	}
+}
+
+func memWrite(t *testing.T, fsys afero.Fs, path, content string) {
+	t.Helper()
+
+	err := afero.WriteFile(fsys, path, []byte(content), 0o600)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Closes #22.

## What

Every package that reads files now carries an `afero.Fs`. A nil `Fs` means the real one, so the zero value behaves exactly as before and no existing caller changes.

| Package | Where |
| --- | --- |
| `pkg/scanner` | `Scanner.Fs`, walked with `afero.Walk` instead of `filepath.WalkDir` |
| `pkg/schema` | `Store.Fs`, for local locations only |
| `pkg/lint` | `Options.Fs`, read by `LintFile` |
| `pkg/config` | `ParseFile` takes the fs as its first argument |
| `pkg/cmd/otelcol-config-lint` | `Options.Fs`, threaded into all of the above |

`Store.Fs` deliberately governs only the local half. A remote registry goes over `HTTPClient`, which is where that path was already injectable and where a filesystem has nothing to say — the issue's "reaching into the catalog touches the HTTP path too" concern.

`schema.ReadFile` and `schema.ReadIndexFile` keep their signatures and keep reading the real filesystem; the store calls unexported variants that take an `Fs`. `pkg/cmd/schemagen` is untouched — it is a generator that writes files, shells out to the Go toolchain and fetches over the network, so an `Fs` would only cover a fraction of what it does.

## afero, not `fs.FS`

The issue asked for this to be weighed. These packages are handed absolute, OS-shaped paths straight off a command line, which is what `afero.Fs` takes. `fs.FS` wants rooted, slash-separated, relative names, so every entry point would need an `os.DirFS` wrapper and a path rewrite to accept `--schema-location /etc/schemas` or `otelcol-config-lint run /srv/configs`. The dependency is free in practice: spf13 is already here for cobra and pflag.

## The walk is not a like-for-like swap (second commit)

`afero.Walk` is a port of the *old* `filepath.Walk`, not of `filepath.WalkDir`: it lstats every entry it lists and hands the failure to the callback, where `WalkDir` took the name and the kind straight from the directory read and never stat'd regular files at all. Returning that error unconditionally — which is what the first commit did — widened what ends a scan. A file removed while the walk was running, or a directory that is listable but not searchable, aborted discovery and left the run reporting nothing for a tree that was almost entirely fine. On the default `Fs == nil` path, which is what the shipped binary takes.

The two failures are told apart by what afero passes alongside them:

- a directory that could not be **listed** arrives with its own `info` — losing one would shorten the file list without saying so, so it still ends the scan (`TestScanReportsADirectoryItCannotRead`);
- an entry that could not be **stat'd** arrives with `info == nil` — its name is known, so a config file goes into the set and the linter reports it as a file it could not read, which is what happened before afero (`TestScanSurvivesAnEntryItCannotStat`).

Reverting just the scanner fix makes the new test fail with `walk /repo: stat /repo/gone.yaml: file does not exist`, i.e. the whole scan lost.

## Why it was worth doing

`pkg/scanner`'s tests built a real directory tree per case. They now build a `MemMapFs`, which is what makes the unreadable-directory case expressible at all — on a real filesystem it needs a chmod that root would ignore anyway.

The real-filesystem test was kept and widened to a nested tree with a dot directory, a vendor directory and an exclude pattern, rather than the single flat file it started as. OsFs implements `afero.Lstater` and MemMapFs does not, so the two take different paths through afero, and the in-memory tests alone would not have caught the walk regression above.

New tests also pin that `Store.Fs`, `lint.Options.Fs` and the command's `Options.Fs` are honoured, including a full `run` — settings file, schema location and config tree — executed entirely in memory.

## Deliberate calls worth a second opinion

- **`config.ParseFile` has no callers in the tree**, so its new `fsys` parameter is unused here and the signature change breaks external importers of `pkg/config` (the module has no tags). Kept anyway, so that no library read path touches `os` directly and the function is usable against an `Fs` if anyone does call it. Deleting it instead would be a reasonable counter-proposal, but that is an API removal this PR did not set out to make.
- **`.golangci.yaml` grew three entries**: `github.com/spf13/afero` in both depguard allow lists, `Fs$` in the `ireturn` allow list (there is no concrete type to return in its place), and `ireturn`/`wrapcheck` excluded on `_test.go` — a fake filesystem has to return afero's interfaces, and wrapping an error a test is about to assert on only hides it. The last one is the loosest; the alternative was dropping the two fault-injection tests.

## Verification

`golangci-lint run` is clean, `go test -race ./...` passes, and the built binary still lints and lists against `testdata/schemas` on the real filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)