### PR TITLE
feat(rule): check the memory_limiter, and size it against its container

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,8 +39,12 @@ linters:
         # Option and result structs are meant to be partially set, with the
         # zero value carrying the default behaviour.
         - 'github\.com/minuk-dev/otelcol-config-lint/pkg/lint\.(Options|FormatterOptions|Result|Summary)'
+        - 'github\.com/minuk-dev/otelcol-config-lint/pkg/lint\.(EnvironmentPolicy|EnvironmentOverride)'
         - 'github\.com/minuk-dev/otelcol-config-lint/pkg/schema\.(Store|Schema|Component|Field)'
         - 'github\.com/minuk-dev/otelcol-config-lint/pkg/rule\.Context'
+        # An environment nobody described is the zero value, and saying so is
+        # the point: the rules that need one then report nothing.
+        - 'github\.com/minuk-dev/otelcol-config-lint/pkg/rule\.Environment'
         # cobra.Command has some forty fields and its zero values are the
         # defaults every command wants; each one sets only what it changes.
         - 'github\.com/spf13/cobra\.Command'
@@ -89,6 +93,13 @@ linters:
         - id
         - in # table-driven test input
         - tt # table-driven test case
+        # The Kubernetes memory units, whose names are what a manifest writes.
+        - Ki
+        - Mi
+        - Gi
+        - Ti
+        - Pi
+        - Ei
     cyclop:
       max-complexity: 15 # default 10 is too strict for the config walkers
     funlen:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ config.yaml:22:3: error: unknown exporter type "logging" in collector v0.157.0 [
     hint: "logging" exists in v0.110.0 but not in v0.157.0
 config.yaml:29:30: error: service.extensions references "pprof" which is not declared under extensions [undefined-reference]
     hint: declared extensions: health_check
+config.yaml:34:5: error: processor "memory_limiter" sets neither limit_mib nor limit_percentage: 'limit_mib' or 'limit_percentage' must be greater than zero [memory-limiter-config]
+    hint: set limit_mib to the memory the collector may use; spike_limit_mib then defaults to 20% of it
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
 ```
+
+A rule that reports what the collector requires or recommends carries a `docs:`
+link to the upstream page that says so, so the claim can be checked rather than
+taken on trust. It is in the JSON output as `docs`, and in the GitHub
+annotations.
 
 No collector binary and no Go toolchain are needed at lint time. The component
 schemas are fetched from the published registry, so a new collector release
@@ -232,6 +240,10 @@ alone.
 **Practice** — `processor-order` (memory_limiter first), `missing-memory-limiter`,
 `missing-batch`, `insecure-tls`, `memory-limiter-config`,
 `memory-limiter-sizing`.
+
+Every practice rule cites the upstream page it rests on — the
+`memorylimiterprocessor` and `batchprocessor` READMEs, `configtls`, and the
+Kubernetes resource docs for the container's request and limit.
 
 `memory_limiter` is the one processor this linter tells people to add, and two
 of its constraints cannot be written as a field schema:

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The flags below belong to `run`:
 | `--disable` | comma-separated rules to turn off |
 | `--severity` | comma-separated `rule=level` overrides |
 | `--exclude` | glob patterns to skip when walking directories |
+| `--kubernetes` | the config runs in a Kubernetes pod |
+| `--memory-request`, `--memory-limit` | the container's resources, e.g. `256Mi`, `1Gi`, `2G`. Either one implies `--kubernetes` |
 | `-n` | files checked in parallel |
 | `--summary`, `--verbose`, `--no-color`, `--exit-on-error` | output control |
 
@@ -156,6 +158,50 @@ schemaLocations:
   - default         # then the published registry
 ```
 
+#### The deployment environment
+
+`memory-limiter-sizing` compares a `memory_limiter` against the container it
+runs in, which the config file cannot state. The `kubernetes` block supplies it.
+
+It is resolved **per file**, because a run is not one deployment: an agent
+DaemonSet at `256Mi` and a gateway Deployment at `4Gi` sit in the same directory
+and are checked in the same run.
+
+```yaml
+kubernetes:
+  enabled: true
+  memoryRequest: 512Mi        # the defaults, for any file no override matches
+  memoryLimit: 512Mi
+  overrides:
+    - paths: ["configs/agent-*.yaml"]
+      memoryRequest: 256Mi
+      memoryLimit: 256Mi
+    - paths: ["configs/gateway/*.yaml"]
+      memoryRequest: 4Gi
+      memoryLimit: 4Gi
+    - paths: ["configs/legacy/*.yaml"]
+      enabled: false          # opt a subtree back out
+```
+
+- Overrides are matched in list order and the **first match wins**. A matching
+  override replaces the defaults; it does not merge with them.
+- `paths` are globs matched against both the whole path and the base name,
+  exactly as `--exclude` is, so the two behave identically — including which
+  patterns do not work: there is no `**`.
+- `enabled` defaults to true when either memory number is written, since a
+  block stating what the container has is a block about a container.
+- Sizes are Kubernetes quantities: `512Mi`, `1Gi`, `2G`, or a bare byte count.
+  Anything else is an error rather than a silently different number.
+- A file that matches no override and has no defaults to fall back on simply
+  skips `memory-limiter-sizing`. That is per file: the rest of the run is
+  unaffected. `--verbose` prints what each file resolved to.
+- Config read from stdin is reported as `stdin`, which no glob is meant to
+  match, so it gets the defaults.
+
+`--kubernetes`, `--memory-request` and `--memory-limit` are the single-file
+convenience: they set the defaults and, like every flag, win over the file.
+There is deliberately no flag form of the overrides.
+
 ## What it checks
 
 `otelcol-config-lint list rules` prints the current set with default severities.
@@ -184,7 +230,23 @@ coverage never produces false positives. `${env:...}` expansions are left
 alone.
 
 **Practice** — `processor-order` (memory_limiter first), `missing-memory-limiter`,
-`missing-batch`, `insecure-tls`.
+`missing-batch`, `insecure-tls`, `memory-limiter-config`,
+`memory-limiter-sizing`.
+
+`memory_limiter` is the one processor this linter tells people to add, and two
+of its constraints cannot be written as a field schema:
+`check_interval` must be greater than zero and yet defaults to `0s`, so leaving
+it out is an error rather than a choice, and `limit_mib`/`limit_percentage` are
+a one-of. `memory-limiter-config` checks what upstream's own `Validate()`
+checks, quoting its wording, and matches on the component type so
+`memory_limiter/aggressive` is covered too.
+
+`memory-limiter-sizing` is the other half, and it needs a number the config
+cannot carry: the container's memory limit. A limiter that passes every check
+above is still decoration if `limit_mib` sits at or above the container limit,
+because the kernel kills the collector before the limiter ever engages. It runs
+only for files the [`kubernetes` block](#the-deployment-environment) describes,
+so a run that configures nothing sees nothing new.
 
 ## Schemas
 
@@ -347,6 +409,7 @@ pkg/schema/                   schema types, version resolution and location look
 pkg/rule/                     the rules and the registry
 pkg/lint/                     the engine and the output formatters
 pkg/diag/                     diagnostics, severities and positions
+pkg/quantity/                 Kubernetes memory quantities, parsed and printed back
 pkg/version/                  the linter's own version, stamped at build time
 action.yml                    the GitHub Action; Dockerfile wraps the released image it runs
 build/docker/Dockerfile       the distroless linter image releases publish

--- a/pkg/cmd/otelcol-config-lint/environment.go
+++ b/pkg/cmd/otelcol-config-lint/environment.go
@@ -1,0 +1,138 @@
+package otelcolconfiglint
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/lint"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/quantity"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+)
+
+// ErrNoOverridePaths reports an environment override that matches nothing.
+var ErrNoOverridePaths = errors.New("an override needs at least one path pattern")
+
+// kubernetesSettings is the "kubernetes" block of a settings file: what the
+// pods these configs run in look like, which is what the sizing rules check
+// against.
+//
+// The block states the defaults, and overrides state the files that are a
+// different workload -- an agent DaemonSet at 256Mi next to a gateway
+// Deployment at 4Gi. There is deliberately no flag form of the overrides: a
+// path-to-limits table belongs in a file.
+type kubernetesSettings struct {
+	// Enabled says the configs run in Kubernetes. When it is not set, writing
+	// either memory number is taken to mean the same thing.
+	Enabled *bool `yaml:"enabled"`
+	// MemoryRequest and MemoryLimit are the container's resources, written as
+	// a Kubernetes quantity such as "512Mi".
+	MemoryRequest string `yaml:"memoryRequest"`
+	MemoryLimit   string `yaml:"memoryLimit"`
+	// Overrides are matched in order and the first match wins.
+	Overrides []kubernetesOverride `yaml:"overrides"`
+}
+
+// kubernetesOverride is one path-matched entry of the kubernetes block. It
+// replaces the defaults for the files it matches rather than merging with
+// them, so what a file resolves to is stated in one place.
+type kubernetesOverride struct {
+	// Paths are glob patterns, matched against both the whole path and the
+	// base name, exactly as the exclude patterns are.
+	Paths         []string `yaml:"paths"`
+	Enabled       *bool    `yaml:"enabled"`
+	MemoryRequest string   `yaml:"memoryRequest"`
+	MemoryLimit   string   `yaml:"memoryLimit"`
+}
+
+// environmentPolicy builds the per-path environment from the flags and the
+// settings file. The flags set the defaults only; they are the single-file
+// convenience, and the file is what a repository of configs commits.
+func (o *Options) environmentPolicy() (lint.EnvironmentPolicy, error) {
+	var none lint.EnvironmentPolicy
+
+	fallback, err := environmentOf(o.kubernetesEnabled, o.memoryRequest, o.memoryLimit)
+	if err != nil {
+		return none, fmt.Errorf("kubernetes: %w", err)
+	}
+
+	policy := lint.EnvironmentPolicy{Default: fallback, Overrides: nil}
+
+	for i, over := range o.kubernetesOverrides {
+		where := fmt.Sprintf("kubernetes.overrides[%d]", i)
+
+		if len(over.Paths) == 0 {
+			return none, fmt.Errorf("%s: %w", where, ErrNoOverridePaths)
+		}
+
+		env, envErr := environmentOf(over.Enabled, over.MemoryRequest, over.MemoryLimit)
+		if envErr != nil {
+			return none, fmt.Errorf("%s: %w", where, envErr)
+		}
+
+		policy.Overrides = append(policy.Overrides, lint.EnvironmentOverride{Paths: over.Paths, Env: env})
+	}
+
+	err = policy.Validate()
+	if err != nil {
+		return none, fmt.Errorf("kubernetes.overrides: %w", err)
+	}
+
+	return policy, nil
+}
+
+// environmentOf turns one set of written values into an environment. An
+// unstated "enabled" is read from the memory numbers: a block that says how
+// much memory the container has is a block about a container.
+func environmentOf(enabled *bool, request, limit string) (rule.Environment, error) {
+	req, err := parseSize("memoryRequest", request)
+	if err != nil {
+		return rule.Environment{}, err
+	}
+
+	lim, err := parseSize("memoryLimit", limit)
+	if err != nil {
+		return rule.Environment{}, err
+	}
+
+	on := request != "" || limit != ""
+	if enabled != nil {
+		on = *enabled
+	}
+
+	return rule.Environment{Kubernetes: on, MemoryRequest: req, MemoryLimit: lim}, nil
+}
+
+// parseSize reads a Kubernetes quantity, treating an unwritten value as
+// unknown rather than as zero bytes.
+func parseSize(name, text string) (int64, error) {
+	if text == "" {
+		return 0, nil
+	}
+
+	size, err := quantity.Parse(text)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", name, err)
+	}
+
+	return size, nil
+}
+
+// describeEnvironment renders what a file resolved to, so --verbose can answer
+// "why was this file not checked" without anyone re-reading the glob list.
+func describeEnvironment(env rule.Environment) string {
+	if !env.Kubernetes {
+		return "no deployment environment"
+	}
+
+	parts := []string{"kubernetes"}
+	if env.MemoryRequest > 0 {
+		parts = append(parts, "memory request "+quantity.Format(env.MemoryRequest))
+	}
+
+	if env.MemoryLimit > 0 {
+		parts = append(parts, "memory limit "+quantity.Format(env.MemoryLimit))
+	}
+
+	return strings.Join(parts, ", ")
+}

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -94,7 +94,10 @@ type Options struct {
 	exclude          string
 	minSeverity      string
 	failOn           string
+	memoryRequest    string
+	memoryLimit      string
 	workers          int
+	kubernetes       bool
 	strict           bool
 	ignoreMissing    bool
 	summary          bool
@@ -104,6 +107,15 @@ type Options struct {
 
 	// internal state
 	store schema.Store
+	// kubernetesEnabled is what the flag or the settings file said about
+	// running in Kubernetes; nil when neither said anything, which leaves the
+	// answer to be read from the memory numbers.
+	kubernetesEnabled *bool
+	// kubernetesOverrides are the per-path environments, which only the
+	// settings file can state.
+	kubernetesOverrides []kubernetesOverride
+	// envPolicy resolves the environment of each file linted.
+	envPolicy lint.EnvironmentPolicy
 }
 
 // NewCommand builds the root command. A nil opts is allowed, in which case a
@@ -162,6 +174,9 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 	flags.StringVar(&o.failOn, "fail-on", "error", "severity that makes a file invalid: error, warning or info")
 	// Spelled -n before cobra; the shorthand keeps that working.
 	flags.IntVarP(&o.workers, "n", "n", defaultWorkers(), "number of files to check in parallel")
+	flags.BoolVar(&o.kubernetes, "kubernetes", false, "the config runs in a Kubernetes pod")
+	flags.StringVar(&o.memoryRequest, "memory-request", "", "container memory request, e.g. 256Mi")
+	flags.StringVar(&o.memoryLimit, "memory-limit", "", "container memory limit, e.g. 512Mi")
 	flags.BoolVar(&o.strict, "strict", false, "report unknown component settings as errors")
 	flags.BoolVar(&o.ignoreMissing, "ignore-missing-schemas", false,
 		"do not fail on components missing from the schema")
@@ -182,6 +197,11 @@ func (o *Options) Prepare(cmd *cobra.Command) error {
 	o.applySettings(fileSettings, cmd.Flags().Changed)
 
 	o.store = schema.Store{Locations: o.schemaLocations, Distribution: o.distribution, Fs: o.Fs}
+
+	o.envPolicy, err = o.environmentPolicy()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -302,10 +322,18 @@ func (o *Options) lintAll(
 		results[r.Path] = r
 	}
 
+	// An environment decides whether some rules run at all, so a verbose run
+	// says which one each file resolved to.
+	sayEnvironment := o.verbose && o.envPolicy.Configured()
+
 	for _, f := range sets.List(files) {
 		r := results[f]
 
 		summary.Add(r)
+
+		if sayEnvironment {
+			cmd.PrintErrf("otelcol-config-lint: %s: %s\n", r.Path, describeEnvironment(o.envPolicy.Resolve(r.Path)))
+		}
 
 		err := formatter.Result(r)
 		if err != nil {
@@ -356,6 +384,7 @@ func (o *Options) newLinter(cmd *cobra.Command) (*lint.Linter, error) {
 		Availability:         lint.NewVersionIndex(o.store),
 		Distributions:        lint.NewDistributionIndex(o.store, cat.CollectorVersion),
 		Severities:           severities,
+		Environment:          o.envPolicy.Resolve,
 		Strict:               o.strict,
 		IgnoreMissingSchemas: o.ignoreMissing,
 		MinSeverity:          minSeverity,
@@ -441,6 +470,9 @@ type settings struct {
 	Disable              []string          `yaml:"disable"`
 	Severity             map[string]string `yaml:"severity"`
 	Exclude              []string          `yaml:"exclude"`
+	// Kubernetes describes the pods the configs run in, per path, for the
+	// rules that cannot judge a config without knowing what it runs in.
+	Kubernetes kubernetesSettings `yaml:"kubernetes"`
 }
 
 // loadSettings reads a settings file. When path is empty the default file is
@@ -488,6 +520,8 @@ func (o *Options) applySettings(s *settings, changed func(name string) bool) {
 	}
 
 	str("collector-version", &o.collectorVersion, s.CollectorVersion)
+	str("memory-request", &o.memoryRequest, s.Kubernetes.MemoryRequest)
+	str("memory-limit", &o.memoryLimit, s.Kubernetes.MemoryLimit)
 	str("distribution", &o.distribution, s.Distribution)
 	str("output", &o.output, s.Output)
 	str("min-severity", &o.minSeverity, s.MinSeverity)
@@ -495,6 +529,17 @@ func (o *Options) applySettings(s *settings, changed func(name string) bool) {
 	boolean("strict", &o.strict, s.Strict)
 	boolean("ignore-missing-schemas", &o.ignoreMissing, s.IgnoreMissingSchemas)
 	boolean("summary", &o.summary, s.Summary)
+
+	// The deployment environment is a tri-state: the flag wins, then the file,
+	// and with neither the memory numbers speak for themselves.
+	switch {
+	case changed("kubernetes"):
+		o.kubernetesEnabled = &o.kubernetes
+	case s.Kubernetes.Enabled != nil:
+		o.kubernetesEnabled = s.Kubernetes.Enabled
+	}
+
+	o.kubernetesOverrides = s.Kubernetes.Overrides
 
 	if !changed("schema-location") && len(s.SchemaLocations) > 0 {
 		o.schemaLocations = append(o.schemaLocations, s.SchemaLocations...)

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -738,3 +738,183 @@ func TestReportOrderDoesNotDependOnArgumentOrder(t *testing.T) {
 		t.Errorf("results are not in path order: %v", got)
 	}
 }
+
+// limiterConfig is a config whose only interesting part is a memory_limiter
+// with a fixed limit: room enough in a gateway's container, far too much in an
+// agent's.
+const limiterConfig = `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  debug:
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [debug]
+`
+
+// writeFile writes a fixture, creating the directories leading to it.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	err := os.MkdirAll(filepath.Dir(path), 0o750)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(path, []byte(content), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// rulesFired returns the rules each file in a JSON report was flagged by.
+func rulesFired(t *testing.T, out string) map[string][]string {
+	t.Helper()
+
+	var report struct {
+		Files []struct {
+			Filename    string `json:"filename"`
+			Diagnostics []struct {
+				Rule string `json:"rule"`
+			} `json:"diagnostics"`
+		} `json:"files"`
+	}
+
+	err := json.Unmarshal([]byte(out), &report)
+	if err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+
+	fired := map[string][]string{}
+
+	for _, f := range report.Files {
+		for _, d := range f.Diagnostics {
+			name := filepath.Base(f.Filename)
+			fired[name] = append(fired[name], d.Rule)
+		}
+	}
+
+	return fired
+}
+
+// TestEnvironmentIsResolvedPerFile is the point of the whole kubernetes block:
+// one run over one directory, two workloads, and only the one that does not fit
+// its container is flagged.
+func TestEnvironmentIsResolvedPerFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "configs", "agent-node.yaml"), limiterConfig)
+	writeFile(t, filepath.Join(dir, "configs", "gateway", "gw.yaml"), limiterConfig)
+	writeFile(t, filepath.Join(dir, "configs", "legacy", "old.yaml"), limiterConfig)
+
+	settings := filepath.Join(dir, "settings.yaml")
+	writeFile(t, settings, `
+kubernetes:
+  memoryRequest: 512Mi
+  memoryLimit: 512Mi
+  overrides:
+    - paths: ["agent-*.yaml"]
+      memoryRequest: 256Mi
+      memoryLimit: 256Mi
+    - paths: ["gw.yaml"]
+      memoryRequest: 4Gi
+      memoryLimit: 4Gi
+    - paths: ["old.yaml"]
+      enabled: false
+`)
+
+	_, out, errOut := lint(t, "", "--config", settings, "--output", "json", filepath.Join(dir, "configs"))
+
+	fired := rulesFired(t, out)
+	if !slices.Contains(fired["agent-node.yaml"], "memory-limiter-sizing") {
+		t.Errorf("512Mi does not fit a 256Mi container: %v\n%s", fired, errOut)
+	}
+
+	if slices.Contains(fired["gw.yaml"], "memory-limiter-sizing") {
+		t.Errorf("512Mi fits a 4Gi container: %v", fired)
+	}
+
+	if slices.Contains(fired["old.yaml"], "memory-limiter-sizing") {
+		t.Errorf("an override that turns kubernetes off should opt the file out: %v", fired)
+	}
+}
+
+// TestMemoryFlagsCoverTheSingleFileCase pins that the flags feed the defaults
+// and imply that the config runs in Kubernetes.
+func TestMemoryFlagsCoverTheSingleFileCase(t *testing.T) {
+	t.Parallel()
+
+	_, out, _ := lint(t, limiterConfig, "--memory-limit", "256Mi", "--output", "json", "-")
+	if !slices.Contains(rulesFired(t, out)["stdin"], "memory-limiter-sizing") {
+		t.Errorf("--memory-limit alone should be enough to size the limiter:\n%s", out)
+	}
+
+	_, out, _ = lint(t, limiterConfig, "--memory-limit", "4Gi", "--output", "json", "-")
+	if slices.Contains(rulesFired(t, out)["stdin"], "memory-limiter-sizing") {
+		t.Errorf("512Mi fits a 4Gi container:\n%s", out)
+	}
+}
+
+// TestFlagsWinOverTheKubernetesBlock keeps the environment on the same
+// precedence rule as every other option.
+func TestFlagsWinOverTheKubernetesBlock(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	settings := filepath.Join(dir, "settings.yaml")
+	writeFile(t, settings, "kubernetes:\n  memoryLimit: 4Gi\n")
+
+	_, out, _ := lint(t, limiterConfig, "--config", settings, "--memory-limit", "256Mi", "--output", "json", "-")
+	if !slices.Contains(rulesFired(t, out)["stdin"], "memory-limiter-sizing") {
+		t.Errorf("--memory-limit should beat the settings file:\n%s", out)
+	}
+}
+
+func TestBadMemoryQuantityIsAUsageError(t *testing.T) {
+	t.Parallel()
+
+	code, _, errOut := lint(t, "", "--memory-limit", "512MB", validConfig)
+	if code != 2 || !strings.Contains(errOut, "not a memory quantity") {
+		t.Errorf("a bad quantity should stop the run, got exit %d: %s", code, errOut)
+	}
+
+	dir := t.TempDir()
+	settings := filepath.Join(dir, "settings.yaml")
+	writeFile(t, settings, "kubernetes:\n  overrides:\n    - paths: [\"[bad\"]\n      memoryLimit: 1Gi\n")
+
+	code, _, errOut = lint(t, "", "--config", settings, validConfig)
+	if code != 2 || !strings.Contains(errOut, "override 1") {
+		t.Errorf("a malformed glob should stop the run, got exit %d: %s", code, errOut)
+	}
+}
+
+// TestVerboseSaysWhichEnvironmentAFileGot answers "why was this file not
+// checked" without anyone re-reading the glob list.
+func TestVerboseSaysWhichEnvironmentAFileGot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "agent-node.yaml"), limiterConfig)
+
+	_, _, errOut := lint(t, "", "--verbose", "--memory-limit", "256Mi", "--memory-request", "256Mi", dir)
+	if !strings.Contains(errOut, "agent-node.yaml: kubernetes, memory request 256Mi, memory limit 256Mi") {
+		t.Errorf("a verbose run should say what each file resolved to:\n%s", errOut)
+	}
+
+	_, _, errOut = lint(t, "", "--verbose", dir)
+	if strings.Contains(errOut, "no deployment environment") {
+		t.Errorf("with no environment configured there is nothing to say:\n%s", errOut)
+	}
+}

--- a/pkg/diag/diag.go
+++ b/pkg/diag/diag.go
@@ -96,6 +96,10 @@ type Diagnostic struct {
 	Path string `json:"path,omitempty"`
 	// Hint is an optional suggested fix shown below the message.
 	Hint string `json:"hint,omitempty"`
+	// Docs optionally links to where upstream states what the finding is
+	// based on, so a rule that says "this is what upstream recommends" can be
+	// checked rather than taken on trust.
+	Docs string `json:"docs,omitempty"`
 }
 
 // Diagnostics is an ordered collection of findings.

--- a/pkg/lint/environment.go
+++ b/pkg/lint/environment.go
@@ -1,0 +1,74 @@
+package lint
+
+import (
+	"fmt"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/scanner"
+)
+
+// EnvironmentPolicy resolves the environment a config file is deployed into.
+//
+// A run is not one deployment: an agent DaemonSet and a gateway Deployment sit
+// in the same directory and are checked in the same run, so the numbers the
+// sizing rules need belong to a path, not to the run. A path that matches
+// nothing gets the defaults, and defaults that were never set say nothing,
+// which leaves those rules quiet.
+//
+// The zero value resolves every path to an unknown environment.
+type EnvironmentPolicy struct {
+	// Default applies to any path no override matches.
+	Default rule.Environment
+	// Overrides are consulted in order and the first match wins. A matching
+	// override replaces the defaults; it does not merge with them.
+	Overrides []EnvironmentOverride
+}
+
+// EnvironmentOverride is one path-matched entry of a policy.
+type EnvironmentOverride struct {
+	// Paths are glob patterns, matched by scanner.Match against both the whole
+	// path and the base name, exactly as the exclude patterns are.
+	Paths []string
+	// Env is what a path matching any of the patterns resolves to.
+	Env rule.Environment
+}
+
+// Validate reports the first pattern that cannot be used as a glob. It is
+// meant to be called once, before linting: a pattern nothing can match would
+// otherwise look like an override that simply did not apply.
+func (p EnvironmentPolicy) Validate() error {
+	for i, over := range p.Overrides {
+		for _, pattern := range over.Paths {
+			err := scanner.CheckPattern(pattern)
+			if err != nil {
+				return fmt.Errorf("override %d: %w", i+1, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Resolve returns the environment for a config file path. It reads nothing but
+// the policy, which is why LintAll's workers can all call it at once; a policy
+// must therefore not be changed once linting has started.
+//
+// Config read from standard input is reported under a name no glob is meant to
+// match, so it resolves to the defaults.
+func (p EnvironmentPolicy) Resolve(path string) rule.Environment {
+	for _, over := range p.Overrides {
+		for _, pattern := range over.Paths {
+			if scanner.Match(pattern, path) {
+				return over.Env
+			}
+		}
+	}
+
+	return p.Default
+}
+
+// Configured reports whether the policy can resolve anything at all, so a
+// caller can stay quiet about environments nobody asked for.
+func (p EnvironmentPolicy) Configured() bool {
+	return p.Default.Known() || len(p.Overrides) > 0
+}

--- a/pkg/lint/environment_test.go
+++ b/pkg/lint/environment_test.go
@@ -1,0 +1,169 @@
+package lint_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/lint"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/quantity"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+)
+
+func testPolicy() lint.EnvironmentPolicy {
+	return lint.EnvironmentPolicy{
+		Default: rule.Environment{Kubernetes: true, MemoryRequest: 512 * quantity.Mi, MemoryLimit: 512 * quantity.Mi},
+		Overrides: []lint.EnvironmentOverride{
+			{
+				Paths: []string{"configs/agent-*.yaml"},
+				Env: rule.Environment{
+					Kubernetes: true, MemoryRequest: 256 * quantity.Mi, MemoryLimit: 256 * quantity.Mi,
+				},
+			},
+			{
+				Paths: []string{"configs/gateway/*.yaml", "gw.yaml"},
+				Env:   rule.Environment{Kubernetes: true, MemoryRequest: 4 * quantity.Gi, MemoryLimit: 4 * quantity.Gi},
+			},
+			{
+				Paths: []string{"configs/legacy/*.yaml"},
+				Env:   rule.Environment{Kubernetes: false, MemoryRequest: 0, MemoryLimit: 0},
+			},
+		},
+	}
+}
+
+func TestEnvironmentPolicyResolvesPerPath(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]int64{
+		"configs/agent-node.yaml":     256 * quantity.Mi,
+		"configs/gateway/main.yaml":   4 * quantity.Gi,
+		"gw.yaml":                     4 * quantity.Gi,
+		"configs/collector.yaml":      512 * quantity.Mi,
+		"somewhere/else/config.yaml":  512 * quantity.Mi,
+		"stdin":                       512 * quantity.Mi,
+		filepath.Clean("./gw.yaml"):   4 * quantity.Gi,
+		"configs/legacy/ancient.yaml": 0,
+	}
+
+	policy := testPolicy()
+	for path, want := range tests {
+		if got := policy.Resolve(path).MemoryLimit; got != want {
+			t.Errorf("Resolve(%q) limit = %d, want %d", path, got, want)
+		}
+	}
+
+	if policy.Resolve("configs/legacy/ancient.yaml").Known() {
+		t.Error("an override that turns Kubernetes off should leave the environment unknown")
+	}
+}
+
+func TestEnvironmentPolicyTakesTheFirstMatch(t *testing.T) {
+	t.Parallel()
+
+	policy := lint.EnvironmentPolicy{
+		Default: rule.Environment{},
+		Overrides: []lint.EnvironmentOverride{
+			{Paths: []string{"*.yaml"}, Env: rule.Environment{Kubernetes: true, MemoryLimit: quantity.Gi}},
+			{Paths: []string{"agent.yaml"}, Env: rule.Environment{Kubernetes: true, MemoryLimit: 2 * quantity.Gi}},
+		},
+	}
+
+	if got := policy.Resolve("agent.yaml").MemoryLimit; got != quantity.Gi {
+		t.Errorf("the first matching override should win, got %d", got)
+	}
+}
+
+func TestZeroEnvironmentPolicyKnowsNothing(t *testing.T) {
+	t.Parallel()
+
+	var policy lint.EnvironmentPolicy
+
+	if policy.Configured() {
+		t.Error("a policy nobody configured should not claim to be")
+	}
+
+	if policy.Resolve("anything.yaml").Known() {
+		t.Error("a policy nobody configured should resolve to an unknown environment")
+	}
+}
+
+func TestEnvironmentPolicyRejectsAPatternThatCannotMatch(t *testing.T) {
+	t.Parallel()
+
+	policy := lint.EnvironmentPolicy{
+		Default: rule.Environment{},
+		Overrides: []lint.EnvironmentOverride{
+			{Paths: []string{"good-*.yaml"}, Env: rule.Environment{}},
+			{Paths: []string{"[bad"}, Env: rule.Environment{}},
+		},
+	}
+
+	err := policy.Validate()
+	if err == nil {
+		t.Fatal("a malformed glob should be reported")
+	}
+
+	if !strings.Contains(err.Error(), "override 2") {
+		t.Errorf("the error should say which override is wrong: %v", err)
+	}
+}
+
+func TestLinterResolvesTheEnvironmentOfEveryFile(t *testing.T) {
+	t.Parallel()
+
+	// Enough memory for the gateway, far too little for the agent.
+	const src = `
+receivers: {otlp: }
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [memory_limiter], exporters: [debug]}
+`
+
+	policy := lint.EnvironmentPolicy{
+		Default: rule.Environment{Kubernetes: true, MemoryRequest: 4 * quantity.Gi, MemoryLimit: 4 * quantity.Gi},
+		Overrides: []lint.EnvironmentOverride{
+			{
+				Paths: []string{"agent-*.yaml"},
+				Env: rule.Environment{
+					Kubernetes: true, MemoryRequest: 256 * quantity.Mi, MemoryLimit: 256 * quantity.Mi,
+				},
+			},
+		},
+	}
+
+	l := newLinter(t, lint.Options{Environment: policy.Resolve})
+
+	if r := l.Lint("agent-node.yaml", []byte(src)); !fires(r, "memory-limiter-sizing") {
+		t.Errorf("the agent's limiter does not fit its container: %+v", r.Diagnostics)
+	}
+
+	if r := l.Lint("gateway.yaml", []byte(src)); fires(r, "memory-limiter-sizing") {
+		t.Errorf("the gateway has room for the same limiter: %+v", r.Diagnostics)
+	}
+}
+
+func TestLinterWithoutAResolverKnowsNoEnvironment(t *testing.T) {
+	t.Parallel()
+
+	src := strings.Replace(good, "limit_mib: 512", "limit_mib: 4096", 1)
+	if r := newLinter(t, lint.Options{}).Lint("x.yaml", []byte(src)); fires(r, "memory-limiter-sizing") {
+		t.Errorf("sizing needs an environment nobody gave: %+v", r.Diagnostics)
+	}
+}
+
+func fires(r lint.Result, name string) bool {
+	for _, d := range r.Diagnostics {
+		if d.Rule == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -65,6 +65,12 @@ type Options struct {
 	// IgnoreMissingSchemas keeps components that are absent from the schema
 	// from failing the run, for configs using a custom distribution.
 	IgnoreMissingSchemas bool
+	// Environment resolves the deployment environment of one config file, for
+	// the rules that cannot judge a config on its own. It is called from every
+	// worker LintAll starts, so it must be safe for concurrent use and must
+	// not change once linting has begun. A nil resolver leaves every file's
+	// environment unknown, which keeps those rules silent.
+	Environment func(path string) rule.Environment
 	// MinSeverity drops diagnostics less serious than this level.
 	MinSeverity diag.Severity
 	// FailOn is the severity at which a file counts as invalid.
@@ -159,6 +165,7 @@ func (l *Linter) Lint(path string, src []byte) Result {
 		Avail:  l.opts.Availability,
 		Dists:  l.opts.Distributions,
 		Strict: l.opts.Strict,
+		Env:    l.environment(path),
 	}
 
 	var found diag.Diagnostics
@@ -226,6 +233,16 @@ func (l *Linter) fs() afero.Fs {
 	}
 
 	return l.opts.Fs
+}
+
+// environment resolves where a file is deployed, which is unknown unless the
+// caller supplied a resolver.
+func (l *Linter) environment(path string) rule.Environment {
+	if l.opts.Environment == nil {
+		return rule.Environment{}
+	}
+
+	return l.opts.Environment(path)
 }
 
 // Summary counts results by status and diagnostics by severity.

--- a/pkg/lint/linter_test.go
+++ b/pkg/lint/linter_test.go
@@ -22,6 +22,8 @@ receivers:
 processors:
   memory_limiter:
     check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
   batch:
 exporters:
   debug:
@@ -312,5 +314,26 @@ func TestVersionIndexFindsRemovedComponents(t *testing.T) {
 
 	if len(idx.Versions("exporter", "definitely_not_a_component")) != 0 {
 		t.Error("an unknown component should have no versions")
+	}
+}
+
+// TestAMissingCheckIntervalIsReportedOnce pins that memory-limiter-config
+// stands down where the field schema already marks check_interval required:
+// one missing key, one finding, not two about the same line.
+func TestAMissingCheckIntervalIsReportedOnce(t *testing.T) {
+	t.Parallel()
+
+	src := strings.Replace(good, "    check_interval: 1s\n", "", 1)
+
+	var about []string
+
+	for _, d := range newLinter(t, lint.Options{}).Lint("x.yaml", []byte(src)).Diagnostics {
+		if strings.Contains(d.Message, "check_interval") {
+			about = append(about, d.Rule)
+		}
+	}
+
+	if len(about) != 1 {
+		t.Errorf("want one finding about check_interval, got %v", about)
 	}
 }

--- a/pkg/lint/linter_test.go
+++ b/pkg/lint/linter_test.go
@@ -337,3 +337,51 @@ func TestAMissingCheckIntervalIsReportedOnce(t *testing.T) {
 		t.Errorf("want one finding about check_interval, got %v", about)
 	}
 }
+
+// TestFormattersCarryTheDocumentationLink pins that a finding's citation
+// survives into the output; a link nobody can see is not a citation.
+func TestFormattersCarryTheDocumentationLink(t *testing.T) {
+	t.Parallel()
+
+	// A memory_limiter that is present and empty: the collector refuses to
+	// start, and upstream's README is what says so.
+	src := strings.Replace(good, "    check_interval: 1s\n    limit_mib: 512\n    spike_limit_mib: 128\n", "", 1)
+	result := newLinter(t, lint.Options{}).Lint("x.yaml", []byte(src))
+
+	const docs = "processor/memorylimiterprocessor/README.md"
+
+	cited := false
+
+	for _, d := range result.Diagnostics {
+		if strings.Contains(d.Docs, docs) {
+			cited = true
+		}
+	}
+
+	if !cited {
+		t.Fatalf("no finding cited the processor's README: %+v", result.Diagnostics)
+	}
+
+	for _, name := range []string{"text", "json", "github"} {
+		var buf bytes.Buffer
+
+		f, err := lint.NewFormatter(name, &buf, lint.FormatterOptions{})
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+
+		err = f.Result(result)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+
+		err = f.Finish(lint.Summary{})
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+
+		if !strings.Contains(buf.String(), docs) {
+			t.Errorf("%s output drops the link:\n%s", name, buf.String())
+		}
+	}
+}

--- a/pkg/lint/output.go
+++ b/pkg/lint/output.go
@@ -168,6 +168,10 @@ func (f *textFormatter) diagnostic(d diag.Diagnostic) error {
 		err = writef(f.w, "    %s %s\n", f.color(ansiDim, "hint:"), d.Hint)
 	}
 
+	if err == nil && d.Docs != "" {
+		err = writef(f.w, "    %s %s\n", f.color(ansiDim, "docs:"), d.Docs)
+	}
+
 	return err
 }
 
@@ -363,6 +367,10 @@ func (f *githubFormatter) Result(r Result) error {
 		msg := d.Message + " [" + d.Rule + "]"
 		if d.Hint != "" {
 			msg += "\nhint: " + d.Hint
+		}
+
+		if d.Docs != "" {
+			msg += "\ndocs: " + d.Docs
 		}
 
 		err := writef(f.w, "::%s file=%s,line=%d,col=%d::%s\n",

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -1,0 +1,143 @@
+// Package quantity parses the memory sizes Kubernetes manifests are written
+// in, so a limit can be copied out of a pod spec and given to the linter as it
+// stands. Only the suffixes that make sense for memory are accepted; anything
+// else is an error rather than a silently different number.
+package quantity
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// ErrInvalid reports a string that is not a memory quantity.
+var ErrInvalid = errors.New("not a memory quantity")
+
+// The binary multipliers Kubernetes writes as Ki, Mi, Gi and so on.
+const (
+	Ki = 1 << 10
+	Mi = Ki << 10
+	Gi = Mi << 10
+	Ti = Gi << 10
+	Pi = Ti << 10
+	Ei = Pi << 10
+)
+
+// The decimal multipliers Kubernetes writes as k, M, G and so on.
+const (
+	kilo = 1e3
+	mega = 1e6
+	giga = 1e9
+	tera = 1e12
+	peta = 1e15
+	exa  = 1e18
+)
+
+// unit is one accepted suffix and what it multiplies by. The suffixes are
+// listed longest first so "Mi" is not read as "M" with a stray "i".
+type unit struct {
+	suffix string
+	factor float64
+}
+
+// units are the suffixes Parse accepts, in the order they are tried.
+func units() []unit {
+	return []unit{
+		{suffix: "Ki", factor: Ki},
+		{suffix: "Mi", factor: Mi},
+		{suffix: "Gi", factor: Gi},
+		{suffix: "Ti", factor: Ti},
+		{suffix: "Pi", factor: Pi},
+		{suffix: "Ei", factor: Ei},
+		{suffix: "k", factor: kilo},
+		{suffix: "M", factor: mega},
+		{suffix: "G", factor: giga},
+		{suffix: "T", factor: tera},
+		{suffix: "P", factor: peta},
+		{suffix: "E", factor: exa},
+		{suffix: "", factor: 1},
+	}
+}
+
+// Parse converts a Kubernetes memory quantity such as "512Mi", "1Gi", "2G" or
+// a bare byte count into bytes.
+func Parse(text string) (int64, error) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return 0, fmt.Errorf("%q is %w", text, ErrInvalid)
+	}
+
+	digits, suffix := split(trimmed)
+
+	factor, ok := factorOf(suffix)
+	if !ok {
+		return 0, fmt.Errorf("%q is %w: %q is not a memory suffix (want Ki, Mi, Gi, Ti, Pi, Ei, k, M, G, T, P or E)",
+			text, ErrInvalid, suffix)
+	}
+
+	value, err := strconv.ParseFloat(digits, 64)
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("%q is %w: want a non-negative number, optionally with a suffix", text, ErrInvalid)
+	}
+
+	bytes := value * factor
+	if bytes > math.MaxInt64 {
+		return 0, fmt.Errorf("%q is %w: it does not fit in a byte count", text, ErrInvalid)
+	}
+
+	return int64(math.Round(bytes)), nil
+}
+
+// split cuts a quantity into its number and its suffix.
+func split(text string) (string, string) {
+	end := 0
+	for end < len(text) && (text[end] >= '0' && text[end] <= '9' || text[end] == '.') {
+		end++
+	}
+
+	return text[:end], text[end:]
+}
+
+func factorOf(suffix string) (float64, bool) {
+	for _, candidate := range units() {
+		if candidate.suffix == suffix {
+			return candidate.factor, true
+		}
+	}
+
+	return 0, false
+}
+
+// Format renders a byte count the way a manifest would state it, so a
+// diagnostic quotes the number back in the units it was given in.
+func Format(bytes int64) string {
+	if bytes < Ki {
+		return strconv.FormatInt(bytes, 10)
+	}
+
+	binary := []unit{
+		{suffix: "Ei", factor: Ei},
+		{suffix: "Pi", factor: Pi},
+		{suffix: "Ti", factor: Ti},
+		{suffix: "Gi", factor: Gi},
+		{suffix: "Mi", factor: Mi},
+		{suffix: "Ki", factor: Ki},
+	}
+
+	for _, candidate := range binary {
+		size := int64(candidate.factor)
+		if bytes >= size && bytes%size == 0 {
+			return strconv.FormatInt(bytes/size, 10) + candidate.suffix
+		}
+	}
+
+	// Not a whole number of any unit: one decimal place of the largest unit
+	// that does not round to zero says more than the exact byte count.
+	if bytes >= Mi {
+		return strconv.FormatFloat(float64(bytes)/Mi, 'f', 1, 64) + "Mi"
+	}
+
+	return strconv.FormatFloat(float64(bytes)/Ki, 'f', 1, 64) + "Ki"
+}

--- a/pkg/quantity/quantity_test.go
+++ b/pkg/quantity/quantity_test.go
@@ -1,0 +1,97 @@
+package quantity_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/quantity"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		in   string
+		want int64
+	}{
+		"a bare byte count": {in: "1048576", want: quantity.Mi},
+		"mebibytes":         {in: "512Mi", want: 512 * quantity.Mi},
+		"gibibytes":         {in: "1Gi", want: quantity.Gi},
+		"kibibytes":         {in: "256Ki", want: 256 * quantity.Ki},
+		"decimal gigabytes": {in: "2G", want: 2_000_000_000},
+		"decimal megabytes": {in: "700M", want: 700_000_000},
+		"a fraction":        {in: "1.5Gi", want: quantity.Gi + quantity.Gi/2},
+		"surrounded by space": {
+			in: "  512Mi  ", want: 512 * quantity.Mi,
+		},
+		"zero": {in: "0", want: 0},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := quantity.Parse(tt.in)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tt.in, err)
+			}
+
+			if got != tt.want {
+				t.Errorf("Parse(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRejectsWhatIsNotASize(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{"", "  ", "512MB", "512 Mi", "lots", "-1Mi", "1m", "Mi", "1e30Ei"} {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := quantity.Parse(in)
+			if err == nil {
+				t.Fatalf("Parse(%q) should have failed", in)
+			}
+
+			if !errors.Is(err, quantity.ErrInvalid) {
+				t.Errorf("Parse(%q) = %v, want an ErrInvalid", in, err)
+			}
+		})
+	}
+}
+
+func TestFormatSpeaksTheUnitsAManifestUses(t *testing.T) {
+	t.Parallel()
+
+	tests := map[int64]string{
+		512:                       "512",
+		512 * quantity.Ki:         "512Ki",
+		512 * quantity.Mi:         "512Mi",
+		quantity.Gi:               "1Gi",
+		quantity.Gi + quantity.Mi: "1025Mi",
+		700_000_000:               "667.6Mi",
+	}
+
+	for in, want := range tests {
+		if got := quantity.Format(in); got != want {
+			t.Errorf("Format(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFormatRoundTripsWhatParseReads(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{"512Mi", "1Gi", "256Ki", "4Gi"} {
+		size, err := quantity.Parse(in)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", in, err)
+		}
+
+		if got := quantity.Format(size); got != in {
+			t.Errorf("Format(Parse(%q)) = %q", in, got)
+		}
+	}
+}

--- a/pkg/rule/docs.go
+++ b/pkg/rule/docs.go
@@ -1,0 +1,27 @@
+package rule
+
+// The upstream documentation a rule can point at. A rule that reports what the
+// collector requires or recommends carries the page that says so, so a reader
+// can check the claim instead of taking the linter's word for it.
+//
+// The links are to main rather than to the release being validated: they are
+// where upstream states the recommendation, and the wording outlives any one
+// version. A component that has been removed since is reported by
+// unknown-component long before its README matters.
+const (
+	// memoryLimiterDocs states check_interval's 0s default and its recommended
+	// value, spike_limit_mib's 20% default, the roughly 50MiB the process runs
+	// above limit_mib, that the processor belongs first in a pipeline, and the
+	// advice to set GOMEMLIMIT to 80% of the hard limit.
+	memoryLimiterDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
+		"/blob/main/processor/memorylimiterprocessor/README.md"
+	// batchDocs states what batching is for and where it belongs.
+	batchDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
+		"/blob/main/processor/batchprocessor/README.md"
+	// tlsDocs states what the TLS settings mean, insecure among them.
+	tlsDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
+		"/blob/main/config/configtls/README.md"
+	// kubernetesResourceDocs states what requests and limits do, and the QoS
+	// class a pod lands in when they differ.
+	kubernetesResourceDocs = "https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+)

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -40,6 +40,7 @@ func (r processorOrder) Check(ctx *Context) {
 					Message: "memory_limiter is processor " + itoa(i+1) + " in pipeline " + quote(p.Key) +
 						"; it must be first",
 					Hint: "move " + quote(ref.ID.String()) + " to the front of " + path,
+					Docs: memoryLimiterDocs,
 				})
 			}
 
@@ -52,6 +53,7 @@ func (r processorOrder) Check(ctx *Context) {
 					Node: ref.Node, Path: "service." + ref.Path,
 					Message:  "batch runs before other processors in pipeline " + quote(p.Key),
 					Hint:     "put batch last so upstream processors see individual items and cannot drop whole batches",
+					Docs:     batchDocs,
 					Severity: diag.Info,
 				})
 			}
@@ -71,6 +73,7 @@ func (r missingMemoryLimiter) Check(ctx *Context) {
 			Node: nodeOr(p.ProcessorsNode, p.KeyNode), Path: "service.pipelines." + p.Key + ".processors",
 			Message: "pipeline " + quote(p.Key) + " has no memory_limiter processor",
 			Hint:    "add memory_limiter as the first processor to bound the collector's memory use",
+			Docs:    memoryLimiterDocs,
 		})
 	}
 }
@@ -87,6 +90,7 @@ func (r missingBatch) Check(ctx *Context) {
 			Node: nodeOr(p.ProcessorsNode, p.KeyNode), Path: "service.pipelines." + p.Key + ".processors",
 			Message: "pipeline " + quote(p.Key) + " has no batch processor",
 			Hint:    "add batch before the exporters to reduce the number of outgoing requests",
+			Docs:    batchDocs,
 		})
 	}
 }
@@ -117,6 +121,7 @@ func (r insecureTLS) Check(ctx *Context) {
 					Message: quote(shortPath(hit.path)) + " disables TLS verification for " +
 						string(kind) + " " + quote(c.ID.String()),
 					Hint: "supply ca_file/cert_file instead of skipping verification outside local testing",
+					Docs: tlsDocs,
 				})
 			}
 		}

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -84,6 +84,10 @@ type Finding struct {
 	Message string
 	// Hint optionally suggests a fix.
 	Hint string
+	// Docs optionally links to the upstream documentation the finding rests
+	// on. A rule that reports what upstream requires or recommends should say
+	// where it says so.
+	Docs string
 	// Severity overrides the rule's default for this one finding.
 	Severity diag.Severity
 }
@@ -102,6 +106,7 @@ func (c *Context) Report(f Finding) {
 		Position: c.File.Pos(f.Node),
 		Path:     f.Path,
 		Hint:     f.Hint,
+		Docs:     f.Docs,
 	})
 }
 

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -42,10 +42,35 @@ type Context struct {
 	// Strict makes lenient checks report at their strict severity, mirroring
 	// kubeconform's -strict flag.
 	Strict bool
+	// Env describes where this file is deployed. Its zero value means nothing
+	// is known, and the rules that need one then report nothing.
+	Env Environment
 
 	rule     Rule
 	severity diag.Severity
 	out      *diag.Diagnostics
+}
+
+// Environment describes where a config file is deployed. Some settings are
+// only wrong in the light of numbers the config cannot carry -- a memory limit
+// is a limit against something -- and this is how the caller supplies them.
+//
+// The zero value means nothing is known. It is the value every file has unless
+// the caller says otherwise, so a rule that needs an environment must treat it
+// as "say nothing" rather than as zero bytes.
+type Environment struct {
+	// Kubernetes reports that the config runs in a Kubernetes pod.
+	Kubernetes bool
+	// MemoryRequest is the container's memory request in bytes; 0 is unknown.
+	MemoryRequest int64
+	// MemoryLimit is the container's memory limit in bytes; 0 is unknown.
+	MemoryLimit int64
+}
+
+// Known reports whether the environment carries anything worth checking
+// against.
+func (e Environment) Known() bool {
+	return e.Kubernetes && (e.MemoryRequest > 0 || e.MemoryLimit > 0)
 }
 
 // Finding is a single problem a rule wants to report.
@@ -109,6 +134,7 @@ func All() []Rule {
 		referenceRules(),
 		componentRules(),
 		fieldRules(),
+		settingsRules(),
 		practiceRules(),
 	)
 	slices.SortFunc(rules, func(a, b Rule) int { return strings.Compare(a.Name(), b.Name()) })

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -92,6 +92,8 @@ receivers:
 processors:
   memory_limiter:
     check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
   batch:
 exporters:
   otlp:

--- a/pkg/rule/settings.go
+++ b/pkg/rule/settings.go
@@ -1,0 +1,431 @@
+package rule
+
+import (
+	"strconv"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/quantity"
+)
+
+// settingsRules check what a field schema cannot state: a value that must be
+// written even though the field has a default, two fields that are a one-of,
+// and comparisons between one field and another.
+func settingsRules() []Rule {
+	return []Rule{
+		memoryLimiterConfig{base{"memory-limiter-config",
+			"a memory_limiter the collector will refuse to start", diag.Error}},
+		memoryLimiterSizing{base{"memory-limiter-sizing",
+			"a memory_limiter whose limits do not fit the container it runs in", diag.Warning}},
+	}
+}
+
+// The numbers upstream documents, in the memorylimiterprocessor README.
+const (
+	// recommendedInterval is the check_interval the README tells people to
+	// start from.
+	recommendedInterval = time.Second
+	// intervalFloor and intervalCeiling bound how far from the recommended
+	// interval a value has to be before it is worth a remark. Anything in
+	// between is a deliberate choice, not a mistake.
+	intervalFloor   = 100 * time.Millisecond
+	intervalCeiling = 5 * time.Second
+
+	// spikeDefaultPercent is what spike_limit_mib defaults to, as a share of
+	// limit_mib.
+	spikeDefaultPercent = 20
+	// processOverhead is how far the collector's total memory use runs above
+	// the figure the limiter enforces, per the README.
+	processOverhead = 50 * quantity.Mi
+	// ceilingPercent is the share of the container's memory limit the hard
+	// limit is documented to stay under.
+	ceilingPercent = 80
+	// wholePercent is 100%, the divisor for every percentage above.
+	wholePercent = 100
+)
+
+// mib is the unit limit_mib and spike_limit_mib are counted in.
+const mib = quantity.Mi
+
+// setting is one value read out of a memory_limiter's settings block.
+type setting struct {
+	// node is the value node, or nil when the key was not written.
+	node *yaml.Node
+	// present reports that the key was written at all.
+	present bool
+	// known reports that num holds the value. A confmap expansion such as
+	// ${env:LIMIT} is present but never known, and neither is a value of the
+	// wrong type, which invalid-value reports on its own.
+	known bool
+	// num is the value: a count for the integer settings, and nanoseconds for
+	// check_interval.
+	num int64
+}
+
+// positive reports a value that is known and above zero.
+func (s setting) positive() bool { return s.known && s.num > 0 }
+
+// memoryLimiter is one declared memory_limiter instance and the settings the
+// collector validates before it starts.
+type memoryLimiter struct {
+	id config.ID
+	// node anchors findings about the instance as a whole.
+	node *yaml.Node
+	// path is the dotted path of the instance, e.g. "processors.memory_limiter".
+	path string
+
+	checkInterval setting
+	limitMiB      setting
+	limitPercent  setting
+	spikeMiB      setting
+	spikePercent  setting
+}
+
+// name renders the instance for a message, so two findings about the same
+// container limit can be told apart.
+func (m memoryLimiter) name() string { return "processor " + quote(m.id.String()) }
+
+// setting returns the value node of one of the instance's settings, falling
+// back to the instance itself when the key is absent.
+func (m memoryLimiter) at(s setting) *yaml.Node { return nodeOr(s.node, m.node) }
+
+// hardLimit returns the number of bytes the limiter will actually enforce, and
+// whether it could be worked out at all. limit_mib wins over limit_percentage,
+// as it does upstream, and a percentage is only a number when the container's
+// memory limit is known.
+//
+// A value resolved at runtime leaves the whole figure unknown: a partly known
+// hard limit is worse than none, since every finding about it would be
+// confident about a number nobody has yet.
+func (m memoryLimiter) hardLimit(env Environment) (int64, bool) {
+	if unknownValue(m.limitMiB) || unknownValue(m.limitPercent) {
+		return 0, false
+	}
+
+	if m.limitMiB.positive() {
+		return m.limitMiB.num * mib, true
+	}
+
+	if m.limitPercent.positive() && env.MemoryLimit > 0 {
+		return env.MemoryLimit * m.limitPercent.num / wholePercent, true
+	}
+
+	return 0, false
+}
+
+// memoryLimiters returns every declared memory_limiter. Instances are matched
+// on their type, so "memory_limiter/aggressive" is covered too.
+func memoryLimiters(f *config.File) []memoryLimiter {
+	sec := f.Sections[config.KindProcessor]
+	if sec == nil {
+		return nil
+	}
+
+	var out []memoryLimiter
+
+	for _, c := range sec.Components {
+		if c.ID.Type == memoryLimiterType {
+			out = append(out, readMemoryLimiter(c))
+		}
+	}
+
+	return out
+}
+
+func readMemoryLimiter(c config.Component) memoryLimiter {
+	lim := memoryLimiter{
+		id:            c.ID,
+		node:          nodeOr(c.KeyNode, c.ValueNode),
+		path:          config.KindProcessor.Section() + "." + c.ID.String(),
+		checkInterval: absent(),
+		limitMiB:      absent(),
+		limitPercent:  absent(),
+		spikeMiB:      absent(),
+		spikePercent:  absent(),
+	}
+
+	if c.ValueNode == nil || c.ValueNode.Kind != yaml.MappingNode {
+		return lim
+	}
+
+	for _, e := range mapEntries(c.ValueNode, lim.path) {
+		switch e.key {
+		case "check_interval":
+			lim.checkInterval = readDuration(e.node)
+		case "limit_mib":
+			lim.limitMiB = readInt(e.node)
+		case "limit_percentage":
+			lim.limitPercent = readInt(e.node)
+		case "spike_limit_mib":
+			lim.spikeMiB = readInt(e.node)
+		case "spike_limit_percentage":
+			lim.spikePercent = readInt(e.node)
+		default:
+			// Every other setting is the field schema's business.
+		}
+	}
+
+	return lim
+}
+
+func absent() setting { return setting{node: nil, present: false, known: false, num: 0} }
+
+// readInt reads an integer setting. A value nothing can know before the
+// collector starts -- an expansion, or text of the wrong type -- is present
+// but not known, which stops every check that would need the number.
+func readInt(node *yaml.Node) setting {
+	out := setting{node: node, present: true, known: false, num: 0}
+	if node == nil || node.Kind != yaml.ScalarNode || hasExpansion(node.Value) {
+		return out
+	}
+
+	num, err := strconv.ParseInt(node.Value, 10, 64)
+	if err != nil {
+		return out
+	}
+
+	out.known, out.num = true, num
+
+	return out
+}
+
+// readDuration reads a duration setting, holding it in nanoseconds.
+func readDuration(node *yaml.Node) setting {
+	out := setting{node: node, present: true, known: false, num: 0}
+	if node == nil || node.Kind != yaml.ScalarNode || hasExpansion(node.Value) {
+		return out
+	}
+
+	dur, err := time.ParseDuration(node.Value)
+	if err != nil {
+		return out
+	}
+
+	out.known, out.num = true, int64(dur)
+
+	return out
+}
+
+type memoryLimiterConfig struct{ base }
+
+func (r memoryLimiterConfig) Check(ctx *Context) {
+	for _, lim := range memoryLimiters(ctx.File) {
+		r.checkInterval(ctx, lim)
+		r.checkLimits(ctx, lim)
+		r.checkSpikes(ctx, lim)
+	}
+}
+
+// checkInterval reports the one setting a memory_limiter cannot start without.
+// Its default is 0s, so leaving it out is an error rather than a choice.
+func (r memoryLimiterConfig) checkInterval(ctx *Context, lim memoryLimiter) {
+	path := joinPath(lim.path, "check_interval")
+	interval := time.Duration(lim.checkInterval.num)
+
+	switch {
+	case !lim.checkInterval.present:
+		// The field schema marks check_interval required on every release that
+		// describes the component, and required-field reports it there. Saying
+		// it twice about one line helps nobody.
+		if schemaRequires(ctx, memoryLimiterType, "check_interval") {
+			return
+		}
+
+		ctx.Report(Finding{
+			Node: lim.node, Path: path,
+			Message: lim.name() + " has no check_interval, and its default of 0s is rejected: " +
+				"'check_interval' must be greater than zero",
+			Hint: "set check_interval: 1s, the value upstream recommends",
+		})
+	case lim.checkInterval.known && interval <= 0:
+		ctx.Report(Finding{
+			Node: lim.at(lim.checkInterval), Path: path,
+			Message: lim.name() + " sets check_interval to " + interval.String() +
+				": 'check_interval' must be greater than zero",
+			Hint: "set check_interval: 1s, the value upstream recommends",
+		})
+	case lim.checkInterval.known && (interval < intervalFloor || interval > intervalCeiling):
+		ctx.Report(Finding{
+			Node: lim.at(lim.checkInterval), Path: path, Severity: diag.Info,
+			Message: lim.name() + " checks memory every " + interval.String() +
+				"; upstream recommends " + recommendedInterval.String(),
+			Hint: "a long interval lets memory run away between checks, a very short one costs CPU",
+		})
+	}
+}
+
+// checkLimits reports the one-of that a flat list of required fields cannot
+// express: either limit_mib or limit_percentage has to be set.
+func (r memoryLimiterConfig) checkLimits(ctx *Context, lim memoryLimiter) {
+	if lim.limitMiB.positive() || lim.limitPercent.positive() {
+		return
+	}
+
+	// An expansion is a value, just not one that can be read here.
+	if unknownValue(lim.limitMiB) || unknownValue(lim.limitPercent) {
+		return
+	}
+
+	ctx.Report(Finding{
+		Node: lim.node, Path: joinPath(lim.path, "limit_mib"),
+		Message: lim.name() + " sets neither limit_mib nor limit_percentage: " +
+			"'limit_mib' or 'limit_percentage' must be greater than zero",
+		Hint: "set limit_mib to the memory the collector may use; spike_limit_mib then defaults to " +
+			itoa(spikeDefaultPercent) + "% of it",
+	})
+}
+
+// checkSpikes reports the comparisons between two fields, which a schema
+// describing one field at a time cannot make.
+func (r memoryLimiterConfig) checkSpikes(ctx *Context, lim memoryLimiter) {
+	if lim.spikeMiB.known && lim.limitMiB.positive() && lim.spikeMiB.num >= lim.limitMiB.num {
+		ctx.Report(Finding{
+			Node: lim.at(lim.spikeMiB), Path: joinPath(lim.path, "spike_limit_mib"),
+			Message: lim.name() + " sets spike_limit_mib to " + itoa64(lim.spikeMiB.num) +
+				" and limit_mib to " + itoa64(lim.limitMiB.num) +
+				": 'spike_limit_mib' must be smaller than 'limit_mib'",
+			Hint: "leave spike_limit_mib out to take the default of " + itoa(spikeDefaultPercent) +
+				"% of limit_mib, which is where upstream suggests starting",
+		})
+	}
+
+	if lim.spikePercent.known && lim.limitPercent.positive() && lim.spikePercent.num >= lim.limitPercent.num {
+		ctx.Report(Finding{
+			Node: lim.at(lim.spikePercent), Path: joinPath(lim.path, "spike_limit_percentage"),
+			Message: lim.name() + " sets spike_limit_percentage to " + itoa64(lim.spikePercent.num) +
+				" and limit_percentage to " + itoa64(lim.limitPercent.num) +
+				": 'spike_limit_percentage' must be smaller than 'limit_percentage'",
+		})
+	}
+
+	for _, pct := range []struct {
+		key string
+		val setting
+	}{
+		{key: "limit_percentage", val: lim.limitPercent},
+		{key: "spike_limit_percentage", val: lim.spikePercent},
+	} {
+		if pct.val.known && pct.val.num > wholePercent {
+			ctx.Report(Finding{
+				Node: lim.at(pct.val), Path: joinPath(lim.path, pct.key),
+				Message: lim.name() + " sets " + pct.key + " to " + itoa64(pct.val.num) +
+					": 'limit_percentage' and 'spike_limit_percentage' must be greater than zero " +
+					"and less than or equal to hundred",
+			})
+		}
+	}
+}
+
+// unknownValue reports a setting that was written but whose value cannot be
+// read here, so no check that needs the number can run.
+func unknownValue(s setting) bool { return s.present && !s.known }
+
+// schemaRequires reports whether the targeted release's field schema already
+// marks a processor setting required.
+func schemaRequires(ctx *Context, typ, field string) bool {
+	if !ctx.schemaReady() {
+		return false
+	}
+
+	comp, ok := ctx.Schema.Lookup(config.KindProcessor, typ)
+	if !ok || comp.Fields == nil {
+		return false
+	}
+
+	return contains(comp.Fields.Required, field)
+}
+
+type memoryLimiterSizing struct{ base }
+
+func (r memoryLimiterSizing) Check(ctx *Context) {
+	if !ctx.Env.Known() {
+		return
+	}
+
+	for _, lim := range memoryLimiters(ctx.File) {
+		r.checkPercentage(ctx, lim)
+
+		hard, ok := lim.hardLimit(ctx.Env)
+		if !ok {
+			continue
+		}
+
+		r.checkLimit(ctx, lim, hard)
+		r.checkRequest(ctx, lim, hard)
+	}
+}
+
+// checkPercentage reports a percentage limit with nothing to be a percentage
+// of. Outside a container with a memory limit it resolves against the whole
+// node, which is not a limit on this collector at all.
+func (r memoryLimiterSizing) checkPercentage(ctx *Context, lim memoryLimiter) {
+	if !lim.limitPercent.present || ctx.Env.MemoryLimit > 0 {
+		return
+	}
+
+	ctx.Report(Finding{
+		Node: lim.at(lim.limitPercent), Path: joinPath(lim.path, "limit_percentage"),
+		Message: lim.name() + " limits memory by percentage, but the container has no memory limit",
+		Hint: "the percentage resolves against the node's memory instead, so the limiter is effectively off; " +
+			"set a container memory limit, or use limit_mib",
+	})
+}
+
+// checkLimit compares what the limiter will enforce against the limit the
+// kernel enforces. Only the most serious of the three applies, so a limit that
+// is over the container's is not also reported as being over 80% of it.
+func (r memoryLimiterSizing) checkLimit(ctx *Context, lim memoryLimiter, hard int64) {
+	limit := ctx.Env.MemoryLimit
+	if limit <= 0 {
+		return
+	}
+
+	finding := Finding{
+		Node: lim.at(lim.limitMiB), Path: lim.path,
+		Hint: "keep the hard limit near " + itoa(ceilingPercent) + "% of the container memory limit, " +
+			"and set GOMEMLIMIT to about " + itoa(ceilingPercent) + "% of the hard limit so the collector " +
+			"collects garbage before the limiter has to refuse data",
+	}
+
+	switch {
+	case hard >= limit:
+		finding.Severity = diag.Error
+		finding.Message = lim.name() + " enforces " + quantity.Format(hard) +
+			", at or above the container memory limit of " + quantity.Format(limit) +
+			"; the kernel kills the collector before the limiter engages"
+	case hard+processOverhead > limit:
+		finding.Message = lim.name() + " enforces " + quantity.Format(hard) + " of the container's " +
+			quantity.Format(limit) + ", leaving " + quantity.Format(limit-hard) +
+			"; the process runs about " + quantity.Format(processOverhead) + " above what the limiter counts"
+	case hard > limit*ceilingPercent/wholePercent:
+		finding.Message = lim.name() + " enforces " + quantity.Format(hard) + ", above " +
+			itoa(ceilingPercent) + "% of the container memory limit of " + quantity.Format(limit)
+	default:
+		return
+	}
+
+	ctx.Report(finding)
+}
+
+// checkRequest reports a limiter that may use memory the scheduler never
+// reserved.
+func (r memoryLimiterSizing) checkRequest(ctx *Context, lim memoryLimiter, hard int64) {
+	request := ctx.Env.MemoryRequest
+	if request <= 0 || request >= hard {
+		return
+	}
+
+	ctx.Report(Finding{
+		Node: lim.at(lim.limitMiB), Path: lim.path, Severity: diag.Info,
+		Message: lim.name() + " may use " + quantity.Format(hard) + ", above the container memory request of " +
+			quantity.Format(request),
+		Hint: "the pod is Burstable and is evicted first under node pressure; " +
+			"collectors usually set the memory request equal to the limit",
+	})
+}
+
+// itoa64 renders a setting's value for a message.
+func itoa64(n int64) string { return strconv.FormatInt(n, 10) }

--- a/pkg/rule/settings.go
+++ b/pkg/rule/settings.go
@@ -239,6 +239,7 @@ func (r memoryLimiterConfig) checkInterval(ctx *Context, lim memoryLimiter) {
 			Message: lim.name() + " has no check_interval, and its default of 0s is rejected: " +
 				"'check_interval' must be greater than zero",
 			Hint: "set check_interval: 1s, the value upstream recommends",
+			Docs: memoryLimiterDocs,
 		})
 	case lim.checkInterval.known && interval <= 0:
 		ctx.Report(Finding{
@@ -246,6 +247,7 @@ func (r memoryLimiterConfig) checkInterval(ctx *Context, lim memoryLimiter) {
 			Message: lim.name() + " sets check_interval to " + interval.String() +
 				": 'check_interval' must be greater than zero",
 			Hint: "set check_interval: 1s, the value upstream recommends",
+			Docs: memoryLimiterDocs,
 		})
 	case lim.checkInterval.known && (interval < intervalFloor || interval > intervalCeiling):
 		ctx.Report(Finding{
@@ -253,6 +255,7 @@ func (r memoryLimiterConfig) checkInterval(ctx *Context, lim memoryLimiter) {
 			Message: lim.name() + " checks memory every " + interval.String() +
 				"; upstream recommends " + recommendedInterval.String(),
 			Hint: "a long interval lets memory run away between checks, a very short one costs CPU",
+			Docs: memoryLimiterDocs,
 		})
 	}
 }
@@ -275,6 +278,7 @@ func (r memoryLimiterConfig) checkLimits(ctx *Context, lim memoryLimiter) {
 			"'limit_mib' or 'limit_percentage' must be greater than zero",
 		Hint: "set limit_mib to the memory the collector may use; spike_limit_mib then defaults to " +
 			itoa(spikeDefaultPercent) + "% of it",
+		Docs: memoryLimiterDocs,
 	})
 }
 
@@ -289,6 +293,7 @@ func (r memoryLimiterConfig) checkSpikes(ctx *Context, lim memoryLimiter) {
 				": 'spike_limit_mib' must be smaller than 'limit_mib'",
 			Hint: "leave spike_limit_mib out to take the default of " + itoa(spikeDefaultPercent) +
 				"% of limit_mib, which is where upstream suggests starting",
+			Docs: memoryLimiterDocs,
 		})
 	}
 
@@ -298,6 +303,7 @@ func (r memoryLimiterConfig) checkSpikes(ctx *Context, lim memoryLimiter) {
 			Message: lim.name() + " sets spike_limit_percentage to " + itoa64(lim.spikePercent.num) +
 				" and limit_percentage to " + itoa64(lim.limitPercent.num) +
 				": 'spike_limit_percentage' must be smaller than 'limit_percentage'",
+			Docs: memoryLimiterDocs,
 		})
 	}
 
@@ -314,6 +320,7 @@ func (r memoryLimiterConfig) checkSpikes(ctx *Context, lim memoryLimiter) {
 				Message: lim.name() + " sets " + pct.key + " to " + itoa64(pct.val.num) +
 					": 'limit_percentage' and 'spike_limit_percentage' must be greater than zero " +
 					"and less than or equal to hundred",
+				Docs: memoryLimiterDocs,
 			})
 		}
 	}
@@ -371,6 +378,7 @@ func (r memoryLimiterSizing) checkPercentage(ctx *Context, lim memoryLimiter) {
 		Message: lim.name() + " limits memory by percentage, but the container has no memory limit",
 		Hint: "the percentage resolves against the node's memory instead, so the limiter is effectively off; " +
 			"set a container memory limit, or use limit_mib",
+		Docs: memoryLimiterDocs,
 	})
 }
 
@@ -388,6 +396,7 @@ func (r memoryLimiterSizing) checkLimit(ctx *Context, lim memoryLimiter, hard in
 		Hint: "keep the hard limit near " + itoa(ceilingPercent) + "% of the container memory limit, " +
 			"and set GOMEMLIMIT to about " + itoa(ceilingPercent) + "% of the hard limit so the collector " +
 			"collects garbage before the limiter has to refuse data",
+		Docs: memoryLimiterDocs,
 	}
 
 	switch {
@@ -424,6 +433,7 @@ func (r memoryLimiterSizing) checkRequest(ctx *Context, lim memoryLimiter, hard 
 			quantity.Format(request),
 		Hint: "the pod is Burstable and is evicted first under node pressure; " +
 			"collectors usually set the memory request equal to the limit",
+		Docs: kubernetesResourceDocs,
 	})
 }
 

--- a/pkg/rule/settings_test.go
+++ b/pkg/rule/settings_test.go
@@ -309,3 +309,30 @@ func TestMemoryLimiterSizingLeavesExpansionsAlone(t *testing.T) {
 		t.Errorf("a limit resolved at runtime cannot be sized, got %+v", found)
 	}
 }
+
+// TestFindingsCiteUpstream pins that a rule reporting what the collector
+// requires says where upstream says so, rather than asking to be believed.
+func TestFindingsCiteUpstream(t *testing.T) {
+	t.Parallel()
+
+	const memoryLimiterDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
+		"/blob/main/processor/memorylimiterprocessor/README.md"
+
+	found := checkRule(t, "memory-limiter-config", limiter("memory_limiter", ""), rule.Environment{})
+	if len(found) == 0 {
+		t.Fatal("an empty memory_limiter should be reported")
+	}
+
+	for _, d := range found {
+		if d.Docs != memoryLimiterDocs {
+			t.Errorf("finding %q links to %q, want the processor's README", d.Message, d.Docs)
+		}
+	}
+
+	env := rule.Environment{Kubernetes: true, MemoryRequest: 128 * quantity.Mi, MemoryLimit: 256 * quantity.Mi}
+	for _, d := range checkRule(t, "memory-limiter-sizing", sized("512"), env) {
+		if d.Docs == "" {
+			t.Errorf("finding %q cites nothing", d.Message)
+		}
+	}
+}

--- a/pkg/rule/settings_test.go
+++ b/pkg/rule/settings_test.go
@@ -1,0 +1,311 @@
+package rule_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/quantity"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+)
+
+// checkRule runs one rule over src in a given deployment environment.
+func checkRule(t *testing.T, name, src string, env rule.Environment) diag.Diagnostics {
+	t.Helper()
+
+	f, err := config.Parse("test.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	r, ok := rule.Lookup(name)
+	if !ok {
+		t.Fatalf("rule %q is not registered", name)
+	}
+
+	return rule.Run(r, rule.Context{File: f, Schema: testSchema(), Index: rule.NewIndex(f), Env: env}, r.Severity())
+}
+
+// reports whether any finding mentions substr.
+func reports(found diag.Diagnostics, substr string) bool {
+	for _, d := range found {
+		if strings.Contains(d.Message, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// limiter wraps memory_limiter settings in a config that is otherwise clean.
+// The settings are written already indented by four spaces.
+func limiter(name, settings string) string {
+	return `
+receivers: {otlp: }
+processors:
+  ` + name + `:
+` + settings + `
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [` + name + `], exporters: [debug]}
+`
+}
+
+func TestMemoryLimiterConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		settings string
+		want     string // a phrase the finding has to carry
+	}{
+		"nothing set at all": {
+			settings: "",
+			want:     "'check_interval' must be greater than zero",
+		},
+		"no limit": {
+			settings: "    check_interval: 1s",
+			want:     "'limit_mib' or 'limit_percentage' must be greater than zero",
+		},
+		"check_interval is zero": {
+			settings: "    check_interval: 0s\n    limit_mib: 512",
+			want:     "'check_interval' must be greater than zero",
+		},
+		"check_interval written as a bare zero": {
+			settings: "    check_interval: 0\n    limit_mib: 512",
+			want:     "'check_interval' must be greater than zero",
+		},
+		"limit set to zero": {
+			settings: "    check_interval: 1s\n    limit_mib: 0",
+			want:     "'limit_mib' or 'limit_percentage' must be greater than zero",
+		},
+		"spike at the limit": {
+			settings: "    check_interval: 1s\n    limit_mib: 512\n    spike_limit_mib: 512",
+			want:     "'spike_limit_mib' must be smaller than 'limit_mib'",
+		},
+		"spike above the limit": {
+			settings: "    check_interval: 1s\n    limit_mib: 512\n    spike_limit_mib: 600",
+			want:     "'spike_limit_mib' must be smaller than 'limit_mib'",
+		},
+		"spike percentage at the limit": {
+			settings: "    check_interval: 1s\n    limit_percentage: 50\n    spike_limit_percentage: 50",
+			want:     "'spike_limit_percentage' must be smaller than 'limit_percentage'",
+		},
+		"a percentage above a hundred": {
+			settings: "    check_interval: 1s\n    limit_percentage: 120",
+			want:     "less than or equal to hundred",
+		},
+		"a spike percentage above a hundred": {
+			settings: "    check_interval: 1s\n    limit_percentage: 50\n    spike_limit_percentage: 120",
+			want:     "less than or equal to hundred",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "memory-limiter-config", limiter("memory_limiter", tt.settings), rule.Environment{})
+			if !reports(found, tt.want) {
+				t.Errorf("no finding mentioned %q; got %+v", tt.want, found)
+			}
+
+			for _, d := range found {
+				if d.Severity != diag.Error {
+					continue
+				}
+
+				if !strings.Contains(d.Message, "memory_limiter") {
+					t.Errorf("a finding should name the instance: %q", d.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestMemoryLimiterConfigAcceptsAWorkingLimiter(t *testing.T) {
+	t.Parallel()
+
+	settings := "    check_interval: 1s\n    limit_mib: 512\n    spike_limit_mib: 128"
+	if found := checkRule(t, "memory-limiter-config", limiter("memory_limiter", settings),
+		rule.Environment{}); len(found) > 0 {
+		t.Errorf("a valid memory_limiter should be quiet, got %+v", found)
+	}
+
+	// A percentage limiter is just as valid as a fixed one.
+	settings = "    check_interval: 1s\n    limit_percentage: 80\n    spike_limit_percentage: 25"
+	if found := checkRule(t, "memory-limiter-config", limiter("memory_limiter", settings),
+		rule.Environment{}); len(found) > 0 {
+		t.Errorf("a percentage memory_limiter should be quiet, got %+v", found)
+	}
+}
+
+func TestMemoryLimiterConfigMatchesOnType(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "memory-limiter-config", limiter("memory_limiter/aggressive", ""), rule.Environment{})
+	if !reports(found, "memory_limiter/aggressive") {
+		t.Errorf("a named instance should be checked and named, got %+v", found)
+	}
+}
+
+func TestMemoryLimiterConfigLeavesExpansionsAlone(t *testing.T) {
+	t.Parallel()
+
+	settings := "    check_interval: ${env:INTERVAL}\n    limit_mib: ${env:LIMIT}\n    spike_limit_mib: ${env:SPIKE}"
+	if found := checkRule(t, "memory-limiter-config", limiter("memory_limiter", settings),
+		rule.Environment{}); len(found) > 0 {
+		t.Errorf("values resolved at runtime cannot be checked, got %+v", found)
+	}
+}
+
+func TestMemoryLimiterConfigRemarksOnAFarOffInterval(t *testing.T) {
+	t.Parallel()
+
+	settings := "    check_interval: 30s\n    limit_mib: 512\n    spike_limit_mib: 128"
+
+	found := checkRule(t, "memory-limiter-config", limiter("memory_limiter", settings), rule.Environment{})
+	if len(found) != 1 || found[0].Severity != diag.Info {
+		t.Fatalf("want one info about the interval, got %+v", found)
+	}
+
+	settings = "    check_interval: 2s\n    limit_mib: 512\n    spike_limit_mib: 128"
+	if found := checkRule(t, "memory-limiter-config", limiter("memory_limiter", settings),
+		rule.Environment{}); len(found) > 0 {
+		t.Errorf("an interval near the recommended one is a choice, not a finding: %+v", found)
+	}
+}
+
+// sized is a memory_limiter with a fixed limit, for the sizing tests.
+func sized(limitMiB string) string {
+	return limiter("memory_limiter", "    check_interval: 1s\n    limit_mib: "+limitMiB+"\n    spike_limit_mib: 64")
+}
+
+func TestMemoryLimiterSizing(t *testing.T) {
+	t.Parallel()
+
+	container := rule.Environment{Kubernetes: true, MemoryRequest: 512 * quantity.Mi, MemoryLimit: 512 * quantity.Mi}
+
+	tests := map[string]struct {
+		src  string
+		env  rule.Environment
+		want diag.Severity
+		says string
+	}{
+		"a limit at the container's": {
+			src: sized("512"), env: container,
+			want: diag.Error, says: "before the limiter engages",
+		},
+		"a limit above the container's": {
+			src: sized("1024"), env: container,
+			want: diag.Error, says: "before the limiter engages",
+		},
+		"no headroom for the process itself": {
+			src: sized("480"), env: container,
+			want: diag.Warning, says: "leaving",
+		},
+		"above the documented ceiling": {
+			src: sized("440"), env: container,
+			want: diag.Warning, says: "above 80%",
+		},
+		"a percentage of a container with no limit": {
+			src:  limiter("memory_limiter", "    check_interval: 1s\n    limit_percentage: 80"),
+			env:  rule.Environment{Kubernetes: true, MemoryRequest: 512 * quantity.Mi, MemoryLimit: 0},
+			want: diag.Warning, says: "no memory limit",
+		},
+		"a percentage above the ceiling": {
+			src:  limiter("memory_limiter", "    check_interval: 1s\n    limit_percentage: 90"),
+			env:  container,
+			want: diag.Warning, says: "above 80%",
+		},
+		"more than the pod asked for": {
+			src:  sized("400"),
+			env:  rule.Environment{Kubernetes: true, MemoryRequest: 256 * quantity.Mi, MemoryLimit: 512 * quantity.Mi},
+			want: diag.Info, says: "memory request",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "memory-limiter-sizing", tt.src, tt.env)
+			if !reports(found, tt.says) {
+				t.Fatalf("no finding mentioned %q; got %+v", tt.says, found)
+			}
+
+			for _, d := range found {
+				if strings.Contains(d.Message, tt.says) && d.Severity != tt.want {
+					t.Errorf("want severity %q, got %q for %q", tt.want, d.Severity, d.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestMemoryLimiterSizingIsSilentWithoutAnEnvironment(t *testing.T) {
+	t.Parallel()
+
+	for name, env := range map[string]rule.Environment{
+		"nothing configured":         {},
+		"kubernetes with no numbers": {Kubernetes: true},
+		"numbers but not kubernetes": {MemoryLimit: 512 * quantity.Mi},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if found := checkRule(t, "memory-limiter-sizing", sized("4096"), env); len(found) > 0 {
+				t.Errorf("nothing should be reported without an environment, got %+v", found)
+			}
+		})
+	}
+}
+
+func TestMemoryLimiterSizingFitsTheContainer(t *testing.T) {
+	t.Parallel()
+
+	env := rule.Environment{Kubernetes: true, MemoryRequest: 512 * quantity.Mi, MemoryLimit: 512 * quantity.Mi}
+	if found := checkRule(t, "memory-limiter-sizing", sized("400"), env); len(found) > 0 {
+		t.Errorf("a limiter that fits its container should be quiet, got %+v", found)
+	}
+}
+
+func TestMemoryLimiterSizingNamesEveryInstance(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4096
+  memory_limiter/aggressive:
+    check_interval: 1s
+    limit_mib: 8192
+exporters: {debug: }
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, memory_limiter/aggressive]
+      exporters: [debug]
+`
+	env := rule.Environment{Kubernetes: true, MemoryRequest: 0, MemoryLimit: 512 * quantity.Mi}
+
+	found := checkRule(t, "memory-limiter-sizing", src, env)
+	if !reports(found, "\"memory_limiter\"") || !reports(found, "\"memory_limiter/aggressive\"") {
+		t.Errorf("both instances share the one container limit and both should be named: %+v", found)
+	}
+}
+
+func TestMemoryLimiterSizingLeavesExpansionsAlone(t *testing.T) {
+	t.Parallel()
+
+	env := rule.Environment{Kubernetes: true, MemoryRequest: 256 * quantity.Mi, MemoryLimit: 256 * quantity.Mi}
+	src := limiter("memory_limiter", "    check_interval: 1s\n    limit_mib: ${env:LIMIT}")
+
+	if found := checkRule(t, "memory-limiter-sizing", src, env); len(found) > 0 {
+		t.Errorf("a limit resolved at runtime cannot be sized, got %+v", found)
+	}
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -155,25 +155,44 @@ func (s *Scanner) wanted(name string) bool {
 	return slices.Contains(s.Extensions, strings.ToLower(filepath.Ext(name)))
 }
 
-// excluded reports whether a path matches any exclude pattern. Patterns are
-// matched against both the full path and the base name.
+// excluded reports whether a path matches any exclude pattern.
 func (s *Scanner) excluded(path string) bool {
-	base := filepath.Base(path)
 	for _, pattern := range s.Exclude {
-		if ok, _ := filepath.Match(pattern, base); ok {
-			return true
-		}
-
-		if ok, _ := filepath.Match(pattern, path); ok {
-			return true
-		}
-
-		// A pattern with a star also matches anywhere in the path, so
-		// "*generated*" reaches files a plain glob would not.
-		if strings.Contains(pattern, "*") && strings.Contains(path, strings.Trim(pattern, "*")) {
+		if Match(pattern, path) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// Match reports whether a path matches a glob pattern. The pattern is tried
+// against both the whole path and the base name, so "*.tmpl.yaml" reaches a
+// file wherever it sits. It is exported so that every path pattern the tool
+// takes -- excludes, and the settings file's per-path environments -- behaves
+// the same way, including which patterns do not work.
+func Match(pattern, path string) bool {
+	if ok, _ := filepath.Match(pattern, filepath.Base(path)); ok {
+		return true
+	}
+
+	if ok, _ := filepath.Match(pattern, path); ok {
+		return true
+	}
+
+	// A pattern with a star also matches anywhere in the path, so
+	// "*generated*" reaches files a plain glob would not.
+	return strings.Contains(pattern, "*") && strings.Contains(path, strings.Trim(pattern, "*"))
+}
+
+// CheckPattern reports a glob filepath.Match cannot parse, so a bad pattern is
+// a clear error at startup rather than a pattern that silently matches
+// nothing.
+func CheckPattern(pattern string) error {
+	_, err := filepath.Match(pattern, "")
+	if err != nil {
+		return fmt.Errorf("pattern %q: %w", pattern, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Closes #43.

## What

Two rules, split by what they need to run.

**`memory-limiter-config`** (`error`, no external input) checks every declared
`memory_limiter` against what upstream's `Validate()` actually rejects, quoting
its wording:

| Condition | Reported as |
| --- | --- |
| `check_interval` absent or `<= 0` | `'check_interval' must be greater than zero` |
| neither `limit_mib` nor `limit_percentage` above zero | `'limit_mib' or 'limit_percentage' must be greater than zero` |
| `spike_limit_mib >= limit_mib` | `'spike_limit_mib' must be smaller than 'limit_mib'` |
| `spike_limit_percentage >= limit_percentage` | `'spike_limit_percentage' must be smaller than 'limit_percentage'` |
| either percentage above 100 | `... less than or equal to hundred` |

Plus an `info` when `check_interval` is far from the recommended `1s` (outside
100ms–5s; anything in between is a choice, not a mistake). Matching is on the
component type, so `memory_limiter/aggressive` is covered, and every message
names the instance. A `${env:...}` expansion counts as set and stops the checks
that would need its number.

**`memory-limiter-sizing`** (`warning`) compares the effective hard limit `H`
against the container: `H >= memoryLimit` is an error (the kernel kills the
collector before the limiter engages), `H + 50Mi > memoryLimit` and
`H > 80% of memoryLimit` are warnings, `limit_percentage` with no container
memory limit is a warning, and `memoryRequest < H` is an info about Burstable
QoS. `GOMEMLIMIT` stays hint text rather than a finding of its own. It reports
nothing for a file with no environment, so nobody who ignores this feature sees
anything new.

## Supplying the environment

Per file, which is the hard requirement: `run ./configs` checks an agent
DaemonSet at `256Mi` and a gateway Deployment at `4Gi` in the same run.

```yaml
kubernetes:
  memoryRequest: 512Mi        # defaults, for any file no override matches
  memoryLimit: 512Mi
  overrides:
    - paths: ["configs/agent-*.yaml"]
      memoryRequest: 256Mi
      memoryLimit: 256Mi
    - paths: ["configs/legacy/*.yaml"]
      enabled: false
```

First match wins and replaces the defaults rather than merging with them.
Patterns go through the same matcher `--exclude` uses, so the two glob features
behave identically, including which patterns do not work. `--kubernetes`,
`--memory-request` and `--memory-limit` set the defaults only and win over the
file; either memory flag implies `--kubernetes`. `--verbose` prints what each
file resolved to.

Plumbing: `rule.Environment` on `rule.Context` (zero value meaning unknown, so
every existing rule is untouched), a `func(path string) rule.Environment`
resolver on `lint.Options` called from `Linter.Lint`, and
`lint.EnvironmentPolicy`, which is read-only after construction and so is safe
under `LintAll`'s workers. Quantities are parsed once, at startup, by the new
`pkg/quantity` (`512Mi`, `1Gi`, `2G`, bare bytes; anything else is an error).

## Two judgement calls worth a look

- **The generated schemas already mark `check_interval` required**, on every
  release and distribution, so `required-field` reports an absent one today.
  Rather than say it twice about one line, `memory-limiter-config` stands down
  for that one case when the schema covers it; it still reports `check_interval: 0s`,
  and still reports the absence when no schema describes the component.
  `TestAMissingCheckIntervalIsReportedOnce` pins it. Happy to drop the guard and
  accept the duplicate if you would rather the rule never depend on the schema.
- **The `spike_limit_mib`-is-absent remark** is hint text on the tuning
  findings rather than a finding of its own, reading "really just a hint
  attached to the tuning story" from the issue that way.
- The `max_gc_interval_*` checks are left out, as the issue suggested.
- No GitHub Action inputs for the three flags: a repository of configs wants the
  `kubernetes` block, which the existing `config` input already reaches.

## Tests

`pkg/quantity` round-trips and rejections; every condition of both rules,
including named instances, expansions and the silent-without-an-environment
case; policy resolution, first-match and bad globs; and a command-level run over
one directory where two files resolve to different limits and only one is
flagged. `make lint` and `make test` are clean.

Two fixtures gained `limit_mib`/`spike_limit_mib`: they declared a
`memory_limiter` the collector would have refused to start, which is now the
point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)