### PR TITLE
fix(schemagen): resolve a manifest's local replacement absolutely

### DIFF
--- a/pkg/cmd/schemagen/builder.go
+++ b/pkg/cmd/schemagen/builder.go
@@ -252,7 +252,7 @@ func (m *manifest) replacements() []string {
 
 		target := strings.TrimSpace(replacement)
 		if isLocalPath(target) && !filepath.IsAbs(target) {
-			target = filepath.Join(m.replaceBase(), target)
+			target = absolutePath(filepath.Join(m.replaceBase(), target))
 		}
 
 		out = append(out, strings.TrimSpace(module)+" => "+target)
@@ -266,6 +266,30 @@ func (m *manifest) replacements() []string {
 // at "../../../internal/obi-src", which is three levels up from
 // "distributions/otelcol-contrib/_build" -- the repository root -- and only two
 // from the manifest itself.
+// absolute resolves a replacement path against the directory schemagen was
+// invoked from.
+//
+// A manifest's local replacement is written to be read from the manifest's own
+// tree -- contrib's "go.opentelemetry.io/obi => ../../../internal/obi-src" is
+// three levels up from the distribution directory -- but the go.mod that
+// replacement is copied into is the synthetic workspace, which lives in the
+// cache directory. A path relative to where schemagen ran does not point at
+// the same place from there, and the go command will not even parse it: a
+// filesystem replacement must be rooted or start with "." or "..", so a
+// "releases/internal/obi-src" is rejected outright and takes the whole
+// distribution with it.
+//
+// A path that cannot be made absolute is left as it was, so the go command
+// reports what is wrong with it rather than this reporting something else.
+func absolutePath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+
+	return abs
+}
+
 func (m *manifest) replaceBase() string {
 	out := m.Dist.OutputPath
 


### PR DESCRIPTION
`contrib` cannot be generated for `v0.156.0` or later — the newest releases, and
the distribution most configs are linted against:

```
go.mod:250: replacement module without version must be directory path (rooted or starting with . or ..)
```

## What happens

From `v0.156.0` the contrib manifest carries a local replacement:

```yaml
replaces:
  # Prepared by scripts/prepare-obi.sh from a tagged upstream source archive.
  - go.opentelemetry.io/obi => ../../../internal/obi-src
```

That path is written to be read from the manifest's own tree — three levels up
from `distributions/otelcol-contrib/`. But the `go.mod` it gets copied into is
not there: it is the synthetic workspace, under the cache directory.

`replaceBase()` joins the manifest's directory onto it, which yields
`releases/internal/obi-src` — a path relative to wherever schemagen was
invoked. That points somewhere else entirely from the workspace, and the go
command will not even parse it, because a filesystem replacement must be rooted
or start with `.` or `..`.

The result is not a bad path warning; it is `go mod tidy`, `go mod download`
and `go list` all failing to parse `go.mod`, so the entire distribution is
skipped:

```
contrib=releases/distributions/otelcol-contrib/manifest.yaml: skipped
  (resolve modules: go list -m -e -json all: exit status 1: go: errors parsing go.mod:)
```

## The fix

Make the joined path absolute. That is the only form which means the same place
from a `go.mod` written somewhere else, and it is what the go command requires.

A path that cannot be made absolute is left as it was, so the go command
reports what is actually wrong with it rather than this reporting something
else.

## Verification

Reproduced against the real `v0.158.0` manifest: before, `go list -m -e -json
all` in the generated workspace fails with the parse error above; after, the
replacement is written as an absolute path and contrib resolves.

`go test ./...` passes.

Independent of #57, though a full backfill needs both: #57 is what keeps one
unresolvable module from discarding a distribution, and this is what keeps a
local replacement from discarding one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)