### PR TITLE
fix: two silent overflows in the memory_limiter sizing path

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
           allow:
             - $gostd
             - github.com/minuk-dev/otelcol-config-lint
+            - github.com/samber/lo
             - github.com/samber/mo
             - github.com/spf13/afero
             - github.com/spf13/cobra
@@ -22,6 +23,7 @@ linters:
           allow:
             - $gostd
             - github.com/minuk-dev/otelcol-config-lint
+            - github.com/samber/lo
             - github.com/samber/mo
             - github.com/spf13/afero
             - github.com/spf13/cobra

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/minuk-dev/otelcol-config-lint
 go 1.25.4
 
 require (
+	github.com/samber/lo v1.53.0
 	github.com/samber/mo v1.17.0
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/samber/mo v1.17.0 h1:EbeLc7nxIdpalstxQQakLOcXxULuMRqo7PJPtY18bQg=
 github.com/samber/mo v1.17.0/go.mod h1:DlgzJ4SYhOh41nP1L9kh9rDNERuf8IqWSAs+gj2Vxag=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	otelcolconfiglint "github.com/minuk-dev/otelcol-config-lint/pkg/cmd/otelcol-config-lint"
 )
@@ -763,6 +766,15 @@ service:
       exporters: [debug]
 `
 
+// limiterWith is limiterConfig with the memory_limiter settings replaced, for
+// the cases where the limiter itself is what is wrong. The settings are written
+// already indented by four spaces.
+func limiterWith(settings string) string {
+	const declared = "    check_interval: 1s\n    limit_mib: 512\n    spike_limit_mib: 128\n"
+
+	return strings.Replace(limiterConfig, declared, settings+"\n", 1)
+}
+
 // writeFile writes a fixture, creating the directories leading to it.
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
@@ -778,17 +790,26 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
-// rulesFired returns the rules each file in a JSON report was flagged by.
-func rulesFired(t *testing.T, out string) map[string][]string {
+// finding is one diagnostic of a JSON report, as a test reads it.
+type finding struct {
+	Rule     string `json:"rule"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+	Docs     string `json:"docs"`
+}
+
+// fileReport is one file's entry in a JSON report.
+type fileReport struct {
+	Filename    string    `json:"filename"`
+	Diagnostics []finding `json:"diagnostics"`
+}
+
+// findings returns the diagnostics of a JSON report, keyed by file base name.
+func findings(t *testing.T, out string) map[string][]finding {
 	t.Helper()
 
 	var report struct {
-		Files []struct {
-			Filename    string `json:"filename"`
-			Diagnostics []struct {
-				Rule string `json:"rule"`
-			} `json:"diagnostics"`
-		} `json:"files"`
+		Files []fileReport `json:"files"`
 	}
 
 	err := json.Unmarshal([]byte(out), &report)
@@ -796,16 +817,20 @@ func rulesFired(t *testing.T, out string) map[string][]string {
 		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
 	}
 
-	fired := map[string][]string{}
+	byFile := lo.GroupBy(report.Files, func(f fileReport) string { return filepath.Base(f.Filename) })
 
-	for _, f := range report.Files {
-		for _, d := range f.Diagnostics {
-			name := filepath.Base(f.Filename)
-			fired[name] = append(fired[name], d.Rule)
-		}
-	}
+	return lo.MapValues(byFile, func(files []fileReport, _ string) []finding {
+		return lo.FlatMap(files, func(f fileReport, _ int) []finding { return f.Diagnostics })
+	})
+}
 
-	return fired
+// rulesFired returns the rules each file in a JSON report was flagged by.
+func rulesFired(t *testing.T, out string) map[string][]string {
+	t.Helper()
+
+	return lo.MapValues(findings(t, out), func(found []finding, _ string) []string {
+		return lo.Map(found, func(d finding, _ int) string { return d.Rule })
+	})
 }
 
 // TestEnvironmentIsResolvedPerFile is the point of the whole kubernetes block:
@@ -917,4 +942,257 @@ func TestVerboseSaysWhichEnvironmentAFileGot(t *testing.T) {
 	if strings.Contains(errOut, "no deployment environment") {
 		t.Errorf("with no environment configured there is nothing to say:\n%s", errOut)
 	}
+}
+
+// TestVerboseSaysWhenAFileHasNoEnvironment is the other half of the question
+// --verbose answers: with a policy in force, a file the policy opts out has to
+// say so, or a rule that stayed silent looks like a rule that passed.
+func TestVerboseSaysWhenAFileHasNoEnvironment(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "configs", "old.yaml"), limiterConfig)
+
+	settings := filepath.Join(dir, "settings.yaml")
+	writeFile(t, settings, "kubernetes:\n  memoryLimit: 256Mi\n  overrides:\n"+
+		"    - paths: [\"old.yaml\"]\n      enabled: false\n")
+
+	_, out, errOut := lint(t, "", "--config", settings, "--verbose", filepath.Join(dir, "configs"))
+
+	assert.Contains(t, errOut, "old.yaml: no deployment environment", "an opted-out file should say so")
+	assert.NotContains(t, out, "memory-limiter-sizing", "an opted-out file is not sized")
+}
+
+// TestMemoryLimiterConfigReachesTheCommandLine pins that the rule's findings
+// survive the whole path a user sees -- the real schema, the severity gate and
+// the text formatter -- and that a config the collector refuses to start on
+// fails the run.
+func TestMemoryLimiterConfigReachesTheCommandLine(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		settings string
+		says     string
+	}{
+		"a check_interval of zero": {
+			settings: "    check_interval: 0s\n    limit_mib: 512",
+			says:     "'check_interval' must be greater than zero",
+		},
+		"no limit at all": {
+			settings: "    check_interval: 1s",
+			says:     "'limit_mib' or 'limit_percentage' must be greater than zero",
+		},
+		"a spike at the limit": {
+			settings: "    check_interval: 1s\n    limit_mib: 512\n    spike_limit_mib: 512",
+			says:     "'spike_limit_mib' must be smaller than 'limit_mib'",
+		},
+		"a percentage above a hundred": {
+			settings: "    check_interval: 1s\n    limit_percentage: 120",
+			says:     "less than or equal to hundred",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			code, out, errOut := lint(t, limiterWith(tt.settings), "-")
+			require.Equal(t, 1, code, "a limiter the collector rejects should fail the run: %s%s", out, errOut)
+
+			assert.Contains(t, out, tt.says)
+			assert.Contains(t, out, "[memory-limiter-config]")
+		})
+	}
+}
+
+// TestAWorkingLimiterPassesTheCommandLine is the other side of the rule: the
+// configuration upstream recommends comes through clean, down to the last
+// remark, or the rule is noise a project will turn off.
+func TestAWorkingLimiterPassesTheCommandLine(t *testing.T) {
+	t.Parallel()
+
+	code, out, errOut := lint(t, limiterConfig, "--fail-on", "info", "--min-severity", "warning", "-")
+	require.Equal(t, 0, code, "a recommended limiter should pass: %s%s", out, errOut)
+}
+
+// TestFindingsCiteUpstreamInEveryFormat pins that the citation reaches whoever
+// is reading. A link the reporter drops is not a citation, and the machine
+// formats are where a reviewer meets the finding.
+func TestFindingsCiteUpstreamInEveryFormat(t *testing.T) {
+	t.Parallel()
+
+	const docs = "processor/memorylimiterprocessor/README.md"
+
+	src := limiterWith("    check_interval: 1s")
+
+	_, text, _ := lint(t, src, "-")
+	assert.Contains(t, text, "docs: https://", "the text report should cite upstream")
+	assert.Contains(t, text, docs)
+
+	_, out, _ := lint(t, src, "--output", "json", "-")
+	cited := lo.ContainsBy(findings(t, out)["stdin"], func(d finding) bool {
+		return d.Rule == "memory-limiter-config" && strings.Contains(d.Docs, docs)
+	})
+	assert.True(t, cited, "the JSON report should carry a docs field:\n%s", out)
+
+	_, github, _ := lint(t, src, "--output", "github", "-")
+	assert.Contains(t, github, "%0Adocs: https://", "an annotation carries the citation, newline escaped")
+}
+
+// TestSizingIsAWarningNotAGate pins the severity the rule was given: a limiter
+// that merely leaves too little headroom is a remark, and only a stricter gate
+// turns it into a failure.
+func TestSizingIsAWarningNotAGate(t *testing.T) {
+	t.Parallel()
+
+	// 512Mi enforced in a 600Mi container: above the documented 80% ceiling,
+	// but not yet a limit the kernel wins.
+	const container = "600Mi"
+
+	code, out, errOut := lint(t, limiterConfig, "--memory-limit", container, "-")
+	require.Equal(t, 0, code, "a sizing warning does not fail the run: %s%s", out, errOut)
+	require.Contains(t, out, "[memory-limiter-sizing]")
+
+	code, _, _ = lint(t, limiterConfig, "--memory-limit", container, "--fail-on", "warning", "-")
+	assert.Equal(t, 1, code, "--fail-on warning should make the sizing warning fail")
+
+	code, out, _ = lint(t, limiterConfig, "--memory-limit", container, "--disable", "memory-limiter-sizing", "-")
+	assert.Equal(t, 0, code)
+	assert.NotContains(t, out, "memory-limiter-sizing", "the rule is switchable off like any other")
+}
+
+// TestAnOverrideReplacesTheDefaults pins the documented merge rule: what a file
+// resolves to is stated in one place, so an override naming only a limit does
+// not inherit the default request.
+func TestAnOverrideReplacesTheDefaults(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "configs", "agent-node.yaml"), limiterConfig)
+	writeFile(t, filepath.Join(dir, "configs", "other.yaml"), limiterConfig)
+
+	settings := filepath.Join(dir, "settings.yaml")
+	writeFile(t, settings, `
+kubernetes:
+  memoryRequest: 128Mi
+  memoryLimit: 4Gi
+  overrides:
+    - paths: ["agent-*.yaml"]
+      memoryLimit: 4Gi
+`)
+
+	_, out, _ := lint(t, "", "--config", settings, "--output", "json", filepath.Join(dir, "configs"))
+
+	found := findings(t, out)
+	said := func(file string) string {
+		return strings.Join(lo.Map(found[file], func(d finding, _ int) string { return d.Message }), "\n")
+	}
+
+	assert.Contains(t, said("other.yaml"), "memory request of 128Mi",
+		"a file no override matches takes the defaults")
+	assert.NotContains(t, said("agent-node.yaml"), "memory request",
+		"an override states the whole environment, so the default request is gone")
+}
+
+// TestTheFirstMatchingOverrideWins pins the order rule, which is what lets a
+// single file be carved out of a pattern that also covers it.
+func TestTheFirstMatchingOverrideWins(t *testing.T) {
+	t.Parallel()
+
+	const overrides = `
+kubernetes:
+  memoryLimit: 4Gi
+  overrides:
+    - paths: [%q]
+      memoryLimit: %s
+    - paths: [%q]
+      memoryLimit: %s
+`
+
+	tests := map[string]struct {
+		settings string
+		sized    bool
+	}{
+		"the roomy container is named first": {
+			settings: fmt.Sprintf(overrides, "*.yaml", "4Gi", "agent-node.yaml", "128Mi"),
+			sized:    false,
+		},
+		"the tight container is named first": {
+			settings: fmt.Sprintf(overrides, "agent-node.yaml", "128Mi", "*.yaml", "4Gi"),
+			sized:    true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "configs", "agent-node.yaml"), limiterConfig)
+
+			settings := filepath.Join(dir, "settings.yaml")
+			writeFile(t, settings, tt.settings)
+
+			_, out, _ := lint(t, "", "--config", settings, "--output", "json", filepath.Join(dir, "configs"))
+
+			fired := rulesFired(t, out)["agent-node.yaml"]
+			if tt.sized {
+				assert.Contains(t, fired, "memory-limiter-sizing", "the first matching override decides")
+			} else {
+				assert.NotContains(t, fired, "memory-limiter-sizing", "the first matching override decides")
+			}
+		})
+	}
+}
+
+// TestStdinTakesTheDefaultEnvironment pins what the README promises about a
+// config with no path: it is reported as "stdin", which the overrides are not
+// meant to match, so it resolves to the defaults rather than to whichever
+// pattern happens to be broad.
+func TestStdinTakesTheDefaultEnvironment(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	settings := filepath.Join(dir, "settings.yaml")
+	writeFile(t, settings, "kubernetes:\n  memoryLimit: 256Mi\n  overrides:\n"+
+		"    - paths: [\"*.yaml\"]\n      memoryLimit: 4Gi\n")
+
+	_, out, _ := lint(t, limiterConfig, "--config", settings, "--output", "json", "-")
+
+	assert.Contains(t, rulesFired(t, out)["stdin"], "memory-limiter-sizing",
+		"stdin should have taken the 256Mi default")
+}
+
+// TestAMemoryQuantityThatDoesNotFitIsRejected pins the boundary of the byte
+// count. 8Ei is 2^63, the first size an int64 cannot hold; converting it would
+// give a different number per architecture, so it has to stop the run the way
+// any other unreadable quantity does.
+func TestAMemoryQuantityThatDoesNotFitIsRejected(t *testing.T) {
+	t.Parallel()
+
+	for _, flag := range []string{"--memory-limit", "--memory-request"} {
+		t.Run(flag, func(t *testing.T) {
+			t.Parallel()
+
+			code, _, errOut := lint(t, "", flag, "8Ei", validConfig)
+			assert.Equal(t, 2, code, "%s 8Ei should stop the run: %s", flag, errOut)
+			assert.Contains(t, errOut, "does not fit in a byte count")
+		})
+	}
+}
+
+// TestALimitTooLargeToSizeIsNotGivenANumber pins that a limit_mib no byte count
+// can hold leaves the file unsized. Multiplying it out wraps, and the wrapped
+// product lands back in a plausible range: the limiter below would otherwise be
+// reported as enforcing exactly the container's 512Mi, a figure written nowhere.
+func TestALimitTooLargeToSizeIsNotGivenANumber(t *testing.T) {
+	t.Parallel()
+
+	// 2^44 MiB is 2^64 bytes plus the 512Mi a wrap would leave behind.
+	src := limiterWith("    check_interval: 1s\n    limit_mib: 17592186044928")
+
+	_, out, _ := lint(t, src, "--memory-limit", "512Mi", "--output", "json", "-")
+
+	assert.NotContains(t, rulesFired(t, out)["stdin"], "memory-limiter-sizing",
+		"a limit that does not fit in a byte count cannot be sized")
 }

--- a/pkg/quantity/quantity.go
+++ b/pkg/quantity/quantity.go
@@ -10,6 +10,9 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/samber/lo"
+	"github.com/samber/mo"
 )
 
 // ErrInvalid reports a string that is not a memory quantity.
@@ -34,6 +37,15 @@ const (
 	peta = 1e15
 	exa  = 1e18
 )
+
+// overflow is the first byte count that does not fit. A float64 cannot hold
+// MaxInt64 exactly -- the nearest value it has is 2^63, one above -- so the
+// bound has to be that value rather than MaxInt64, which would round up to it
+// and let 8Ei through. Converting an out-of-range float to an int64 is
+// implementation-defined in Go: it saturates on arm64 and wraps to the most
+// negative int64 on amd64, so a number past the bound has to be an error here
+// rather than a different answer per architecture.
+const overflow = 1 << 63
 
 // unit is one accepted suffix and what it multiplies by. The suffixes are
 // listed longest first so "Mi" is not read as "M" with a stray "i".
@@ -71,7 +83,7 @@ func Parse(text string) (int64, error) {
 
 	digits, suffix := split(trimmed)
 
-	factor, ok := factorOf(suffix)
+	factor, ok := factorOf(suffix).Get()
 	if !ok {
 		return 0, fmt.Errorf("%q is %w: %q is not a memory suffix (want Ki, Mi, Gi, Ti, Pi, Ei, k, M, G, T, P or E)",
 			text, ErrInvalid, suffix)
@@ -82,12 +94,12 @@ func Parse(text string) (int64, error) {
 		return 0, fmt.Errorf("%q is %w: want a non-negative number, optionally with a suffix", text, ErrInvalid)
 	}
 
-	bytes := value * factor
-	if bytes > math.MaxInt64 {
+	bytes := math.Round(value * factor)
+	if bytes >= overflow {
 		return 0, fmt.Errorf("%q is %w: it does not fit in a byte count", text, ErrInvalid)
 	}
 
-	return int64(math.Round(bytes)), nil
+	return int64(bytes), nil
 }
 
 // split cuts a quantity into its number and its suffix.
@@ -100,14 +112,12 @@ func split(text string) (string, string) {
 	return text[:end], text[end:]
 }
 
-func factorOf(suffix string) (float64, bool) {
-	for _, candidate := range units() {
-		if candidate.suffix == suffix {
-			return candidate.factor, true
-		}
-	}
+// factorOf returns what a suffix multiplies by, and nothing at all when it is
+// not one of the accepted suffixes.
+func factorOf(suffix string) mo.Option[float64] {
+	found, ok := lo.Find(units(), func(candidate unit) bool { return candidate.suffix == suffix })
 
-	return 0, false
+	return mo.TupleToOption(found.factor, ok)
 }
 
 // Format renders a byte count the way a manifest would state it, so a
@@ -126,11 +136,13 @@ func Format(bytes int64) string {
 		{suffix: "Ki", factor: Ki},
 	}
 
-	for _, candidate := range binary {
+	whole, ok := lo.Find(binary, func(candidate unit) bool {
 		size := int64(candidate.factor)
-		if bytes >= size && bytes%size == 0 {
-			return strconv.FormatInt(bytes/size, 10) + candidate.suffix
-		}
+
+		return bytes >= size && bytes%size == 0
+	})
+	if ok {
+		return strconv.FormatInt(bytes/int64(whole.factor), 10) + whole.suffix
 	}
 
 	// Not a whole number of any unit: one decimal place of the largest unit

--- a/pkg/quantity/quantity_test.go
+++ b/pkg/quantity/quantity_test.go
@@ -25,6 +25,9 @@ func TestParse(t *testing.T) {
 			in: "  512Mi  ", want: 512 * quantity.Mi,
 		},
 		"zero": {in: "0", want: 0},
+		// The largest whole unit that still fits, which is where the overflow
+		// bound has to sit rather than one unit lower.
+		"the largest size that fits": {in: "7Ei", want: 7 * quantity.Ei},
 	}
 
 	for name, tt := range tests {
@@ -46,7 +49,14 @@ func TestParse(t *testing.T) {
 func TestParseRejectsWhatIsNotASize(t *testing.T) {
 	t.Parallel()
 
-	for _, in := range []string{"", "  ", "512MB", "512 Mi", "lots", "-1Mi", "1m", "Mi", "1e30Ei"} {
+	// "8Ei" is 2^63, the first byte count that does not fit. It is the case a
+	// bound of MaxInt64 lets through, because a float64 rounds MaxInt64 up to
+	// exactly that number: the conversion that follows would then saturate on
+	// one architecture and wrap to a negative size on another.
+	for _, in := range []string{
+		"", "  ", "512MB", "512 Mi", "lots", "-1Mi", "1m", "Mi", "1e30Ei",
+		"8Ei", "9223372036854775807", "16Ei",
+	} {
 		t.Run(in, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/rule/settings.go
+++ b/pkg/rule/settings.go
@@ -1,9 +1,12 @@
 package rule
 
 import (
+	"math"
 	"strconv"
 	"time"
 
+	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"gopkg.in/yaml.v3"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
@@ -92,28 +95,39 @@ func (m memoryLimiter) name() string { return "processor " + quote(m.id.String()
 // back to the instance itself when the key is absent.
 func (m memoryLimiter) at(s setting) *yaml.Node { return nodeOr(s.node, m.node) }
 
-// hardLimit returns the number of bytes the limiter will actually enforce, and
-// whether it could be worked out at all. limit_mib wins over limit_percentage,
-// as it does upstream, and a percentage is only a number when the container's
-// memory limit is known.
+// hardLimit returns the number of bytes the limiter will actually enforce, or
+// nothing when it cannot be worked out at all. limit_mib wins over
+// limit_percentage, as it does upstream, and a percentage is only a number when
+// the container's memory limit is known.
 //
 // A value resolved at runtime leaves the whole figure unknown: a partly known
 // hard limit is worse than none, since every finding about it would be
 // confident about a number nobody has yet.
-func (m memoryLimiter) hardLimit(env Environment) (int64, bool) {
+func (m memoryLimiter) hardLimit(env Environment) mo.Option[int64] {
 	if unknownValue(m.limitMiB) || unknownValue(m.limitPercent) {
-		return 0, false
+		return mo.None[int64]()
 	}
 
+	// A figure that does not fit in a byte count is left unknown rather than
+	// wrapped: a wrapped product is a plausible-looking number that appears
+	// nowhere in the config, and a finding quoting it would be worse than none.
 	if m.limitMiB.positive() {
-		return m.limitMiB.num * mib, true
+		if m.limitMiB.num > math.MaxInt64/mib {
+			return mo.None[int64]()
+		}
+
+		return mo.Some(m.limitMiB.num * mib)
 	}
 
 	if m.limitPercent.positive() && env.MemoryLimit > 0 {
-		return env.MemoryLimit * m.limitPercent.num / wholePercent, true
+		if env.MemoryLimit > math.MaxInt64/m.limitPercent.num {
+			return mo.None[int64]()
+		}
+
+		return mo.Some(env.MemoryLimit * m.limitPercent.num / wholePercent)
 	}
 
-	return 0, false
+	return mo.None[int64]()
 }
 
 // memoryLimiters returns every declared memory_limiter. Instances are matched
@@ -124,15 +138,11 @@ func memoryLimiters(f *config.File) []memoryLimiter {
 		return nil
 	}
 
-	var out []memoryLimiter
+	declared := lo.Filter(sec.Components, func(c config.Component, _ int) bool {
+		return c.ID.Type == memoryLimiterType
+	})
 
-	for _, c := range sec.Components {
-		if c.ID.Type == memoryLimiterType {
-			out = append(out, readMemoryLimiter(c))
-		}
-	}
-
-	return out
+	return lo.Map(declared, func(c config.Component, _ int) memoryLimiter { return readMemoryLimiter(c) })
 }
 
 func readMemoryLimiter(c config.Component) memoryLimiter {
@@ -355,7 +365,7 @@ func (r memoryLimiterSizing) Check(ctx *Context) {
 	for _, lim := range memoryLimiters(ctx.File) {
 		r.checkPercentage(ctx, lim)
 
-		hard, ok := lim.hardLimit(ctx.Env)
+		hard, ok := lim.hardLimit(ctx.Env).Get()
 		if !ok {
 			continue
 		}

--- a/pkg/rule/settings_test.go
+++ b/pkg/rule/settings_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/quantity"
@@ -297,6 +299,26 @@ service:
 	if !reports(found, "\"memory_limiter\"") || !reports(found, "\"memory_limiter/aggressive\"") {
 		t.Errorf("both instances share the one container limit and both should be named: %+v", found)
 	}
+}
+
+// TestMemoryLimiterSizingDoesNotInventANumber pins that a limit_mib too large
+// to hold as a byte count leaves the hard limit unknown. Multiplying it out
+// wraps, and a wrapped product lands back in a plausible range: the limiter
+// below would otherwise be reported as enforcing exactly the container's 512Mi,
+// a figure that appears nowhere in the config.
+func TestMemoryLimiterSizingDoesNotInventANumber(t *testing.T) {
+	t.Parallel()
+
+	env := rule.Environment{Kubernetes: true, MemoryRequest: 0, MemoryLimit: 512 * quantity.Mi}
+
+	// 2^44 MiB is 2^64 bytes plus the 512Mi that the wrap leaves behind.
+	assert.Empty(t, checkRule(t, "memory-limiter-sizing", sized("17592186044928"), env),
+		"a limit that does not fit in a byte count cannot be sized")
+
+	// The same for a percentage large enough to overflow the multiplication.
+	src := limiter("memory_limiter", "    check_interval: 1s\n    limit_percentage: 99999999999999")
+	assert.Empty(t, checkRule(t, "memory-limiter-sizing", src, env),
+		"a percentage that does not fit cannot be sized")
 }
 
 func TestMemoryLimiterSizingLeavesExpansionsAlone(t *testing.T) {


### PR DESCRIPTION
Two byte-count overflows on the path from `--memory-limit` to a
`memory-limiter-sizing` finding, and the command-level tests that were
missing around it.

## A size of exactly 2^63 slipped past the guard

`quantity.Parse` compared against `math.MaxInt64`, which a float64 rounds up
to 2^63 — so the one value the check existed to reject passed it. `8Ei` is
that value. What followed is implementation defined in Go: arm64 saturates,
amd64 wraps negative, and releases ship both. A negative limit then fails the
`MemoryLimit > 0` test the sizing rules start from, so `--memory-limit 8Ei`
was accepted and silently switched off the rules it was given for.

## A large `limit_mib` was reported as a number written nowhere

`hardLimit` multiplied `limit_mib` by a mebibyte unguarded. The wrap does not
land somewhere obviously wrong — it lands in the range containers are really
sized in:

```yaml
processors:
  memory_limiter:
    check_interval: 1s
    limit_mib: 17592186044928
```

```
error: processor "memory_limiter" enforces 512Mi, at or above the container
memory limit of 512Mi; the kernel kills the collector before the limiter engages
```

That 512Mi is 2^64 bytes past what was written, and nothing in the report
tells it apart from a true finding. A figure that does not fit is now left
unknown, which the rule already knows how to be quiet about.

## Tests

`memory-limiter-config` and the `docs:` citation were covered where they are
implemented but never through the command a user actually runs. Both are now,
along with what the `kubernetes` block promises: an override replaces the
defaults rather than merging with them, the first match wins, stdin takes the
defaults, an opted-out file says so under `--verbose`, and sizing stays a
warning until a stricter gate is asked for. Two of the new tests are
regressions for the fixes above and fail without them.

## Noticed, not changed

Three things worth a decision rather than a quiet fix:

- **`--kubernetes` alone does nothing.** `Environment.Known()` wants a memory
  number, so the flag documented as "the config runs in a Kubernetes pod"
  changes no output on its own — not even the percentage-without-a-limit
  warning, which is exactly the case of knowing it is Kubernetes and having no
  limit. Today that warning needs a `--memory-request` and no `--memory-limit`
  to appear, which is an accident rather than a rule.
- **Negative settings are ignored.** `spike_limit_mib: -5` and
  `spike_limit_percentage: -5` report nothing, though the fields are `uint32`
  upstream and the collector refuses to load them. `limit_percentage: -5` is
  reported as "sets neither limit_mib nor limit_percentage", which is not what
  is wrong with it.
- **Override globs match the path as it was typed.** The README's
  `paths: ["configs/gateway/*.yaml"]` stops matching when the same run is
  invoked with an absolute path. For `--exclude` that fails open; for an
  override it fails sideways — the file quietly takes the defaults and is
  sized against the wrong container. Base-name and `*substring*` patterns are
  unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)