### PR TITLE
feat(rule): resolve the extensions a component names in its own settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,11 @@ There is deliberately no flag form of the overrides.
 `unknown-service-key`, `invalid-pipeline-key`, `empty-pipeline`,
 `unknown-pipeline-key`, `duplicate-key`, `wrong-node-type`.
 
-**Wiring** — `undefined-reference`, `unused-component`, `duplicate-reference`,
+**Wiring** — `undefined-reference`, `undefined-extension-reference` (an
+extension a component's own settings name — an exporter's
+`sending_queue.storage`, an `auth.authenticator` — that nothing declares, or
+that is declared and then left out of `service.extensions`, which the collector
+refuses to start on), `unused-component`, `duplicate-reference`,
 `connector-wiring` (a connector must export from one pipeline and receive into
 another, and must not close a loop).
 

--- a/pkg/rule/docs.go
+++ b/pkg/rule/docs.go
@@ -21,6 +21,14 @@ const (
 	// tlsDocs states what the TLS settings mean, insecure among them.
 	tlsDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
 		"/blob/main/config/configtls/README.md"
+	// exporterQueueDocs states that sending_queue.storage names the storage
+	// extension a persistent queue writes through.
+	exporterQueueDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
+		"/blob/main/exporter/exporterhelper/README.md"
+	// authDocs states that auth.authenticator names an extension, and which
+	// extensions implement the interface it needs.
+	authDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
+		"/blob/main/config/configauth/README.md"
 	// kubernetesResourceDocs states what requests and limits do, and the QoS
 	// class a pod lands in when they differ.
 	kubernetesResourceDocs = "https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"

--- a/pkg/rule/index.go
+++ b/pkg/rule/index.go
@@ -1,6 +1,8 @@
 package rule
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 )
 
@@ -11,6 +13,14 @@ type Index struct {
 
 	declared map[config.Kind]map[config.ID]config.Component
 	used     map[config.Kind]map[config.ID]bool
+	// enabled holds the extensions service.extensions lists, which is the only
+	// place that starts one. A settings reference marks an extension used
+	// without enabling it, and telling the two apart is what lets
+	// undefined-extension-reference report an extension nobody starts.
+	enabled map[config.ID]bool
+	// extRefs holds the extension references written inside component
+	// settings, in file order.
+	extRefs []ExtensionRef
 
 	// connectorRole records the pipelines a connector takes part in, split by
 	// the side it is wired to.
@@ -24,6 +34,8 @@ func NewIndex(f *config.File) *Index {
 		File:       f,
 		declared:   map[config.Kind]map[config.ID]config.Component{},
 		used:       map[config.Kind]map[config.ID]bool{},
+		enabled:    map[config.ID]bool{},
+		extRefs:    extensionRefs(f),
 		asReceiver: map[config.ID][]config.Pipeline{},
 		asExporter: map[config.ID][]config.Pipeline{},
 	}
@@ -38,6 +50,16 @@ func NewIndex(f *config.File) *Index {
 	}
 
 	for _, ref := range f.Service.Extensions {
+		idx.enabled[ref.ID] = true
+
+		idx.markUsed(config.KindExtension, ref.ID)
+	}
+
+	// A component that names an extension in its own settings is using it,
+	// whether or not the service block enables it. Without this, an extension
+	// referenced only from a sending_queue would be reported twice: once as
+	// unused, once as not enabled.
+	for _, ref := range idx.extRefs {
 		idx.markUsed(config.KindExtension, ref.ID)
 	}
 
@@ -93,8 +115,18 @@ func (idx *Index) Resolve(slot config.Kind, id config.ID) (config.Component, boo
 	return config.Component{}, false
 }
 
-// Used reports whether a declared component is referenced by the service block.
+// Used reports whether a declared component is referenced by the service
+// block, or, for an extension, by another component's settings.
 func (idx *Index) Used(k config.Kind, id config.ID) bool { return idx.used[k][id] }
+
+// Enabled reports whether service.extensions lists the extension, which is
+// what makes the collector instantiate it. An extension can be referenced
+// without being enabled, and then it never runs.
+func (idx *Index) Enabled(id config.ID) bool { return idx.enabled[id] }
+
+// ExtensionRefs returns the extension references written inside component
+// settings, such as an exporter's sending_queue.storage.
+func (idx *Index) ExtensionRefs() []ExtensionRef { return idx.extRefs }
 
 // ConnectorPipelines returns the pipelines a connector feeds, as its receiver
 // side, and then the pipelines that feed it, as its exporter side.
@@ -113,6 +145,160 @@ func (idx *Index) KindOf(id config.ID) (config.Kind, bool) {
 	}
 
 	return "", false
+}
+
+// ExtensionRef is a reference to an extension written inside a component's
+// own settings rather than in the service block, such as an exporter's
+// sending_queue.storage.
+type ExtensionRef struct {
+	// ID is the extension the setting names.
+	ID config.ID
+	// Node is the scalar holding the name, and Path its dotted path.
+	Node *yaml.Node
+	Path string
+	// Component is the component whose settings carry the reference.
+	Component config.Component
+	// Role says what the extension is used for, e.g. "storage".
+	Role string
+	// Docs is the upstream page describing the setting.
+	Docs string
+}
+
+// extensionField is a settings key whose value names an extension. The list is
+// hardcoded because nothing in the field schema marks a string as an extension
+// id: neither configauth.Config nor the queue config says so, so a schema walk
+// cannot find these on its own.
+type extensionField struct {
+	// parent is the key holding the reference, e.g. "sending_queue", and key
+	// is the field inside it that carries the id.
+	parent, key string
+	// role says what the extension is used for, for the message.
+	role string
+	// docs is the upstream page describing the setting.
+	docs string
+}
+
+// extensionFields lists the settings that name an extension. They are matched
+// wherever they appear in a component's settings, not only at the top level:
+// a receiver writes its authenticator under protocols.grpc.auth, and each
+// exporter's queue sits somewhere different again.
+//
+// It returns a fresh slice so callers cannot alter what everyone else sees.
+func extensionFields() []extensionField {
+	return []extensionField{
+		{parent: "sending_queue", key: "storage", role: "storage", docs: exporterQueueDocs},
+		{parent: "auth", key: "authenticator", role: "auth", docs: authDocs},
+	}
+}
+
+// maxSettingsDepth bounds the settings walk. It is past the deepest real
+// component config, and stops an anchor that resolves into itself.
+const maxSettingsDepth = 16
+
+// extensionRefs collects every extension reference in the file's component
+// settings, in declaration order.
+func extensionRefs(f *config.File) []ExtensionRef {
+	var out []ExtensionRef
+
+	for _, kind := range config.Kinds() {
+		sec := f.Sections[kind]
+		if sec == nil {
+			continue
+		}
+
+		for _, c := range sec.Components {
+			out = append(out, componentExtensionRefs(c)...)
+		}
+	}
+
+	return out
+}
+
+func componentExtensionRefs(c config.Component) []ExtensionRef {
+	var out []ExtensionRef
+
+	fields := extensionFields()
+
+	walkSettings(c.ValueNode, c.Kind.Section()+"."+c.ID.String(), 0, func(n *yaml.Node, path string) {
+		for _, e := range mapEntries(n, path) {
+			for _, field := range fields {
+				if e.key != field.parent {
+					continue
+				}
+
+				name, ok := scalarChild(e.node, field.key)
+				if !ok {
+					continue
+				}
+
+				out = append(out, ExtensionRef{
+					ID: config.ParseID(name.Value), Node: name,
+					Path: joinPath(e.path, field.key), Component: c,
+					Role: field.role, Docs: field.docs,
+				})
+			}
+		}
+	})
+
+	return out
+}
+
+// scalarChild returns the named scalar of a mapping, if it holds a name worth
+// resolving. An empty value is not a reference, and one built from a confmap
+// expansion is only known once the collector starts.
+func scalarChild(n *yaml.Node, key string) (*yaml.Node, bool) {
+	n = resolveAlias(n)
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil, false
+	}
+
+	for _, e := range mapEntries(n, "") {
+		if e.key != key {
+			continue
+		}
+
+		val := resolveAlias(e.node)
+		if val == nil || val.Kind != yaml.ScalarNode || val.Value == "" || hasExpansion(val.Value) {
+			return nil, false
+		}
+
+		return val, true
+	}
+
+	return nil, false
+}
+
+// walkSettings visits every mapping inside a component's settings, together
+// with its dotted path.
+func walkSettings(n *yaml.Node, path string, depth int, visit func(*yaml.Node, string)) {
+	n = resolveAlias(n)
+	if n == nil || depth > maxSettingsDepth {
+		return
+	}
+
+	switch n.Kind {
+	case yaml.MappingNode:
+		visit(n, path)
+
+		for _, e := range mapEntries(n, path) {
+			walkSettings(e.node, e.path, depth+1, visit)
+		}
+	case yaml.SequenceNode:
+		for i, item := range n.Content {
+			walkSettings(item, indexPath(path, i), depth+1, visit)
+		}
+	default:
+		// A scalar carries no further settings.
+	}
+}
+
+// resolveAlias follows an anchor reference to the node it stands for.
+func resolveAlias(n *yaml.Node) *yaml.Node {
+	for i := 0; n != nil && n.Kind == yaml.AliasNode && i < maxSettingsDepth; i++ {
+		n = n.Alias
+	}
+
+	return n
 }
 
 func (idx *Index) markUsed(k config.Kind, id config.ID) {

--- a/pkg/rule/index.go
+++ b/pkg/rule/index.go
@@ -1,6 +1,8 @@
 package rule
 
 import (
+	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"gopkg.in/yaml.v3"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
@@ -198,20 +200,16 @@ const maxSettingsDepth = 16
 // extensionRefs collects every extension reference in the file's component
 // settings, in declaration order.
 func extensionRefs(f *config.File) []ExtensionRef {
-	var out []ExtensionRef
-
-	for _, kind := range config.Kinds() {
+	return lo.FlatMap(config.Kinds(), func(kind config.Kind, _ int) []ExtensionRef {
 		sec := f.Sections[kind]
 		if sec == nil {
-			continue
+			return nil
 		}
 
-		for _, c := range sec.Components {
-			out = append(out, componentExtensionRefs(c)...)
-		}
-	}
-
-	return out
+		return lo.FlatMap(sec.Components, func(c config.Component, _ int) []ExtensionRef {
+			return componentExtensionRefs(c)
+		})
+	})
 }
 
 func componentExtensionRefs(c config.Component) []ExtensionRef {
@@ -221,51 +219,47 @@ func componentExtensionRefs(c config.Component) []ExtensionRef {
 
 	walkSettings(c.ValueNode, c.Kind.Section()+"."+c.ID.String(), 0, func(n *yaml.Node, path string) {
 		for _, e := range mapEntries(n, path) {
-			for _, field := range fields {
-				if e.key != field.parent {
-					continue
-				}
-
-				name, ok := scalarChild(e.node, field.key)
-				if !ok {
-					continue
-				}
-
-				out = append(out, ExtensionRef{
-					ID: config.ParseID(name.Value), Node: name,
-					Path: joinPath(e.path, field.key), Component: c,
-					Role: field.role, Docs: field.docs,
-				})
+			field, held := lo.Find(fields, func(f extensionField) bool { return f.parent == e.key })
+			if !held {
+				continue
 			}
+
+			name, named := scalarChild(e.node, field.key).Get()
+			if !named {
+				continue
+			}
+
+			out = append(out, ExtensionRef{
+				ID: config.ParseID(name.Value), Node: name,
+				Path: joinPath(e.path, field.key), Component: c,
+				Role: field.role, Docs: field.docs,
+			})
 		}
 	})
 
 	return out
 }
 
-// scalarChild returns the named scalar of a mapping, if it holds a name worth
-// resolving. An empty value is not a reference, and one built from a confmap
-// expansion is only known once the collector starts.
-func scalarChild(n *yaml.Node, key string) (*yaml.Node, bool) {
+// scalarChild returns the named scalar of a mapping, when it holds a name
+// worth resolving. An empty value is not a reference, and one built from a
+// confmap expansion is only known once the collector starts.
+func scalarChild(n *yaml.Node, key string) mo.Option[*yaml.Node] {
 	n = resolveAlias(n)
 	if n == nil || n.Kind != yaml.MappingNode {
-		return nil, false
+		return mo.None[*yaml.Node]()
 	}
 
-	for _, e := range mapEntries(n, "") {
-		if e.key != key {
-			continue
-		}
-
-		val := resolveAlias(e.node)
-		if val == nil || val.Kind != yaml.ScalarNode || val.Value == "" || hasExpansion(val.Value) {
-			return nil, false
-		}
-
-		return val, true
+	e, found := lo.Find(mapEntries(n, ""), func(e mapEntry) bool { return e.key == key })
+	if !found {
+		return mo.None[*yaml.Node]()
 	}
 
-	return nil, false
+	val := resolveAlias(e.node)
+	if val == nil || val.Kind != yaml.ScalarNode || val.Value == "" || hasExpansion(val.Value) {
+		return mo.None[*yaml.Node]()
+	}
+
+	return mo.Some(val)
 }
 
 // walkSettings visits every mapping inside a component's settings, together

--- a/pkg/rule/reference.go
+++ b/pkg/rule/reference.go
@@ -12,6 +12,8 @@ func referenceRules() []Rule {
 	return []Rule{
 		undefinedReference{base{"undefined-reference",
 			"the service block may only reference components declared in the config", diag.Error}},
+		undefinedExtensionReference{base{"undefined-extension-reference",
+			"an extension a component's own settings name, that nothing declares or starts", diag.Error}},
 		unusedComponent{base{"unused-component",
 			"a declared component that no pipeline references is never instantiated", diag.Warning}},
 		duplicateReference{base{"duplicate-reference",
@@ -53,6 +55,47 @@ func (r undefinedReference) Check(ctx *Context) {
 				})
 			}
 		}
+	}
+}
+
+// undefinedExtensionReference checks the references a component writes into
+// its own settings, which undefinedReference never sees: it walks the service
+// block, and these sit several levels down inside a component. Getting one
+// wrong is a startup failure, and the collector's own error does not say which
+// of the three places is missing the name.
+type undefinedExtensionReference struct{ base }
+
+func (r undefinedExtensionReference) Check(ctx *Context) {
+	for _, ref := range ctx.Index.ExtensionRefs() {
+		subject := string(ref.Component.Kind) + " " + quote(ref.Component.ID.String()) +
+			" references " + ref.Role + " extension " + quote(ref.ID.String())
+
+		if _, declared := ctx.Index.Declared(config.KindExtension, ref.ID); !declared {
+			// A name declared under another section lands here too; the hint
+			// is what tells that apart from a name nothing declares at all.
+			ctx.Report(Finding{
+				Node: ref.Node, Path: ref.Path,
+				Message: subject + " which is not declared under extensions",
+				Hint:    misplacedHint(ctx, ref.ID, config.KindExtension),
+				Docs:    ref.Docs,
+			})
+
+			continue
+		}
+
+		// Without a service block nothing is enabled at all, and
+		// serviceRequired already says so.
+		if ctx.File.Service.Node == nil || ctx.Index.Enabled(ref.ID) {
+			continue
+		}
+
+		ctx.Report(Finding{
+			Node: ref.Node, Path: ref.Path,
+			Message: subject + " which is declared but missing from service.extensions, " +
+				"so the collector never starts it",
+			Hint: "add " + quote(ref.ID.String()) + " to service.extensions",
+			Docs: ref.Docs,
+		})
 	}
 }
 

--- a/pkg/rule/reference_test.go
+++ b/pkg/rule/reference_test.go
@@ -1,31 +1,22 @@
 package rule_test
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
 )
 
-// hints reports whether any finding carries a hint mentioning substr.
-func hints(found diag.Diagnostics, substr string) bool {
-	for _, d := range found {
-		if strings.Contains(d.Hint, substr) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func TestUndefinedExtensionReference(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		src  string
-		want string // a phrase the finding has to carry
-		hint string // a phrase its hint has to carry
+		src     string
+		message string
+		hint    string // a phrase the hint has to carry
 	}{
 		"storage extension nothing declares": {
 			src: `
@@ -39,7 +30,7 @@ service:
   pipelines:
     traces: {receivers: [otlp], exporters: [otlp]}
 `,
-			want: `exporter "otlp" references storage extension "file_storage" ` +
+			message: `exporter "otlp" references storage extension "file_storage" ` +
 				`which is not declared under extensions`,
 			hint: "no extensions are declared in this config",
 		},
@@ -57,7 +48,7 @@ service:
   pipelines:
     traces: {receivers: [otlp], exporters: [otlp]}
 `,
-			want: `exporter "otlp" references auth extension "oauth2client" ` +
+			message: `exporter "otlp" references auth extension "oauth2client" ` +
 				`which is not declared under extensions`,
 			hint: "declared extensions: zpages",
 		},
@@ -74,7 +65,7 @@ service:
   pipelines:
     traces: {receivers: [otlp], exporters: [otlp]}
 `,
-			want: `references storage extension "file_storage" which is declared but ` +
+			message: `exporter "otlp" references storage extension "file_storage" which is declared but ` +
 				`missing from service.extensions, so the collector never starts it`,
 			hint: `add "file_storage" to service.extensions`,
 		},
@@ -91,7 +82,8 @@ service:
   pipelines:
     traces: {receivers: [otlp], processors: [batch], exporters: [otlp]}
 `,
-			want: `references storage extension "batch" which is not declared under extensions`,
+			message: `exporter "otlp" references storage extension "batch" ` +
+				`which is not declared under extensions`,
 			hint: `"batch" is declared under processors`,
 		},
 		"authenticator on a receiver protocol": {
@@ -107,8 +99,8 @@ service:
   pipelines:
     traces: {receivers: [otlp], exporters: [debug]}
 `,
-			want: `receiver "otlp" references auth extension "oidc"`,
-			hint: "no extensions are declared in this config",
+			message: `receiver "otlp" references auth extension "oidc" which is not declared under extensions`,
+			hint:    "no extensions are declared in this config",
 		},
 		"a named instance written without its underscores": {
 			src: `
@@ -124,7 +116,8 @@ service:
   pipelines:
     traces: {receivers: [otlp], exporters: [otlp]}
 `,
-			want: `references storage extension "filestorage/wal" which is not declared under extensions`,
+			message: `exporter "otlp" references storage extension "filestorage/wal" ` +
+				`which is not declared under extensions`,
 			hint: `did you mean "file_storage/wal"?`,
 		},
 	}
@@ -134,15 +127,36 @@ service:
 			t.Parallel()
 
 			found := checkRule(t, "undefined-extension-reference", tt.src, rule.Environment{})
-			if !reports(found, tt.want) {
-				t.Errorf("want a finding carrying %q, got %+v", tt.want, found)
-			}
-
-			if !hints(found, tt.hint) {
-				t.Errorf("want a hint carrying %q, got %+v", tt.hint, found)
-			}
+			require.Len(t, found, 1)
+			assert.Equal(t, tt.message, found[0].Message)
+			assert.Contains(t, found[0].Hint, tt.hint)
+			assert.Equal(t, diag.Error, found[0].Severity)
 		})
 	}
+}
+
+// A finding has to point at the line the name is written on, not at the
+// component, so the reader can go straight to it.
+func TestUndefinedExtensionReferenceIsAnchored(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`
+
+	found := checkRule(t, "undefined-extension-reference", src, rule.Environment{})
+	require.Len(t, found, 1)
+	assert.Equal(t, "exporters.otlp.sending_queue.storage", found[0].Path)
+	assert.Equal(t, 7, found[0].Position.Line)
+	assert.Contains(t, found[0].Docs, "exporter/exporterhelper/README.md")
 }
 
 func TestUndefinedExtensionReferenceStaysQuiet(t *testing.T) {
@@ -213,9 +227,7 @@ extensions: {file_storage: }
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if found := checkRule(t, "undefined-extension-reference", src, rule.Environment{}); len(found) > 0 {
-				t.Errorf("expected no findings, got %+v", found)
-			}
+			assert.Empty(t, checkRule(t, "undefined-extension-reference", src, rule.Environment{}))
 		})
 	}
 }
@@ -241,9 +253,7 @@ service:
 `
 
 	found := checkRule(t, "undefined-extension-reference", src, rule.Environment{})
-	if len(found) != 2 {
-		t.Fatalf("want a finding for each exporter, got %+v", found)
-	}
+	require.Len(t, found, 2, "each exporter names the extension")
 }
 
 // unused-component reports an extension the service block does not list. Once
@@ -265,7 +275,6 @@ service:
     traces: {receivers: [otlp], exporters: [otlp]}
 `
 
-	if found := checkRule(t, "unused-component", src, rule.Environment{}); len(found) > 0 {
-		t.Errorf("an extension named by a component's settings is used, got %+v", found)
-	}
+	assert.Empty(t, checkRule(t, "unused-component", src, rule.Environment{}),
+		"an extension named by a component's settings is used")
 }

--- a/pkg/rule/reference_test.go
+++ b/pkg/rule/reference_test.go
@@ -1,0 +1,271 @@
+package rule_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+)
+
+// hints reports whether any finding carries a hint mentioning substr.
+func hints(found diag.Diagnostics, substr string) bool {
+	for _, d := range found {
+		if strings.Contains(d.Hint, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestUndefinedExtensionReference(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		src  string
+		want string // a phrase the finding has to carry
+		hint string // a phrase its hint has to carry
+	}{
+		"storage extension nothing declares": {
+			src: `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`,
+			want: `exporter "otlp" references storage extension "file_storage" ` +
+				`which is not declared under extensions`,
+			hint: "no extensions are declared in this config",
+		},
+		"authenticator nothing declares": {
+			src: `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    auth:
+      authenticator: oauth2client
+extensions: {zpages: }
+service:
+  extensions: [zpages]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`,
+			want: `exporter "otlp" references auth extension "oauth2client" ` +
+				`which is not declared under extensions`,
+			hint: "declared extensions: zpages",
+		},
+		"storage extension declared but not enabled": {
+			src: `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage
+extensions: {file_storage: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`,
+			want: `references storage extension "file_storage" which is declared but ` +
+				`missing from service.extensions, so the collector never starts it`,
+			hint: `add "file_storage" to service.extensions`,
+		},
+		"name belongs to another section": {
+			src: `
+receivers: {otlp: }
+processors: {batch: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: batch
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [batch], exporters: [otlp]}
+`,
+			want: `references storage extension "batch" which is not declared under extensions`,
+			hint: `"batch" is declared under processors`,
+		},
+		"authenticator on a receiver protocol": {
+			src: `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        auth:
+          authenticator: oidc
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+			want: `receiver "otlp" references auth extension "oidc"`,
+			hint: "no extensions are declared in this config",
+		},
+		"a named instance written without its underscores": {
+			src: `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: filestorage/wal
+extensions: {file_storage/wal: }
+service:
+  extensions: [file_storage/wal]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`,
+			want: `references storage extension "filestorage/wal" which is not declared under extensions`,
+			hint: `did you mean "file_storage/wal"?`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "undefined-extension-reference", tt.src, rule.Environment{})
+			if !reports(found, tt.want) {
+				t.Errorf("want a finding carrying %q, got %+v", tt.want, found)
+			}
+
+			if !hints(found, tt.hint) {
+				t.Errorf("want a hint carrying %q, got %+v", tt.hint, found)
+			}
+		})
+	}
+}
+
+func TestUndefinedExtensionReferenceStaysQuiet(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"declared and enabled": `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage
+    auth:
+      authenticator: oauth2client
+extensions: {file_storage: , oauth2client: }
+service:
+  extensions: [file_storage, oauth2client]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`,
+		"the name is resolved at runtime": `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: ${env:STORAGE}
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`,
+		// A plain "auth: <string>" is not an extension reference. The
+		// azureblob and azuremonitor receivers spell their authentication
+		// mode that way, and reading it as an extension id would report every
+		// one of them.
+		"auth written as a plain string": `
+receivers:
+  azureblob:
+    auth: connection_string
+exporters: {debug: }
+service:
+  pipelines:
+    logs: {receivers: [azureblob], exporters: [debug]}
+`,
+		"the queue is off and names nothing": `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`,
+		"no service block at all": `
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage
+extensions: {file_storage: }
+`,
+	}
+
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if found := checkRule(t, "undefined-extension-reference", src, rule.Environment{}); len(found) > 0 {
+				t.Errorf("expected no findings, got %+v", found)
+			}
+		})
+	}
+}
+
+// An anchor is how a config that repeats a queue block writes it once, and the
+// reference inside it is still a reference.
+func TestExtensionReferenceThroughAnAnchor(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue: &queue
+      storage: file_storage
+  otlp/second:
+    endpoint: other:4317
+    sending_queue: *queue
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp, otlp/second]}
+`
+
+	found := checkRule(t, "undefined-extension-reference", src, rule.Environment{})
+	if len(found) != 2 {
+		t.Fatalf("want a finding for each exporter, got %+v", found)
+	}
+}
+
+// unused-component reports an extension the service block does not list. Once
+// a component's settings name it, the two rules would be reporting the same
+// line, and undefined-extension-reference is the one that explains it.
+func TestSettingsReferenceSilencesUnusedComponent(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage
+extensions: {file_storage: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`
+
+	if found := checkRule(t, "unused-component", src, rule.Environment{}); len(found) > 0 {
+		t.Errorf("an extension named by a component's settings is used, got %+v", found)
+	}
+}

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -217,6 +217,21 @@ service:
 			want: "undefined-reference",
 		},
 		{
+			name: "storage extension named by a queue but never declared",
+			src: `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`,
+			want: "undefined-extension-reference",
+		},
+		{
 			name: "declared but never referenced",
 			src: `
 receivers: {otlp: , jaeger: }


### PR DESCRIPTION
Closes #42.

## What

`undefined-extension-reference` (error) resolves the extension names written inside component settings, which `undefined-reference` never sees — it walks `service.extensions` and the pipeline slots, and these sit several levels down inside a component.

Two paths, per the issue:

| Path | Points at |
| --- | --- |
| `sending_queue.storage` | a storage extension |
| `auth.authenticator` | an auth extension |

Three ways it can be wrong:

- **not declared** — nothing under `extensions:` has the name. The hint lists the declared extensions and runs the name through `suggest()`.
- **wrong kind** — the name is declared under another section. Same message, and `misplacedHint` is what tells the two apart, the way `undefined-reference` already explains a misplaced name (`"batch" is declared under processors; it cannot be used as a extension`).
- **declared but not enabled** — present under `extensions:` but missing from `service.extensions`, so the collector never instantiates it. Hint: add it to `service.extensions`.

Findings carry the upstream page the field is documented on: the `exporterhelper` README for the queue, `configauth` for the authenticator.

## Matched at any depth, not just the top level

The issue's table is relative to the component's settings, but that is not where these are written in practice: a receiver puts its authenticator under `protocols.grpc.auth`, and every exporter's queue sits somewhere different again. Walking the settings for the `parent.key` shape catches all of them — in the contrib v0.157.0 schema `auth.authenticator` appears at 20-odd distinct paths, only a handful of them top-level. The list of paths is still hardcoded, as the issue asked: nothing in the field schema marks a string as an extension id.

## The `auth: <string>` question

The issue asked whether any current release still parses a plain `auth: oidc`. It does not, and reading one as a reference would be a false positive: `auth` **is** a string field in `receiver.azureblob` and `receiver.azuremonitor` (v0.110.0 and v0.157.0 contrib), where the value is the authentication *mode*, and `tls.tpm.auth` is a string across ~175 contrib components. In every release checked, `configauth` is a mapping whose only child is `authenticator`. The rule therefore only reads the mapping shape; a regression test covers the string one.

## Index

`Index` records these references, so an extension referenced only from a `sending_queue` counts as used and `unused-component` stops double-reporting the same line. Being *referenced* and being *enabled* are now separate: `Index.Enabled` is what `service.extensions` grants, and it is what the not-enabled case rests on.

## Also

- Names containing a `${env:...}` expansion are skipped.
- An anchored `sending_queue: &queue` reused by `*queue` is resolved, so both exporters are reported; the walk is depth-bounded.
- Listed under **Wiring** in the README.

## Test plan

- `go test ./...` and `golangci-lint run` are clean.
- New `pkg/rule/reference_test.go`: the three cases, a nested receiver authenticator, a name missing its underscores, and the quiet cases (declared and enabled, expansion, no name at all, no service block, plain-string `auth`), plus the anchor case and a test that `unused-component` stays quiet.
- Ran end to end against the real v0.157.0 contrib schema; both an undeclared authenticator and a declared-but-not-enabled `file_storage` are reported at the right lines, and `unused-component` does not fire alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)