### PR TITLE
fix(rule): two wiring findings that do not read as sentences

### DIFF
--- a/pkg/rule/reference.go
+++ b/pkg/rule/reference.go
@@ -61,7 +61,7 @@ func (r undefinedReference) Check(ctx *Context) {
 func misplacedHint(ctx *Context, id config.ID, want config.Kind) string {
 	if k, ok := ctx.Index.KindOf(id); ok && k != want {
 		return quote(id.String()) + " is declared under " + k.Section() +
-			"; it cannot be used as a " + string(want)
+			"; it cannot be used as " + article(string(want)) + " " + string(want)
 	}
 
 	if declared := declaredIDs(ctx, want); len(declared) > 0 {
@@ -105,14 +105,16 @@ func (r unusedComponent) Check(ctx *Context) {
 				continue
 			}
 
-			where := "no pipeline"
+			// An extension is wired up by being listed, not by being
+			// referenced from a pipeline, so it needs its own wording.
+			missing := "referenced by no pipeline"
 			if kind == config.KindExtension {
-				where = "service.extensions"
+				missing = "not listed in service.extensions"
 			}
 
 			ctx.Report(Finding{
 				Node: c.KeyNode, Path: kind.Section() + "." + c.ID.String(),
-				Message: string(kind) + " " + quote(c.ID.String()) + " is declared but referenced by " + where,
+				Message: string(kind) + " " + quote(c.ID.String()) + " is declared but " + missing,
 				Hint:    "remove it, or reference it so it actually runs",
 			})
 		}

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
@@ -503,5 +506,86 @@ func TestEveryRuleIsDocumented(t *testing.T) {
 		default:
 			t.Errorf("rule %q has an unusable default severity %q", r.Name(), r.Severity())
 		}
+	}
+}
+
+// A finding is a sentence a reader acts on, so the wiring rules are pinned on
+// what they actually say, not only on having fired.
+func TestWiringFindingsReadAsSentences(t *testing.T) {
+	t.Parallel()
+
+	const removeOrReference = "remove it, or reference it so it actually runs"
+
+	tests := map[string]struct {
+		rule    string
+		src     string
+		message string
+		hint    string
+	}{
+		"an extension nothing enables": {
+			rule: "unused-component",
+			src: `
+receivers: {otlp: }
+exporters: {debug: }
+extensions: {zpages: }
+service:
+  extensions: []
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+			message: `extension "zpages" is declared but not listed in service.extensions`,
+			hint:    removeOrReference,
+		},
+		"a processor no pipeline lists": {
+			rule: "unused-component",
+			src: `
+receivers: {otlp: }
+processors: {batch: }
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+			message: `processor "batch" is declared but referenced by no pipeline`,
+			hint:    removeOrReference,
+		},
+		"a processor listed as an extension": {
+			rule: "undefined-reference",
+			src: `
+receivers: {otlp: }
+processors: {batch: }
+exporters: {debug: }
+service:
+  extensions: [batch]
+  pipelines:
+    traces: {receivers: [otlp], processors: [batch], exporters: [debug]}
+`,
+			message: `service.extensions references "batch" which is not declared under extensions`,
+			hint:    `"batch" is declared under processors; it cannot be used as an extension`,
+		},
+		"an extension listed as an exporter": {
+			rule: "undefined-reference",
+			src: `
+receivers: {otlp: }
+extensions: {zpages: }
+service:
+  extensions: [zpages]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [zpages]}
+`,
+			message: `pipeline "traces" references exporter "zpages" which is not declared under exporters`,
+			hint:    `"zpages" is declared under extensions; it cannot be used as an exporter`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, tt.rule, tt.src, rule.Environment{})
+			require.Len(t, found, 1)
+			assert.Equal(t, tt.message, found[0].Message)
+			assert.Equal(t, tt.hint, found[0].Hint)
+		})
 	}
 }


### PR DESCRIPTION
Two user-facing strings in `pkg/rule/reference.go` that say the wrong thing. Split out of #63, which is where they were noticed.

## `unused-component` states the opposite of what it found

```
extension "zpages" is declared but referenced by service.extensions
```

The negation is missing. The message is built from one clause that only fits the pipeline case:

```go
where := "no pipeline"
if kind == config.KindExtension {
    where = "service.extensions"
}
… " is declared but referenced by " + where
```

An extension is wired up by being *listed*, not by being referenced from a pipeline, so it now carries its own clause:

- `extension "zpages" is declared but not listed in service.extensions`
- `processor "batch" is declared but referenced by no pipeline`

## `misplacedHint` gets the article wrong before a vowel

```
"batch" is declared under processors; it cannot be used as a extension
```

`article()` lives next door in `component.go` and `unknownHint` already uses it. Now: `as an extension`, `as an exporter`, `as a receiver`.

## Test plan

Neither string was pinned by a test — the wiring cases only asserted which rule fired. `TestWiringFindingsReadAsSentences` now asserts the full message *and* hint for four cases: an unused extension, an unused processor, a processor listed under `service.extensions`, and an extension listed as an exporter.

`go test ./...` and `golangci-lint run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)