### PR TITLE
feat(rule): check the batch processor's size bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ alone.
 
 **Practice** — `processor-order` (memory_limiter first), `missing-memory-limiter`,
 `missing-batch`, `insecure-tls`, `memory-limiter-config`,
-`memory-limiter-sizing`.
+`memory-limiter-sizing`, `batch-size-bounds`.
 
 Every practice rule cites the upstream page it rests on — the
 `memorylimiterprocessor` and `batchprocessor` READMEs, `configtls`, and the
@@ -263,6 +263,17 @@ above is still decoration if `limit_mib` sits at or above the container limit,
 because the kernel kills the collector before the limiter ever engages. It runs
 only for files the [`kubernetes` block](#the-deployment-environment) describes,
 so a run that configures nothing sees nothing new.
+
+`batch-size-bounds` is the same idea for the `batch` processor, whose
+`Validate()` relates two fields a field schema only ever sees one at a time:
+`send_batch_size` is the count that triggers a send, `send_batch_max_size` is a
+hard cap, and a cap below the trigger is refused at startup. The names read
+backwards from the semantics, so capping at something reasonable-looking like
+`1000` while leaving `send_batch_size` at its default of `8192` is exactly the
+shape that fails — and since nobody wrote the 8192, the finding says it is the
+default rather than quoting it back as if they had. It also reports a negative
+`timeout` and a key repeated in `metadata_keys`, which are compared
+case-insensitively, so `tenant` and `Tenant` are one key.
 
 ## Schemas
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,10 @@ backwards from the semantics, so capping at something reasonable-looking like
 shape that fails — and since nobody wrote the 8192, the finding says it is the
 default rather than quoting it back as if they had. It also reports a negative
 `timeout` and a key repeated in `metadata_keys`, which are compared
-case-insensitively, so `tenant` and `Tenant` are one key.
+case-insensitively, so `tenant` and `Tenant` are one key. Both sizes are
+`uint32` upstream, a range the published field schemas flatten to `int`, so a
+negative or over-large count is reported here too — it fails to load rather than
+to validate, and saying so beats hinting at a fix that still will not start.
 
 ## Schemas
 

--- a/pkg/rule/settings.go
+++ b/pkg/rule/settings.go
@@ -465,6 +465,10 @@ const (
 	// defaultBatchTimeout is how long a batch waits before it is sent
 	// regardless of size, when timeout is left out.
 	defaultBatchTimeout = 200 * time.Millisecond
+	// maxBatchSize is the largest value the two size fields can hold: upstream
+	// types both as uint32. The published field schemas flatten that to "int",
+	// so nothing else in the linter knows the range.
+	maxBatchSize = math.MaxUint32
 )
 
 // batchProcessor is one declared batch instance and the settings the collector
@@ -483,6 +487,10 @@ type batchProcessor struct {
 	// written. The entries are read where the duplicates are reported, since
 	// each finding names the entry it found.
 	metadataKeys *yaml.Node
+	// merged reports a YAML merge key, "<<", among the settings. The document
+	// is read as written, so a key the merge supplies looks absent here, and a
+	// check that would otherwise fill in a default has to say nothing instead.
+	merged bool
 }
 
 // name renders the instance for a message, so a file with more than one batch
@@ -508,6 +516,7 @@ func readBatch(c config.Component) batchProcessor {
 		sendBatchMaxSize: absent(),
 		timeout:          absent(),
 		metadataKeys:     nil,
+		merged:           false,
 	}
 
 	if c.ValueNode == nil || c.ValueNode.Kind != yaml.MappingNode {
@@ -524,6 +533,8 @@ func readBatch(c config.Component) batchProcessor {
 			proc.timeout = readDuration(e.node)
 		case "metadata_keys":
 			proc.metadataKeys = e.node
+		case "<<":
+			proc.merged = true
 		default:
 			// Every other setting is the field schema's business.
 		}
@@ -551,14 +562,27 @@ func (r batchSizeBounds) checkSizes(ctx *Context, proc batchProcessor) {
 		return
 	}
 
+	// A value the field cannot hold never reaches Validate(), so comparing the
+	// two numbers would name a constraint that is not the one being broken.
+	if r.checkRange(ctx, proc) {
+		return
+	}
+
 	// A cap of zero, the default, means batches are not capped at all.
 	if !proc.sendBatchMaxSize.positive() {
 		return
 	}
 
 	size := int64(defaultSendBatchSize)
-	if proc.sendBatchSize.known {
+
+	switch {
+	case proc.sendBatchSize.known:
 		size = proc.sendBatchSize.num
+	case proc.merged:
+		// The merge key may be what sets send_batch_size, and the collector
+		// resolves it before either number is read. Filling in the default
+		// here would report a figure the config overrides.
+		return
 	}
 
 	if proc.sendBatchMaxSize.num >= size {
@@ -581,6 +605,39 @@ func (r batchSizeBounds) checkSizes(ctx *Context, proc batchProcessor) {
 			" or more, or leave it out so batches are not split at all",
 		Docs: batchDocs,
 	})
+}
+
+// checkRange reports a size outside the uint32 the field holds, and reports
+// whether it found one. Such a value fails to decode, so the collector never
+// gets as far as the bounds check: quoting it back in a comparison would
+// diagnose the wrong problem and hint at a fix that still does not load.
+func (r batchSizeBounds) checkRange(ctx *Context, proc batchProcessor) bool {
+	var found bool
+
+	for _, size := range []struct {
+		key string
+		val setting
+	}{
+		{key: "send_batch_size", val: proc.sendBatchSize},
+		{key: "send_batch_max_size", val: proc.sendBatchMaxSize},
+	} {
+		if !size.val.known || (size.val.num >= 0 && size.val.num <= maxBatchSize) {
+			continue
+		}
+
+		found = true
+
+		ctx.Report(Finding{
+			Node: proc.at(size.val), Path: joinPath(proc.path, size.key),
+			Message: proc.name() + " sets " + size.key + " to " + itoa64(size.val.num) +
+				", which the field cannot hold: it counts items as a uint32, " +
+				"so the collector fails to load the config before it validates it",
+			Hint: "write a whole number between 0 and " + itoa64(maxBatchSize),
+			Docs: batchDocs,
+		})
+	}
+
+	return found
 }
 
 // checkTimeout reports the one value the collector rejects outright. Zero is

--- a/pkg/rule/settings.go
+++ b/pkg/rule/settings.go
@@ -191,16 +191,22 @@ func readMemoryLimiter(c config.Component) memoryLimiter {
 
 func absent() setting { return setting{node: nil, present: false, known: false, num: 0} }
 
-// readInt reads an integer setting. A value nothing can know before the
-// collector starts -- an expansion, or text of the wrong type -- is present
-// but not known, which stops every check that would need the number.
+// readInt reads an integer setting, in the base the collector's own decoder
+// reads it: confmap unmarshals through yaml.v3, which resolves 0x400 as 1024,
+// 8_192 as 8192, and a leading zero as octal, so 0100 is 64 and not a hundred.
+// Reading base 10 here would compare, and quote back, a number the collector
+// never sees.
+//
+// A value nothing can know before the collector starts -- an expansion, or text
+// of the wrong type -- is present but not known, which stops every check that
+// would need the number.
 func readInt(node *yaml.Node) setting {
 	out := setting{node: node, present: true, known: false, num: 0}
 	if node == nil || node.Kind != yaml.ScalarNode || hasExpansion(node.Value) {
 		return out
 	}
 
-	num, err := strconv.ParseInt(node.Value, 10, 64)
+	num, err := strconv.ParseInt(node.Value, 0, 64)
 	if err != nil {
 		return out
 	}
@@ -547,7 +553,13 @@ type batchSizeBounds struct{ base }
 
 func (r batchSizeBounds) Check(ctx *Context) {
 	for _, proc := range batchProcessors(ctx.File) {
-		r.checkSizes(ctx, proc)
+		// A size the field cannot hold stands on its own: it fails to decode
+		// whatever the other field says, and it stops the comparison, which
+		// the collector never reaches.
+		if !r.checkRange(ctx, proc) {
+			r.checkSizes(ctx, proc)
+		}
+
 		r.checkTimeout(ctx, proc)
 		r.checkMetadataKeys(ctx, proc)
 	}
@@ -559,12 +571,6 @@ func (r batchSizeBounds) Check(ctx *Context) {
 // is how large one may get, and a cap below the trigger is rejected.
 func (r batchSizeBounds) checkSizes(ctx *Context, proc batchProcessor) {
 	if unknownValue(proc.sendBatchSize) || unknownValue(proc.sendBatchMaxSize) {
-		return
-	}
-
-	// A value the field cannot hold never reaches Validate(), so comparing the
-	// two numbers would name a constraint that is not the one being broken.
-	if r.checkRange(ctx, proc) {
 		return
 	}
 
@@ -681,7 +687,7 @@ func (r batchSizeBounds) checkMetadataKeys(ctx *Context, proc batchProcessor) {
 
 		ctx.Report(Finding{
 			Node: item, Path: indexPath(path, i),
-			Message: proc.name() + " repeats " + quote(item.Value) + " in metadata_keys: " +
+			Message: proc.name() + " repeats " + quote(item.Value) + ": " +
 				"duplicate entry in metadata_keys: " + quote(folded) + " (case-insensitive)",
 			Hint: "the keys are compared case-insensitively, so " + quote(item.Value) +
 				" is one already listed; remove it",

--- a/pkg/rule/settings.go
+++ b/pkg/rule/settings.go
@@ -3,6 +3,7 @@ package rule
 import (
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -19,6 +20,8 @@ import (
 // and comparisons between one field and another.
 func settingsRules() []Rule {
 	return []Rule{
+		batchSizeBounds{base{"batch-size-bounds",
+			"a batch processor the collector will refuse to start", diag.Error}},
 		memoryLimiterConfig{base{"memory-limiter-config",
 			"a memory_limiter the collector will refuse to start", diag.Error}},
 		memoryLimiterSizing{base{"memory-limiter-sizing",
@@ -133,16 +136,21 @@ func (m memoryLimiter) hardLimit(env Environment) mo.Option[int64] {
 // memoryLimiters returns every declared memory_limiter. Instances are matched
 // on their type, so "memory_limiter/aggressive" is covered too.
 func memoryLimiters(f *config.File) []memoryLimiter {
+	return processorsOfType(f, memoryLimiterType, readMemoryLimiter)
+}
+
+// processorsOfType returns every declared processor of one type, read into
+// whatever the caller needs. Matching on the type rather than the whole id is
+// what covers named instances such as "batch/traces".
+func processorsOfType[T any](f *config.File, typ string, read func(config.Component) T) []T {
 	sec := f.Sections[config.KindProcessor]
 	if sec == nil {
 		return nil
 	}
 
-	declared := lo.Filter(sec.Components, func(c config.Component, _ int) bool {
-		return c.ID.Type == memoryLimiterType
-	})
+	declared := lo.Filter(sec.Components, func(c config.Component, _ int) bool { return c.ID.Type == typ })
 
-	return lo.Map(declared, func(c config.Component, _ int) memoryLimiter { return readMemoryLimiter(c) })
+	return lo.Map(declared, func(c config.Component, _ int) T { return read(c) })
 }
 
 func readMemoryLimiter(c config.Component) memoryLimiter {
@@ -445,6 +453,184 @@ func (r memoryLimiterSizing) checkRequest(ctx *Context, lim memoryLimiter, hard 
 			"collectors usually set the memory request equal to the limit",
 		Docs: kubernetesResourceDocs,
 	})
+}
+
+// The numbers upstream defaults to, in the batchprocessor's factory.
+const (
+	// defaultSendBatchSize is the number of items a batch is sent at when
+	// send_batch_size is left out. It is the figure that makes the bounds
+	// check worth having: a cap picked to look reasonable, say 1000, sits
+	// below it without anyone writing 8192 anywhere.
+	defaultSendBatchSize = 8192
+	// defaultBatchTimeout is how long a batch waits before it is sent
+	// regardless of size, when timeout is left out.
+	defaultBatchTimeout = 200 * time.Millisecond
+)
+
+// batchProcessor is one declared batch instance and the settings the collector
+// validates before it starts.
+type batchProcessor struct {
+	id config.ID
+	// node anchors findings about the instance as a whole.
+	node *yaml.Node
+	// path is the dotted path of the instance, e.g. "processors.batch".
+	path string
+
+	sendBatchSize    setting
+	sendBatchMaxSize setting
+	timeout          setting
+	// metadataKeys is the metadata_keys sequence, or nil when the key was not
+	// written. The entries are read where the duplicates are reported, since
+	// each finding names the entry it found.
+	metadataKeys *yaml.Node
+}
+
+// name renders the instance for a message, so a file with more than one batch
+// processor says which is meant.
+func (b batchProcessor) name() string { return "processor " + quote(b.id.String()) }
+
+// at returns the value node of one of the instance's settings, falling back to
+// the instance itself when the key is absent.
+func (b batchProcessor) at(s setting) *yaml.Node { return nodeOr(s.node, b.node) }
+
+// batchProcessors returns every declared batch processor, matched on type so
+// "batch/traces" is covered too.
+func batchProcessors(f *config.File) []batchProcessor {
+	return processorsOfType(f, batchType, readBatch)
+}
+
+func readBatch(c config.Component) batchProcessor {
+	proc := batchProcessor{
+		id:               c.ID,
+		node:             nodeOr(c.KeyNode, c.ValueNode),
+		path:             config.KindProcessor.Section() + "." + c.ID.String(),
+		sendBatchSize:    absent(),
+		sendBatchMaxSize: absent(),
+		timeout:          absent(),
+		metadataKeys:     nil,
+	}
+
+	if c.ValueNode == nil || c.ValueNode.Kind != yaml.MappingNode {
+		return proc
+	}
+
+	for _, e := range mapEntries(c.ValueNode, proc.path) {
+		switch e.key {
+		case "send_batch_size":
+			proc.sendBatchSize = readInt(e.node)
+		case "send_batch_max_size":
+			proc.sendBatchMaxSize = readInt(e.node)
+		case "timeout":
+			proc.timeout = readDuration(e.node)
+		case "metadata_keys":
+			proc.metadataKeys = e.node
+		default:
+			// Every other setting is the field schema's business.
+		}
+	}
+
+	return proc
+}
+
+type batchSizeBounds struct{ base }
+
+func (r batchSizeBounds) Check(ctx *Context) {
+	for _, proc := range batchProcessors(ctx.File) {
+		r.checkSizes(ctx, proc)
+		r.checkTimeout(ctx, proc)
+		r.checkMetadataKeys(ctx, proc)
+	}
+}
+
+// checkSizes compares the cap against the threshold that triggers a send.
+// Neither number is wrong on its own, so a schema describing one field at a
+// time sees nothing: send_batch_size is when a batch goes, send_batch_max_size
+// is how large one may get, and a cap below the trigger is rejected.
+func (r batchSizeBounds) checkSizes(ctx *Context, proc batchProcessor) {
+	if unknownValue(proc.sendBatchSize) || unknownValue(proc.sendBatchMaxSize) {
+		return
+	}
+
+	// A cap of zero, the default, means batches are not capped at all.
+	if !proc.sendBatchMaxSize.positive() {
+		return
+	}
+
+	size := int64(defaultSendBatchSize)
+	if proc.sendBatchSize.known {
+		size = proc.sendBatchSize.num
+	}
+
+	if proc.sendBatchMaxSize.num >= size {
+		return
+	}
+
+	// The default is the whole point of the rule, and also the one number in
+	// the message the reader will not find in their file, so it is named as a
+	// default rather than quoted back at them as if they had written it.
+	written := " and send_batch_size to " + itoa64(size)
+	if !proc.sendBatchSize.present {
+		written = ", below the default send_batch_size of " + itoa64(size)
+	}
+
+	ctx.Report(Finding{
+		Node: proc.at(proc.sendBatchMaxSize), Path: joinPath(proc.path, "send_batch_max_size"),
+		Message: proc.name() + " sets send_batch_max_size to " + itoa64(proc.sendBatchMaxSize.num) + written +
+			": send_batch_max_size must be greater or equal to send_batch_size",
+		Hint: "raise send_batch_max_size to " + itoa64(size) +
+			" or more, or leave it out so batches are not split at all",
+		Docs: batchDocs,
+	})
+}
+
+// checkTimeout reports the one value the collector rejects outright. Zero is
+// allowed and means every batch is sent as soon as it is formed.
+func (r batchSizeBounds) checkTimeout(ctx *Context, proc batchProcessor) {
+	if !proc.timeout.known || proc.timeout.num >= 0 {
+		return
+	}
+
+	ctx.Report(Finding{
+		Node: proc.at(proc.timeout), Path: joinPath(proc.path, "timeout"),
+		Message: proc.name() + " sets timeout to " + time.Duration(proc.timeout.num).String() +
+			": timeout must be greater or equal to 0",
+		Hint: "leave timeout out to take the default of " + defaultBatchTimeout.String() +
+			", or set 0 to send each batch as soon as it is formed",
+		Docs: batchDocs,
+	})
+}
+
+// checkMetadataKeys reports an entry listed twice. The keys are folded to lower
+// case before they are compared, so a duplicate need not look like one.
+func (r batchSizeBounds) checkMetadataKeys(ctx *Context, proc batchProcessor) {
+	if proc.metadataKeys == nil || proc.metadataKeys.Kind != yaml.SequenceNode {
+		return
+	}
+
+	path := joinPath(proc.path, "metadata_keys")
+	seen := map[string]bool{}
+
+	for i, item := range proc.metadataKeys.Content {
+		if item.Kind != yaml.ScalarNode || hasExpansion(item.Value) {
+			continue
+		}
+
+		folded := strings.ToLower(item.Value)
+		if !seen[folded] {
+			seen[folded] = true
+
+			continue
+		}
+
+		ctx.Report(Finding{
+			Node: item, Path: indexPath(path, i),
+			Message: proc.name() + " repeats " + quote(item.Value) + " in metadata_keys: " +
+				"duplicate entry in metadata_keys: " + quote(folded) + " (case-insensitive)",
+			Hint: "the keys are compared case-insensitively, so " + quote(item.Value) +
+				" is one already listed; remove it",
+			Docs: batchDocs,
+		})
+	}
 }
 
 // itoa64 renders a setting's value for a message.

--- a/pkg/rule/settings_test.go
+++ b/pkg/rule/settings_test.go
@@ -371,6 +371,14 @@ func TestBatchSizeBounds(t *testing.T) {
 			settings: "    metadata_keys: [tenant, Tenant]",
 			want:     `duplicate entry in metadata_keys: "tenant" (case-insensitive)`,
 		},
+		"a negative cap": {
+			settings: "    send_batch_size: 100\n    send_batch_max_size: -1",
+			want:     "which the field cannot hold",
+		},
+		"a size larger than a uint32": {
+			settings: "    send_batch_size: 5000000000\n    send_batch_max_size: 20000",
+			want:     "which the field cannot hold",
+		},
 	}
 
 	for name, tt := range tests {
@@ -398,6 +406,45 @@ func TestBatchSizeBoundsSaysTheDefaultIsADefault(t *testing.T) {
 	found := checkRule(t, "batch-size-bounds", batcher("batch", "    send_batch_max_size: 1000"), rule.Environment{})
 	assert.Truef(t, reports(found, "below the default send_batch_size of 8192"),
 		"the message should say 8192 is the default, got %+v", found)
+}
+
+// TestBatchSizeBoundsDiagnosesTheRealConstraint pins that a size the uint32
+// field cannot hold is reported as what it is. Such a value fails to decode, so
+// the collector never reaches the bounds check, and comparing the two numbers
+// would hint at a fix that still does not load.
+func TestBatchSizeBoundsDiagnosesTheRealConstraint(t *testing.T) {
+	t.Parallel()
+
+	settings := "    send_batch_size: 5000000000\n    send_batch_max_size: 20000"
+
+	found := checkRule(t, "batch-size-bounds", batcher("batch", settings), rule.Environment{})
+	require.Lenf(t, found, 1, "want one finding about the size that does not fit, got %+v", found)
+	assert.NotContains(t, found[0].Message, "must be greater or equal to send_batch_size")
+	assert.Contains(t, found[0].Hint, "between 0 and 4294967295")
+}
+
+// TestBatchSizeBoundsLeavesAMergedConfigAlone pins that a merge key stops the
+// default from being filled in. The document is read as written, so a
+// send_batch_size the merge supplies looks absent here, while the collector
+// resolves it before either number is read.
+func TestBatchSizeBoundsLeavesAMergedConfigAlone(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+processors:
+  batch/defaults: &defaults
+    send_batch_size: 500
+  batch:
+    <<: *defaults
+    send_batch_max_size: 1000
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [batch], exporters: [debug]}
+`
+	assert.Empty(t, checkRule(t, "batch-size-bounds", src, rule.Environment{}),
+		"a size the merge key supplies is not the default")
 }
 
 func TestBatchSizeBoundsAcceptsAWorkingBatch(t *testing.T) {

--- a/pkg/rule/settings_test.go
+++ b/pkg/rule/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
@@ -17,14 +18,10 @@ func checkRule(t *testing.T, name, src string, env rule.Environment) diag.Diagno
 	t.Helper()
 
 	f, err := config.Parse("test.yaml", []byte(src))
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err, "parse")
 
 	r, ok := rule.Lookup(name)
-	if !ok {
-		t.Fatalf("rule %q is not registered", name)
-	}
+	require.Truef(t, ok, "rule %q is not registered", name)
 
 	return rule.Run(r, rule.Context{File: f, Schema: testSchema(), Index: rule.NewIndex(f), Env: env}, r.Severity())
 }
@@ -330,6 +327,136 @@ func TestMemoryLimiterSizingLeavesExpansionsAlone(t *testing.T) {
 	if found := checkRule(t, "memory-limiter-sizing", src, env); len(found) > 0 {
 		t.Errorf("a limit resolved at runtime cannot be sized, got %+v", found)
 	}
+}
+
+// batcher wraps batch processor settings in a config that is otherwise clean.
+// The settings are written already indented by four spaces.
+func batcher(name, settings string) string {
+	return `
+receivers: {otlp: }
+processors:
+  ` + name + `:
+` + settings + `
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [` + name + `], exporters: [debug]}
+`
+}
+
+func TestBatchSizeBounds(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		settings string
+		want     string // a phrase the finding has to carry
+	}{
+		"a cap below the default size": {
+			settings: "    send_batch_max_size: 1000",
+			want:     "send_batch_max_size must be greater or equal to send_batch_size",
+		},
+		"a cap below the size written next to it": {
+			settings: "    send_batch_size: 4096\n    send_batch_max_size: 1000",
+			want:     "sets send_batch_max_size to 1000 and send_batch_size to 4096",
+		},
+		"a negative timeout": {
+			settings: "    timeout: -5s",
+			want:     "timeout must be greater or equal to 0",
+		},
+		"a key listed twice": {
+			settings: "    metadata_keys: [tenant, tenant]",
+			want:     `duplicate entry in metadata_keys: "tenant" (case-insensitive)`,
+		},
+		"a key listed twice in another case": {
+			settings: "    metadata_keys: [tenant, Tenant]",
+			want:     `duplicate entry in metadata_keys: "tenant" (case-insensitive)`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "batch-size-bounds", batcher("batch", tt.settings), rule.Environment{})
+			assert.Truef(t, reports(found, tt.want), "no finding mentioned %q; got %+v", tt.want, found)
+
+			for _, d := range found {
+				assert.Containsf(t, d.Message, "batch", "a finding should name the instance: %q", d.Message)
+				assert.Containsf(t, d.Docs, "processor/batchprocessor/README.md",
+					"finding %q links to %q, want the processor's README", d.Message, d.Docs)
+			}
+		})
+	}
+}
+
+// TestBatchSizeBoundsSaysTheDefaultIsADefault pins that the one number in the
+// message the reader will not find in their file is named as a default, not
+// quoted back at them as if they had written it.
+func TestBatchSizeBoundsSaysTheDefaultIsADefault(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "batch-size-bounds", batcher("batch", "    send_batch_max_size: 1000"), rule.Environment{})
+	assert.Truef(t, reports(found, "below the default send_batch_size of 8192"),
+		"the message should say 8192 is the default, got %+v", found)
+}
+
+func TestBatchSizeBoundsAcceptsAWorkingBatch(t *testing.T) {
+	t.Parallel()
+
+	for name, settings := range map[string]string{
+		"nothing set at all":               "",
+		"a cap above the default size":     "    send_batch_max_size: 10000",
+		"a cap above the size set":         "    send_batch_size: 1000\n    send_batch_max_size: 2000",
+		"a cap equal to the size set":      "    send_batch_size: 1000\n    send_batch_max_size: 1000",
+		"no cap at all":                    "    send_batch_size: 10000\n    send_batch_max_size: 0",
+		"a size of zero, which is off":     "    send_batch_size: 0\n    send_batch_max_size: 1000",
+		"a timeout of zero, which is fine": "    timeout: 0s",
+		"keys that differ":                 "    metadata_keys: [tenant, region]",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Empty(t, checkRule(t, "batch-size-bounds", batcher("batch", settings), rule.Environment{}),
+				"a valid batch processor should be quiet")
+		})
+	}
+}
+
+func TestBatchSizeBoundsMatchesOnType(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "batch-size-bounds", batcher("batch/traces", "    send_batch_max_size: 1000"),
+		rule.Environment{})
+	assert.Truef(t, reports(found, "batch/traces"), "a named instance should be checked and named, got %+v", found)
+}
+
+func TestBatchSizeBoundsLeavesExpansionsAlone(t *testing.T) {
+	t.Parallel()
+
+	for name, settings := range map[string]string{
+		"the cap is resolved at runtime":  "    send_batch_max_size: ${env:MAX}",
+		"the size is resolved at runtime": "    send_batch_size: ${env:SIZE}\n    send_batch_max_size: 1000",
+		"a key is resolved at runtime":    `    metadata_keys: ["${env:KEY}", "${env:KEY}"]`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Empty(t, checkRule(t, "batch-size-bounds", batcher("batch", settings), rule.Environment{}),
+				"values resolved at runtime cannot be checked")
+		})
+	}
+}
+
+// TestBatchSizeBoundsPointsAtTheDuplicate pins that a duplicate key is reported
+// against the entry that repeats, not against the processor as a whole.
+func TestBatchSizeBoundsPointsAtTheDuplicate(t *testing.T) {
+	t.Parallel()
+
+	src := batcher("batch", "    metadata_keys: [tenant, region, Tenant]")
+
+	found := checkRule(t, "batch-size-bounds", src, rule.Environment{})
+	require.Lenf(t, found, 1, "want one finding about the repeated key, got %+v", found)
+	assert.Equal(t, "processors.batch.metadata_keys[2]", found[0].Path)
 }
 
 // TestFindingsCiteUpstream pins that a rule reporting what the collector

--- a/pkg/rule/settings_test.go
+++ b/pkg/rule/settings_test.go
@@ -379,6 +379,14 @@ func TestBatchSizeBounds(t *testing.T) {
 			settings: "    send_batch_size: 5000000000\n    send_batch_max_size: 20000",
 			want:     "which the field cannot hold",
 		},
+		"a size the field cannot hold next to one resolved at runtime": {
+			settings: "    send_batch_size: ${env:SIZE}\n    send_batch_max_size: -1",
+			want:     "which the field cannot hold",
+		},
+		"a cap written in octal": {
+			settings: "    send_batch_max_size: 010000",
+			want:     "sets send_batch_max_size to 4096",
+		},
 	}
 
 	for name, tt := range tests {
@@ -445,6 +453,26 @@ service:
 `
 	assert.Empty(t, checkRule(t, "batch-size-bounds", src, rule.Environment{}),
 		"a size the merge key supplies is not the default")
+}
+
+// TestBatchSizeBoundsReadsTheBaseTheCollectorReads pins that a value is
+// resolved the way confmap's own decoder resolves it. yaml.v3 reads a leading
+// zero as octal and 0x as hex, so reading base 10 here would quote back a
+// number the collector never sees -- and pass a config that will not start.
+func TestBatchSizeBoundsReadsTheBaseTheCollectorReads(t *testing.T) {
+	t.Parallel()
+
+	// 010000 is 4096, below the 8192 default, however much it looks like ten
+	// thousand.
+	found := checkRule(t, "batch-size-bounds", batcher("batch", "    send_batch_max_size: 010000"),
+		rule.Environment{})
+	require.Lenf(t, found, 1, "an octal cap below the default should be reported, got %+v", found)
+	assert.Contains(t, found[0].Message, "sets send_batch_max_size to 4096")
+
+	// 0x400 is 1024, which base 10 cannot read at all; the collector can.
+	found = checkRule(t, "batch-size-bounds", batcher("batch", "    send_batch_max_size: 0x400"), rule.Environment{})
+	require.Lenf(t, found, 1, "a hex cap below the default should be reported, got %+v", found)
+	assert.Contains(t, found[0].Message, "sets send_batch_max_size to 1024")
 }
 
 func TestBatchSizeBoundsAcceptsAWorkingBatch(t *testing.T) {


### PR DESCRIPTION
Closes #44.

## Why

`batchprocessor`'s `Validate()` relates two fields:

```go
if cfg.SendBatchMaxSize > 0 && cfg.SendBatchMaxSize < cfg.SendBatchSize {
    return errors.New("send_batch_max_size must be greater or equal to send_batch_size")
}
```

Both are plain ints, so `invalid-value` sees nothing wrong with either one on its own. The config parses, passes every check we have, and the collector then refuses to start. The names read backwards from the semantics — `send_batch_size` is the trigger threshold, `send_batch_max_size` is a hard cap — so capping at something reasonable-looking like `1000` against the default `8192` trigger is exactly the shape that fails.

## What

`batch-size-bounds`, at `diag.Error`, covering the whole of that `Validate()`:

- `send_batch_max_size > 0 && send_batch_max_size < send_batch_size`, with the documented default of 8192 applied when `send_batch_size` is absent
- a negative `timeout`
- a duplicate in `metadata_keys`, folded to lower case before comparing, reported against the entry that repeats

Instances are matched on type, so `batch/traces` is covered, and any value left to a confmap expansion is skipped.

The default is the one number in the message the reader will not find in their file, so it is named as a default rather than quoted back at them:

```
config.yaml:10:26: error: processor "batch/traces" sets send_batch_max_size to 1000, below the default send_batch_size of 8192: send_batch_max_size must be greater or equal to send_batch_size [batch-size-bounds]
    hint: raise send_batch_max_size to 8192 or more, or leave it out so batches are not split at all
    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
config.yaml:11:14: error: processor "batch/traces" sets timeout to -5s: timeout must be greater or equal to 0 [batch-size-bounds]
config.yaml:12:37: error: processor "batch/traces" repeats "Tenant" in metadata_keys: duplicate entry in metadata_keys: "tenant" (case-insensitive) [batch-size-bounds]
```

Per #44's note on #48, the hints point at removing the cap rather than at more batch-processor tuning.

`memoryLimiters` and the new `batchProcessors` now share one `processorsOfType` helper instead of repeating the filter.

## Checks

- `make lint` — 0 issues
- `go test ./...` — all packages pass; `testdata/valid/agent.yaml` and the `clean` fixture stay quiet

🤖 Generated with [Claude Code](https://claude.com/claude-code)