### PR TITLE
feat(rule): report a sending queue a restart empties

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,11 +243,12 @@ alone.
 
 **Practice** — `processor-order` (memory_limiter first), `missing-memory-limiter`,
 `missing-batch`, `insecure-tls`, `memory-limiter-config`,
-`memory-limiter-sizing`, `batch-size-bounds`.
+`memory-limiter-sizing`, `batch-size-bounds`, `no-persistent-queue`.
 
 Every practice rule cites the upstream page it rests on — the
-`memorylimiterprocessor` and `batchprocessor` READMEs, `configtls`, and the
-Kubernetes resource docs for the container's request and limit.
+`memorylimiterprocessor`, `batchprocessor` and `exporterhelper` READMEs,
+`configtls`, and the Kubernetes resource docs for the container's request and
+limit.
 
 `memory_limiter` is the one processor this linter tells people to add, and two
 of its constraints cannot be written as a field schema:
@@ -277,6 +278,37 @@ case-insensitively, so `tenant` and `Tenant` are one key. Both sizes are
 `uint32` upstream, a range the published field schemas flatten to `int`, so a
 negative or over-large count is reported here too — it fails to load rather than
 to validate, and saying so beats hinting at a fix that still will not start.
+
+`no-persistent-queue` is the one opinionated rule, and it reports at `info` for
+that reason. The sending queue is on by default and lives in memory, so a
+deploy, an OOM kill or a node drain takes everything still in it — and nothing
+in the config says so, because an exporter with a `storage` extension and one
+without look identical until the restart.
+
+```yaml
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage    # without this, a restart drops the queue
+```
+
+Persistence takes three steps — a storage extension declared, listed in
+`service.extensions`, and named here — which is why the finding names all three
+and why `undefined-extension-reference` above is worth having alongside it. The
+rule stays quiet on `sending_queue.enabled: false`, on an exporter no pipeline
+references, and on exporters whose field schema has no queue at all, so `debug`
+and `nop` are never mentioned.
+
+It reports once per exporter, not once per config: the fix is written per
+exporter, each queue names its own storage, and a finding without a position
+cannot say which of eight exporters to edit. It is also the rule most likely to
+be unwanted — a sidecar next to an application that can re-send, or an agent
+whose source keeps its own buffer, is right not to want a writable volume. There
+is deliberately no default-disabled rule concept for it: `info` is already below
+`--min-severity warning`, which is a normal way to run, and `disable:
+[no-persistent-queue]` in the settings file turns it off for good. A second
+mechanism that means roughly the same thing would only be another place to look.
 
 ## Schemas
 

--- a/pkg/rule/fields.go
+++ b/pkg/rule/fields.go
@@ -33,6 +33,11 @@ const (
 	typeList = "list"
 )
 
+// boolTag is the tag yaml.v3 resolves a boolean scalar to. A setting is only
+// read as one when the document actually wrote a boolean, so the string
+// "false" is not mistaken for the value.
+const boolTag = "!!bool"
+
 // fieldWalker validates a component's settings against its schema schema.
 // Each rule supplies the callbacks it cares about and ignores the rest.
 type fieldWalker struct {
@@ -195,7 +200,7 @@ func matchesType(schema *schema.Field, node *yaml.Node) bool {
 	case "string":
 		return node.Kind == yaml.ScalarNode
 	case "bool":
-		return node.Tag == "!!bool"
+		return node.Tag == boolTag
 	case "int":
 		return node.Tag == "!!int"
 	case "float":

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 )
 
 // practiceRules check for configurations that load but behave badly.
@@ -18,6 +19,8 @@ func practiceRules() []Rule {
 			"exporting without batching costs throughput and export requests", diag.Info}},
 		insecureTLS{base{"insecure-tls",
 			"TLS verification disabled on a component that talks over the network", diag.Warning}},
+		noPersistentQueue{base{"no-persistent-queue",
+			"a sending queue held in memory, which a restart drops along with everything in it", diag.Info}},
 	}
 }
 
@@ -26,6 +29,13 @@ func practiceRules() []Rule {
 const (
 	memoryLimiterType = "memory_limiter"
 	batchType         = "batch"
+)
+
+// sendingQueueKey is the exporter setting holding the queue, and storageKey the
+// field inside it that makes the queue persistent.
+const (
+	sendingQueueKey = "sending_queue"
+	storageKey      = "storage"
 )
 
 type processorOrder struct{ base }
@@ -128,6 +138,189 @@ func (r insecureTLS) Check(ctx *Context) {
 	}
 }
 
+// noPersistentQueue reports an exporter whose sending queue lives in memory.
+// The queue is on by default, so nothing in the config says the data in it is
+// held only in the process: an exporter with a storage extension and one
+// without look identical, right up until the restart that empties one of them.
+//
+// It reports once per exporter rather than once per config. The fix is written
+// per exporter -- each queue names its own storage -- and a finding without a
+// position cannot say which of eight exporters to edit. That the count of
+// findings then matches the count of edits is the point; a config with eight
+// exporters and no persistence really does have eight of these.
+//
+// The severity is the other half of that. This is a design note, not a defect:
+// a sidecar next to an application that can re-send, or an agent whose source
+// keeps its own buffer, is right not to want a writable volume. diag.Info is
+// the ceiling, so a run at --min-severity warning -- the usual way to run --
+// never sees it, and --disable no-persistent-queue turns it off for good.
+type noPersistentQueue struct{ base }
+
+func (r noPersistentQueue) Check(ctx *Context) {
+	sec := ctx.File.Sections[config.KindExporter]
+	if sec == nil {
+		return
+	}
+
+	for _, c := range sec.Components {
+		// An exporter no pipeline reaches is never instantiated, so it has no
+		// queue to lose; unused-component is what has something to say about it.
+		if !ctx.Index.Used(config.KindExporter, c.ID) {
+			continue
+		}
+
+		queue := readSendingQueue(c)
+
+		if queue.disabled || queue.persisted || queue.merged || !acceptsQueue(ctx, c.ID.Type, queue.written) {
+			continue
+		}
+
+		path := config.KindExporter.Section() + "." + c.ID.String()
+
+		ctx.Report(Finding{
+			Node: nodeOr(queue.node, c.KeyNode), Path: joinPath(path, sendingQueueKey),
+			Message: "exporter " + quote(c.ID.String()) + " " + queue.describe() +
+				"; a restart drops whatever is still queued",
+			Hint: "persistence takes three steps: declare a storage extension such as file_storage, " +
+				"list it in service.extensions so the collector starts it, and name it here as " +
+				sendingQueueKey + "." + storageKey,
+			Docs: exporterQueueDocs,
+		})
+	}
+}
+
+// sendingQueue is what an exporter's settings say about its queue.
+type sendingQueue struct {
+	// node is the sending_queue block, or nil when the key was not written.
+	node *yaml.Node
+	// written reports that the exporter configures a queue at all. The queue
+	// runs either way; this only decides how the finding reads.
+	written bool
+	// disabled reports enabled: false, which is an exporter saying it wants no
+	// queue. There is then nothing to lose on a restart.
+	disabled bool
+	// persisted reports that storage names something. A confmap expansion
+	// counts: it resolves to an extension the linter cannot see, not to
+	// nothing. Only an empty or null value is nobody naming anything.
+	persisted bool
+	// merged reports a YAML merge key among the settings the queue is read
+	// from. A merge may be what supplies storage, and reporting a queue the
+	// document does not fully spell out would name a setting that is there.
+	merged bool
+}
+
+// describe renders what the exporter did, so a written queue missing one field
+// does not read like a queue nobody configured.
+func (q sendingQueue) describe() string {
+	if q.written {
+		return "has a " + sendingQueueKey + " with no " + storageKey +
+			", so the queue is held in memory"
+	}
+
+	return "takes the default " + sendingQueueKey + ", which is held in memory"
+}
+
+// readSendingQueue reads an exporter's queue settings. Only the top level is
+// read, which is where the queue sits and where the field schema describes it:
+// an exporter that wraps another, such as loadbalancing, carries a queue per
+// protocol whose fix is written somewhere else again.
+func readSendingQueue(c config.Component) sendingQueue {
+	queue := sendingQueue{node: nil, written: false, disabled: false, persisted: false, merged: false}
+
+	settings := resolveAlias(c.ValueNode)
+	if settings == nil || settings.Kind != yaml.MappingNode {
+		return queue
+	}
+
+	var block *yaml.Node
+
+	for _, e := range mapEntries(settings, "") {
+		switch e.key {
+		case sendingQueueKey:
+			queue.node, queue.written, block = e.node, true, resolveAlias(e.node)
+		case "<<":
+			// The merge may be what supplies the whole block.
+			queue.merged = true
+		default:
+			// Every other setting is another rule's business.
+		}
+	}
+
+	if block == nil || block.Kind != yaml.MappingNode {
+		return queue
+	}
+
+	// A merge outside the block cannot reach into one the exporter writes
+	// itself: a key present locally replaces the merged value outright. Only
+	// what is inside the block can still supply storage.
+	queue.merged = false
+	readQueueBlock(block, &queue)
+
+	return queue
+}
+
+// readQueueBlock reads the two settings that decide whether there is a queue at
+// all, and whether it survives a restart.
+func readQueueBlock(block *yaml.Node, queue *sendingQueue) {
+	for _, e := range mapEntries(block, "") {
+		val := resolveAlias(e.node)
+		if val == nil {
+			continue
+		}
+
+		switch e.key {
+		case "enabled":
+			queue.disabled = val.Tag == boolTag && val.Value == "false"
+		case storageKey:
+			// Anything but an empty or null value is the setting written.
+			// Whether what was written is a name the collector can resolve is
+			// invalid-value's and undefined-extension-reference's to say.
+			queue.persisted = !isNull(val) && (val.Kind != yaml.ScalarNode || val.Value != "")
+		case "<<":
+			queue.merged = true
+		default:
+			// Every other queue setting is the field schema's business.
+		}
+	}
+}
+
+// acceptsQueue reports whether the exporter type has a sending queue at all.
+// Plenty do not -- debug, nop and every exporter that writes its own client --
+// and telling them they lose a queue they never had is worse than saying
+// nothing.
+//
+// The field schema is the authority wherever it describes the type's settings
+// completely. Where it does not -- no schema was resolved, the type is not in
+// it, or its settings are left open because upstream hands them to a
+// third-party config -- a queue the config writes is the only evidence there is,
+// and a block the component turns out not to accept is unknown-field's to
+// report.
+func acceptsQueue(ctx *Context, typ string, written bool) bool {
+	fields := exporterFields(ctx, typ)
+	if fields == nil || fields.Open || len(fields.Children) == 0 {
+		return written
+	}
+
+	_, held := fields.Children[sendingQueueKey]
+
+	return held
+}
+
+// exporterFields returns the targeted release's field schema for an exporter
+// type, or nil when there is none to consult.
+func exporterFields(ctx *Context, typ string) *schema.Field {
+	if !ctx.schemaReady() {
+		return nil
+	}
+
+	comp, ok := ctx.Schema.Lookup(config.KindExporter, typ)
+	if !ok {
+		return nil
+	}
+
+	return comp.Fields
+}
+
 type tlsHit struct {
 	node *yaml.Node
 	path string
@@ -148,7 +341,7 @@ func findInsecure(n *yaml.Node, path string) []tlsHit {
 		for _, e := range mapEntries(n, path) {
 			switch e.key {
 			case "insecure", "insecure_skip_verify":
-				if e.node.Tag == "!!bool" && e.node.Value == "true" {
+				if e.node.Tag == boolTag && e.node.Value == "true" {
 					out = append(out, tlsHit{node: e.node, path: e.path})
 				}
 			default:

--- a/pkg/rule/practice_test.go
+++ b/pkg/rule/practice_test.go
@@ -1,0 +1,261 @@
+package rule_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// exporting wraps exporter settings in a config that is otherwise clean, with
+// a file_storage extension declared and enabled so a queue has something real
+// to name. The settings are written already indented by four spaces.
+func exporting(settings string) string {
+	return `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+` + settings + `
+extensions: {file_storage: }
+service:
+  extensions: [file_storage]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp]}
+`
+}
+
+func TestNoPersistentQueue(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		settings string
+		want     bool // whether the queue should be reported
+	}{
+		"no queue settings at all": {
+			settings: "",
+			want:     true,
+		},
+		"a queue with no storage": {
+			settings: "    sending_queue:\n      queue_size: 5000",
+			want:     true,
+		},
+		"a queue turned on and left in memory": {
+			settings: "    sending_queue:\n      enabled: true",
+			want:     true,
+		},
+		"an empty storage": {
+			settings: "    sending_queue:\n      storage:",
+			want:     true,
+		},
+		"a storage extension": {
+			settings: "    sending_queue:\n      storage: file_storage",
+			want:     false,
+		},
+		"a storage resolved at runtime": {
+			settings: "    sending_queue:\n      storage: ${env:STORAGE}",
+			want:     false,
+		},
+		"the queue turned off": {
+			settings: "    sending_queue:\n      enabled: false",
+			want:     false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "no-persistent-queue", exporting(tt.settings), rule.Environment{})
+			assert.Len(t, found, map[bool]int{true: 1, false: 0}[tt.want])
+		})
+	}
+}
+
+// The finding is a design note, so what it says is the whole of its value: it
+// has to name the exporter and all three steps persistence takes.
+func TestNoPersistentQueueReadsAsASentence(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "no-persistent-queue", exporting(""), rule.Environment{})
+	require.Len(t, found, 1)
+
+	assert.Equal(t, `exporter "otlphttp" takes the default sending_queue, which is held in memory; `+
+		"a restart drops whatever is still queued", found[0].Message)
+	assert.Equal(t, "persistence takes three steps: declare a storage extension such as file_storage, "+
+		"list it in service.extensions so the collector starts it, and name it here as sending_queue.storage",
+		found[0].Hint)
+	assert.Equal(t, "exporters.otlphttp.sending_queue", found[0].Path)
+	assert.Equal(t, diag.Info, found[0].Severity)
+
+	written := checkRule(t, "no-persistent-queue",
+		exporting("    sending_queue:\n      queue_size: 5000"), rule.Environment{})
+	require.Len(t, written, 1)
+	assert.Equal(t, `exporter "otlphttp" has a sending_queue with no storage, so the queue is held in memory; `+
+		"a restart drops whatever is still queued", written[0].Message)
+}
+
+func TestNoPersistentQueueStaysQuiet(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		// The schema says the debug exporter has no queue, so there is none to
+		// lose.
+		"an exporter with no queue": `
+receivers: {otlp: }
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+		// Writing a queue does not give an exporter one. The schema says debug
+		// has no sending_queue, so there is nothing to persist and
+		// unknown-field is what has something to say about the block.
+		"a queue on an exporter that has none": `
+receivers: {otlp: }
+exporters:
+  debug:
+    sending_queue:
+      queue_size: 5000
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+		// unused-component is what has something to say about this one; an
+		// exporter no pipeline reaches is never instantiated.
+		"an exporter no pipeline references": `
+receivers: {otlp: }
+exporters:
+  debug: {}
+  otlphttp:
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+		// A merge may be what supplies the storage, and the document is read as
+		// written.
+		"a queue built from a merge key": `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue:
+      <<: &queue {storage: file_storage}
+      queue_size: 5000
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp]}
+`,
+		"settings built from a merge key": `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    <<: &base {sending_queue: {storage: file_storage}}
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp]}
+`,
+		// An anchor is the same queue written once and used twice.
+		"a queue behind an anchor": `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue: &queue
+      storage: file_storage
+  otlphttp/second:
+    endpoint: http://other:4318
+    sending_queue: *queue
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp, otlphttp/second]}
+`,
+		// Without a service block nothing is instantiated, and service-required
+		// already says so.
+		"no service block": `
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+`,
+	}
+
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Empty(t, checkRule(t, "no-persistent-queue", src, rule.Environment{}))
+		})
+	}
+}
+
+// Without a schema there is nothing to say which exporters have a queue, so
+// only a queue the config writes itself is evidence of one.
+func TestNoPersistentQueueWithoutASchema(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		settings string
+		want     int
+	}{
+		"a queue nobody wrote": {settings: "", want: 0},
+		"a queue with no storage": {
+			settings: "    sending_queue:\n      queue_size: 5000",
+			want:     1,
+		},
+		"a queue with storage": {
+			settings: "    sending_queue:\n      storage: file_storage",
+			want:     0,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f, err := config.Parse("test.yaml", []byte(exporting(tt.settings)))
+			require.NoError(t, err, "parse")
+
+			r, ok := rule.Lookup("no-persistent-queue")
+			require.True(t, ok, "rule is not registered")
+
+			found := rule.Run(r, rule.Context{File: f, Schema: &schema.Schema{}, Index: rule.NewIndex(f)}, r.Severity())
+			assert.Len(t, found, tt.want)
+		})
+	}
+}
+
+// Reporting per exporter is the deliberate choice: the fix is written per
+// exporter, so the count of findings is the count of edits.
+func TestNoPersistentQueueReportsPerExporter(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+  otlphttp/second:
+    endpoint: http://other:4318
+    sending_queue:
+      storage: file_storage
+  otlphttp/third:
+    endpoint: http://third:4318
+extensions: {file_storage: }
+service:
+  extensions: [file_storage]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp, otlphttp/second, otlphttp/third]}
+`
+
+	found := checkRule(t, "no-persistent-queue", src, rule.Environment{})
+	require.Len(t, found, 2)
+	assert.Equal(t, "exporters.otlphttp.sending_queue", found[0].Path)
+	assert.Equal(t, "exporters.otlphttp/third.sending_queue", found[1].Path)
+}

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -48,6 +48,19 @@ func testSchema() *schema.Schema {
 								"insecure": {Type: "bool"},
 							}},
 						}}},
+				// otlphttp is the exporter with a queue, so the rules that read
+				// one have a type whose schema says it has it. The debug and
+				// otlp entries above deliberately do not, which is what a
+				// schema that describes an exporter without a queue looks like.
+				"otlphttp": {Type: "otlphttp", Signals: []config.Signal{"traces", "metrics", "logs"},
+					Fields: &schema.Field{Type: "map", Children: map[string]*schema.Field{
+						"endpoint": {Type: "string"},
+						"sending_queue": {Type: "map", Open: true, Children: map[string]*schema.Field{
+							"enabled":    {Type: "bool"},
+							"queue_size": {Type: "int"},
+							"storage":    {Type: "string"},
+						}},
+					}}},
 				"logging": {Type: "logging", Signals: []config.Signal{"traces"},
 					Deprecated: "use the debug exporter instead"},
 			},
@@ -405,6 +418,19 @@ service:
     traces: {receivers: [otlp], exporters: [otlp]}
 `,
 			want: "insecure-tls",
+		},
+		{
+			name: "a queue with nowhere to persist to",
+			src: `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp]}
+`,
+			want: "no-persistent-queue",
 		},
 	}
 


### PR DESCRIPTION
Closes #52.

## What

`no-persistent-queue`, at `diag.Info`, in `pkg/rule/practice.go`. For every exporter a pipeline references: if the sending queue is not explicitly disabled and names no `storage`, the queue is in memory and a restart empties it.

```
q.yaml:12:3: info: exporter "otlp" takes the default sending_queue, which is held in memory; a restart drops whatever is still queued [no-persistent-queue]
    hint: persistence takes three steps: declare a storage extension such as file_storage, list it in service.extensions so the collector starts it, and name it here as sending_queue.storage
    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md
```

The hint names all three steps rather than only the setting, since two of three is the usual way this ends up half-done — which is what `undefined-extension-reference` then catches.

## When it stays quiet

- `sending_queue.enabled: false` — a deliberate choice, and no queue to lose.
- An exporter no pipeline references; `unused-component` has something to say about it.
- An exporter whose field schema has no `sending_queue` at all, so `debug` and `nop` are never mentioned. Where the schema does not describe the type, or leaves its settings open, a queue the config writes is the only evidence there is — and a block the component turns out not to accept is `unknown-field`'s to report.
- A `storage` the document does not fully spell out: a confmap expansion, or a merge key that may supply it. That is a name this rule cannot read, not a name nobody wrote. Anchors are followed, so a queue written once and aliased twice is read as written.

## The two decisions the issue asked for

**Per-exporter, not once per config.** The fix is written per exporter — each queue names its own storage — and a finding without a position cannot say which of eight exporters to edit. The count of findings matching the count of edits is the point.

**Not a default-disabled rule.** Nothing here has that concept and this does not need one: `info` is already below `--min-severity warning`, which is a normal way to run, and `disable: [no-persistent-queue]` in the settings file turns it off for good. A second mechanism meaning roughly the same thing would only be another place to look. Recorded in the README and in the rule's own doc comment.

## Tests

`pkg/rule/practice_test.go` covers what fires and what does not, the exact message, hint, path and severity, the schema-less fallback, and the per-exporter count. `testSchema` gains an `otlphttp` exporter whose schema has a queue, so `debug` and `otlp` stay what a schema describing an exporter *without* one looks like, and `TestCleanConfigIsQuiet` is untouched.

Verified end to end against the real published schemas: an `otlp` exporter reported, one with `storage: file_storage` quiet, `debug` quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
