### PR TITLE
fix(rule): read enabled the way storage is read

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,9 +296,12 @@ exporters:
 Persistence takes three steps — a storage extension declared, listed in
 `service.extensions`, and named here — which is why the finding names all three
 and why `undefined-extension-reference` above is worth having alongside it. The
-rule stays quiet on `sending_queue.enabled: false`, on an exporter no pipeline
-references, and on exporters whose field schema has no queue at all, so `debug`
-and `nop` are never mentioned.
+The rule stays quiet on `sending_queue.enabled: false`, on an exporter no
+pipeline references, and on exporters whose field schema describes their
+settings and has no queue among them, which is what keeps `debug` out of it.
+Where the schema resolved nothing for a component — the `datadog` exporter and
+`nop` share that — a queue the config writes is the only evidence there is, and
+it is taken at face value.
 
 It reports once per exporter, not once per config: the fix is written per
 exporter, each queue names its own storage, and a finding without a position

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -171,7 +171,7 @@ func (r noPersistentQueue) Check(ctx *Context) {
 
 		queue := readSendingQueue(c)
 
-		if queue.disabled || queue.persisted || queue.merged || !acceptsQueue(ctx, c.ID.Type, queue.written) {
+		if queue.disabled || queue.persisted || queue.unresolved || !acceptsQueue(ctx, c.ID.Type, queue.written) {
 			continue
 		}
 
@@ -203,10 +203,12 @@ type sendingQueue struct {
 	// counts: it resolves to an extension the linter cannot see, not to
 	// nothing. Only an empty or null value is nobody naming anything.
 	persisted bool
-	// merged reports a YAML merge key among the settings the queue is read
-	// from. A merge may be what supplies storage, and reporting a queue the
-	// document does not fully spell out would name a setting that is there.
-	merged bool
+	// unresolved reports that the document does not settle the question here: a
+	// merge key that may be what supplies storage, or an enabled the collector
+	// only learns once an expansion resolves. Either way the queue read here is
+	// not necessarily the queue that runs, and a finding would be about a
+	// config nobody wrote.
+	unresolved bool
 }
 
 // describe renders what the exporter did, so a written queue missing one field
@@ -225,7 +227,7 @@ func (q sendingQueue) describe() string {
 // an exporter that wraps another, such as loadbalancing, carries a queue per
 // protocol whose fix is written somewhere else again.
 func readSendingQueue(c config.Component) sendingQueue {
-	queue := sendingQueue{node: nil, written: false, disabled: false, persisted: false, merged: false}
+	queue := sendingQueue{node: nil, written: false, disabled: false, persisted: false, unresolved: false}
 
 	settings := resolveAlias(c.ValueNode)
 	if settings == nil || settings.Kind != yaml.MappingNode {
@@ -240,7 +242,7 @@ func readSendingQueue(c config.Component) sendingQueue {
 			queue.node, queue.written, block = e.node, true, resolveAlias(e.node)
 		case "<<":
 			// The merge may be what supplies the whole block.
-			queue.merged = true
+			queue.unresolved = true
 		default:
 			// Every other setting is another rule's business.
 		}
@@ -252,8 +254,8 @@ func readSendingQueue(c config.Component) sendingQueue {
 
 	// A merge outside the block cannot reach into one the exporter writes
 	// itself: a key present locally replaces the merged value outright. Only
-	// what is inside the block can still supply storage.
-	queue.merged = false
+	// what is inside the block can still leave the queue unsettled.
+	queue.unresolved = false
 	readQueueBlock(block, &queue)
 
 	return queue
@@ -270,6 +272,15 @@ func readQueueBlock(block *yaml.Node, queue *sendingQueue) {
 
 		switch e.key {
 		case "enabled":
+			// An expansion is read the same way here as under storage: as a
+			// value this rule cannot see rather than one nobody wrote. A
+			// variable that resolves to false is an exporter with no queue,
+			// and a finding about the queue it lost would be about a config
+			// the collector never runs.
+			if val.Kind == yaml.ScalarNode && hasExpansion(val.Value) {
+				queue.unresolved = true
+			}
+
 			queue.disabled = val.Tag == boolTag && val.Value == "false"
 		case storageKey:
 			// Anything but an empty or null value is the setting written.
@@ -277,7 +288,7 @@ func readQueueBlock(block *yaml.Node, queue *sendingQueue) {
 			// invalid-value's and undefined-extension-reference's to say.
 			queue.persisted = !isNull(val) && (val.Kind != yaml.ScalarNode || val.Value != "")
 		case "<<":
-			queue.merged = true
+			queue.unresolved = true
 		default:
 			// Every other queue setting is the field schema's business.
 		}
@@ -285,16 +296,19 @@ func readQueueBlock(block *yaml.Node, queue *sendingQueue) {
 }
 
 // acceptsQueue reports whether the exporter type has a sending queue at all.
-// Plenty do not -- debug, nop and every exporter that writes its own client --
-// and telling them they lose a queue they never had is worse than saying
-// nothing.
+// Plenty do not -- debug and nop among them -- and telling them they lose a
+// queue they never had is worse than saying nothing.
 //
 // The field schema is the authority wherever it describes the type's settings
-// completely. Where it does not -- no schema was resolved, the type is not in
-// it, or its settings are left open because upstream hands them to a
-// third-party config -- a queue the config writes is the only evidence there is,
-// and a block the component turns out not to accept is unknown-field's to
-// report.
+// completely, which is what keeps debug quiet. Where it does not, a queue the
+// config writes is the only evidence there is. That covers three shapes:
+// no schema was resolved at all, the type is not in it, and the type is in it
+// with no fields -- which reads as "nothing could be resolved for this
+// component" rather than "this component has no settings", since the datadog
+// exporter, which has a queue and a great many other settings, sits in that
+// bucket next to nop. A queue written under an exporter that really has none
+// is then reported here as well as by unknown-field, which is the price of not
+// staying silent about datadog.
 func acceptsQueue(ctx *Context, typ string, written bool) bool {
 	fields := exporterFields(ctx, typ)
 	if fields == nil || fields.Open || len(fields.Children) == 0 {

--- a/pkg/rule/practice_test.go
+++ b/pkg/rule/practice_test.go
@@ -65,6 +65,19 @@ func TestNoPersistentQueue(t *testing.T) {
 			settings: "    sending_queue:\n      enabled: false",
 			want:     false,
 		},
+		// The variable may resolve to false, and then there is no queue to
+		// lose. enabled is read the same way storage is: a value this rule
+		// cannot see, not one nobody wrote.
+		"a queue enabled at runtime": {
+			settings: "    sending_queue:\n      enabled: ${env:QUEUE}",
+			want:     false,
+		},
+		// A string is not the boolean confmap wants, so it does not turn the
+		// queue off; invalid-value is what reports the type.
+		"the queue turned off with a string": {
+			settings: `    sending_queue:` + "\n" + `      enabled: "false"`,
+			want:     true,
+		},
 	}
 
 	for name, tt := range tests {
@@ -193,6 +206,33 @@ exporters:
 			assert.Empty(t, checkRule(t, "no-persistent-queue", src, rule.Environment{}))
 		})
 	}
+}
+
+// A component the schema resolved no fields for is not a component known to
+// have no settings: the datadog exporter, which has a queue, sits in that
+// bucket next to nop. What the config writes is then the only evidence there
+// is. testSchema's logging exporter has the same shape.
+func TestNoPersistentQueueWithoutFields(t *testing.T) {
+	t.Parallel()
+
+	const declared = `
+receivers: {otlp: }
+exporters:
+  logging:
+`
+
+	const wired = `
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [logging]}
+`
+
+	quiet := checkRule(t, "no-persistent-queue", declared+wired, rule.Environment{})
+	assert.Empty(t, quiet, "an exporter that writes no queue says nothing about having one")
+
+	written := checkRule(t, "no-persistent-queue",
+		declared+"    sending_queue:\n      queue_size: 5000\n"+wired, rule.Environment{})
+	assert.Len(t, written, 1)
 }
 
 // Without a schema there is nothing to say which exporters have a queue, so


### PR DESCRIPTION
Follow-up to #67, from a review of it that landed after the merge.

## `enabled` and `storage` disagreed about an expansion

The two halves of one block read a confmap expansion differently. `storage: ${env:STORAGE}` is treated as a name this rule cannot see, and the rule stays quiet. `enabled` matched a literal boolean only, so:

```yaml
exporters:
  otlp:
    sending_queue:
      enabled: ${env:QUEUE_ENABLED}   # resolves to false
```

was reported as an in-memory queue for an exporter that ends up with no queue at all. It is the same question — does the document settle this here — so `merged` becomes `unresolved` and covers both the merge key and the expansion. `enabled: "false"` as a string still reports: confmap wants a boolean, so a string does not turn the queue off, and `invalid-value` is what has something to say about the type.

## What a nil field schema means

The review also read `acceptsQueue`'s fallback as a bug: with no fields for a component it believes what the config wrote, and `nop` has no fields, so a `sending_queue` written under `nop` gets reported.

The behaviour stands, but neither the code comment nor the README said why. `schemagen` leaves `fields` nil when *nothing could be resolved* for a component, not when the component has no settings — which is why `datadog`, an exporter with a queue and a great many other settings, sits in that bucket next to `nop` (`contrib/v0.157.0.json` has exactly those two). Staying silent there would cost every `datadog` config to spare a `nop` config that writes a queue it does not have and fails to load anyway. Both places now say what the fallback is and what it costs, and the README no longer claims `nop` is never mentioned — `debug` is the one the schema actually keeps quiet, and it does.

## Tests

Three cases added: a queue enabled at runtime, `enabled: "false"` as a string, and an exporter the schema resolved no fields for — quiet until it writes a queue itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
