### PR TITLE
feat(rule): report a debug exporter left in a live pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,12 +243,13 @@ alone.
 
 **Practice** — `processor-order` (memory_limiter first), `missing-memory-limiter`,
 `missing-batch`, `insecure-tls`, `memory-limiter-config`,
-`memory-limiter-sizing`, `batch-size-bounds`, `no-persistent-queue`.
+`memory-limiter-sizing`, `batch-size-bounds`, `no-persistent-queue`,
+`debug-exporter-verbosity`.
 
 Every practice rule cites the upstream page it rests on — the
-`memorylimiterprocessor`, `batchprocessor` and `exporterhelper` READMEs,
-`configtls`, and the Kubernetes resource docs for the container's request and
-limit.
+`memorylimiterprocessor`, `batchprocessor`, `exporterhelper` and
+`debugexporter` READMEs, `configtls`, and the Kubernetes resource docs for the
+container's request and limit.
 
 `memory_limiter` is the one processor this linter tells people to add, and two
 of its constraints cannot be written as a field schema:
@@ -312,6 +313,36 @@ is deliberately no default-disabled rule concept for it: `info` is already below
 `--min-severity warning`, which is a normal way to run, and `disable:
 [no-persistent-queue]` in the settings file turns it off for good. A second
 mechanism that means roughly the same thing would only be another place to look.
+
+`debug-exporter-verbosity` catches the exporter somebody added to find out why
+an export was failing and never took out again. It prints what it is given to
+the collector's own log, and at `verbosity: detailed` that is every field of
+every span, data point and record in the pipeline — the collector spends its
+time formatting log lines, and the log backend receives a second copy of all the
+telemetry the collector was meant to be forwarding.
+
+```yaml
+exporters:
+  debug:
+    verbosity: detailed    # a line per record, not per batch
+service:
+  pipelines:
+    traces:
+      exporters: [otlp, debug]    # and it ships to production like this
+```
+
+That is the `warning`. Below it, at `info`, is one quiet note for a `debug`
+exporter at any verbosity: `basic` costs a line per batch rather than per
+record, which is cheap enough not to be a warning, but it is still a diagnostic
+tool left running, and upstream keeps no stable output format, so nothing
+downstream should be parsing it either. Both clauses match on the type, so
+`debug/verbose` counts, and both report per pipeline that references the
+exporter — that is what the message names and where the reader takes it out of.
+An exporter no pipeline references prints nothing and is `unused-component`'s to
+report; the `logging` exporter that came before it is `deprecated-component`'s.
+`warning` rather than `error` is deliberate: a deliberate debug run is
+legitimate and should not fail a CI job, and `--severity
+debug-exporter-verbosity=error` is there for anyone who wants it fatal.
 
 ## Schemas
 

--- a/pkg/rule/docs.go
+++ b/pkg/rule/docs.go
@@ -18,6 +18,11 @@ const (
 	// batchDocs states what batching is for and where it belongs.
 	batchDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
 		"/blob/main/processor/batchprocessor/README.md"
+	// debugDocs states what each verbosity prints, that detailed writes
+	// multiple lines per record, that sampling_initial and sampling_thereafter
+	// bound the rate, and that the output format is not stable.
+	debugDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
+		"/blob/main/exporter/debugexporter/README.md"
 	// tlsDocs states what the TLS settings mean, insecure among them.
 	tlsDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
 		"/blob/main/config/configtls/README.md"

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -1,6 +1,8 @@
 package rule
 
 import (
+	"strings"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
@@ -21,14 +23,24 @@ func practiceRules() []Rule {
 			"TLS verification disabled on a component that talks over the network", diag.Warning}},
 		noPersistentQueue{base{"no-persistent-queue",
 			"a sending queue held in memory, which a restart drops along with everything in it", diag.Info}},
+		debugExporterVerbosity{base{"debug-exporter-verbosity",
+			"a debug exporter left in a pipeline, writing the telemetry it receives to the log", diag.Warning}},
 	}
 }
 
-// memoryLimiter and batch are matched on type, so instances such as
+// memoryLimiter, batch and debug are matched on type, so instances such as
 // "memory_limiter/aggressive" are recognised too.
 const (
 	memoryLimiterType = "memory_limiter"
 	batchType         = "batch"
+	debugType         = "debug"
+)
+
+// verbosityKey is the debug exporter's setting for how much of every record it
+// writes, and detailedLevel the value that writes all of it.
+const (
+	verbosityKey  = "verbosity"
+	detailedLevel = "detailed"
 )
 
 // sendingQueueKey is the exporter setting holding the queue, and storageKey the
@@ -333,6 +345,108 @@ func exporterFields(ctx *Context, typ string) *schema.Field {
 	}
 
 	return comp.Fields
+}
+
+// debugExporterVerbosity reports a debug exporter a pipeline still references.
+//
+// The exporter prints what it is given to the collector's own log, and at
+// verbosity: detailed that is every field of every span, data point and record
+// flowing through the pipeline. In production it is a self-inflicted denial of
+// service: the collector spends its time formatting log lines, and the log
+// backend receives a second copy of all the telemetry the collector was meant
+// to be forwarding.
+//
+// It gets there the ordinary way. Someone adds debug to find out why an export
+// is failing, finds the answer, and the exporter stays in the pipeline list.
+// That is also why the rule reports at every verbosity, one level down: an
+// exporter at the default basic costs a line per batch rather than per record,
+// which is cheap enough not to be a warning, but it is still a diagnostic tool
+// left running, and its output format is documented as unstable, so nothing
+// downstream should be reading it either.
+//
+// It reports per pipeline that references the exporter, since that is what the
+// message names and what the reader removes it from. An exporter no pipeline
+// references is never instantiated and prints nothing; unused-component is what
+// has something to say about that one.
+type debugExporterVerbosity struct{ base }
+
+func (r debugExporterVerbosity) Check(ctx *Context) {
+	for _, p := range ctx.File.Service.Pipelines {
+		for _, ref := range p.Exporters {
+			if ref.ID.Type != debugType {
+				continue
+			}
+
+			// A pipeline naming an exporter nobody declared is
+			// undefined-reference's to report, and there are no settings to
+			// read a verbosity out of.
+			c, declared := ctx.File.Component(config.KindExporter, ref.ID)
+			if !declared {
+				continue
+			}
+
+			ctx.Report(r.finding(p, ref, detailedDebug(c)))
+		}
+	}
+}
+
+// finding renders one referenced debug exporter. Both clauses are anchored at
+// the reference rather than at the settings block, so a debug exporter shared
+// by three pipelines reports in the three places it is wired in rather than
+// three times on one line.
+func (r debugExporterVerbosity) finding(p config.Pipeline, ref config.Ref, detailed bool) Finding {
+	exporters := "service.pipelines." + p.Key + ".exporters"
+
+	if !detailed {
+		return Finding{
+			Node: ref.Node, Path: ref.Path, Severity: diag.Info,
+			Message: "exporter " + quote(ref.ID.String()) + " writes the telemetry of pipeline " +
+				quote(p.Key) + " to the collector's log",
+			Hint: "the exporter is for diagnosing a pipeline rather than for running one; " +
+				"remove it from " + exporters + " once the diagnosis is done, and do not parse what it " +
+				"prints, whose format upstream does not keep stable",
+			Docs: debugDocs,
+		}
+	}
+
+	return Finding{
+		Node: ref.Node, Path: ref.Path,
+		Message: "exporter " + quote(ref.ID.String()) + " runs at " + verbosityKey + ": " + detailedLevel +
+			" in pipeline " + quote(p.Key) + ", logging every record it receives",
+		Hint: "set " + verbosityKey + ": basic, or remove the exporter from " + exporters + "; " +
+			"sampling_initial and sampling_thereafter bound the rate if it has to stay at " + detailedLevel,
+		Docs: debugDocs,
+	}
+}
+
+// detailedDebug reports an exporter that writes every field of every record.
+// The value is folded to lower case, as configtelemetry's own decoder folds it:
+// "Detailed" is the same level to the collector.
+//
+// A value only the collector can resolve -- a confmap expansion, or one a merge
+// key supplies -- is read as not detailed. The note the rule reports either way
+// is true of a debug exporter at any verbosity; a warning quoting a verbosity
+// nobody wrote would not be.
+func detailedDebug(c config.Component) bool {
+	settings := resolveAlias(c.ValueNode)
+	if settings == nil || settings.Kind != yaml.MappingNode {
+		return false
+	}
+
+	for _, e := range mapEntries(settings, "") {
+		if e.key != verbosityKey {
+			continue
+		}
+
+		val := resolveAlias(e.node)
+		if val == nil || val.Kind != yaml.ScalarNode {
+			return false
+		}
+
+		return strings.EqualFold(val.Value, detailedLevel)
+	}
+
+	return false
 }
 
 type tlsHit struct {

--- a/pkg/rule/practice_test.go
+++ b/pkg/rule/practice_test.go
@@ -30,6 +30,201 @@ service:
 `
 }
 
+// debugging wraps debug exporter settings in a config that is otherwise clean.
+// The settings are written already indented by four spaces.
+func debugging(settings string) string {
+	return `
+receivers: {otlp: }
+exporters:
+  debug:
+` + settings + `
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`
+}
+
+func TestDebugExporterVerbosity(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		settings string
+		want     diag.Severity
+	}{
+		"the verbosity that logs every record": {
+			settings: "    verbosity: detailed",
+			want:     diag.Warning,
+		},
+		// configtelemetry folds the value before it reads it, so this is the
+		// same level to the collector.
+		"the same verbosity in capitals": {
+			settings: "    verbosity: Detailed",
+			want:     diag.Warning,
+		},
+		"no settings at all, so the default": {
+			settings: "",
+			want:     diag.Info,
+		},
+		"a verbosity written out as the default": {
+			settings: "    verbosity: basic",
+			want:     diag.Info,
+		},
+		"the verbosity between the two": {
+			settings: "    verbosity: normal",
+			want:     diag.Info,
+		},
+		// Nothing here knows what the variable holds, and a warning quoting a
+		// verbosity nobody wrote would be about a config the collector does not
+		// run. The note below it is true either way.
+		"a verbosity resolved at runtime": {
+			settings: "    verbosity: ${env:VERBOSITY}",
+			want:     diag.Info,
+		},
+		"a setting that is not the verbosity": {
+			settings: "    sampling_initial: 2",
+			want:     diag.Info,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "debug-exporter-verbosity", debugging(tt.settings), rule.Environment{})
+			require.Len(t, found, 1)
+			assert.Equal(t, tt.want, found[0].Severity)
+		})
+	}
+}
+
+// Matching on the type is what covers a named instance, which is how a debug
+// exporter added for one pipeline is usually written.
+func TestDebugExporterVerbosityMatchesOnType(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters:
+  debug/verbose:
+    verbosity: detailed
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug/verbose]}
+`
+
+	found := checkRule(t, "debug-exporter-verbosity", src, rule.Environment{})
+	require.Len(t, found, 1)
+	assert.Equal(t, diag.Warning, found[0].Severity)
+	assert.Contains(t, found[0].Message, `exporter "debug/verbose"`)
+}
+
+// Each clause has to name the pipeline the exporter is wired into, since that
+// is where the reader takes it out of.
+func TestDebugExporterVerbosityReadsAsASentence(t *testing.T) {
+	t.Parallel()
+
+	detailed := checkRule(t, "debug-exporter-verbosity",
+		debugging("    verbosity: detailed"), rule.Environment{})
+	require.Len(t, detailed, 1)
+
+	assert.Equal(t, `exporter "debug" runs at verbosity: detailed in pipeline "traces", `+
+		"logging every record it receives", detailed[0].Message)
+	assert.Equal(t, "set verbosity: basic, or remove the exporter from service.pipelines.traces.exporters; "+
+		"sampling_initial and sampling_thereafter bound the rate if it has to stay at detailed",
+		detailed[0].Hint)
+	assert.Equal(t, "service.pipelines.traces.exporters[0]", detailed[0].Path)
+	assert.Contains(t, detailed[0].Docs, "exporter/debugexporter/README.md")
+
+	quiet := checkRule(t, "debug-exporter-verbosity", debugging(""), rule.Environment{})
+	require.Len(t, quiet, 1)
+
+	assert.Equal(t, `exporter "debug" writes the telemetry of pipeline "traces" to the collector's log`,
+		quiet[0].Message)
+	assert.Equal(t, "the exporter is for diagnosing a pipeline rather than for running one; "+
+		"remove it from service.pipelines.traces.exporters once the diagnosis is done, and do not parse "+
+		"what it prints, whose format upstream does not keep stable", quiet[0].Hint)
+}
+
+// The exporter is reported where it is wired in, so a debug exporter shared by
+// three pipelines reports in the three places it has to be removed from.
+func TestDebugExporterVerbosityReportsPerPipeline(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters:
+  debug:
+    verbosity: detailed
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue: {storage: file_storage}
+extensions: {file_storage: }
+service:
+  extensions: [file_storage]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp, debug]}
+    metrics: {receivers: [otlp], exporters: [debug]}
+`
+
+	found := checkRule(t, "debug-exporter-verbosity", src, rule.Environment{})
+	require.Len(t, found, 2)
+	assert.Equal(t, "service.pipelines.traces.exporters[1]", found[0].Path)
+	assert.Equal(t, "service.pipelines.metrics.exporters[0]", found[1].Path)
+}
+
+func TestDebugExporterVerbosityStaysQuiet(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		// An exporter no pipeline reaches is never instantiated and prints
+		// nothing; unused-component is what has something to say about it.
+		"a debug exporter no pipeline references": `
+receivers: {otlp: }
+exporters:
+  debug:
+    verbosity: detailed
+  otlphttp:
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp]}
+`,
+		// Nothing declares it, so the collector does not start at all and
+		// undefined-reference is the finding worth having.
+		"a debug exporter nobody declared": `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp, debug]}
+`,
+		// The predecessor of the debug exporter is deprecated-component's, and
+		// it is not this exporter type.
+		"the logging exporter": `
+receivers: {otlp: }
+exporters: {logging: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [logging]}
+`,
+		"no service block": `
+exporters:
+  debug:
+    verbosity: detailed
+`,
+	}
+
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Empty(t, checkRule(t, "debug-exporter-verbosity", src, rule.Environment{}))
+		})
+	}
+}
+
 func TestNoPersistentQueue(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -432,6 +432,19 @@ service:
 `,
 			want: "no-persistent-queue",
 		},
+		{
+			name: "a debug exporter logging every record it is given",
+			src: `
+receivers: {otlp: }
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+			want: "debug-exporter-verbosity",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #51.

## What

`debug-exporter-verbosity`, in `pkg/rule/practice.go`, default `diag.Warning`:

- **Warning** — a `debug` exporter at `verbosity: detailed` that a pipeline references. It prints every field of every span, data point and record it is given to the collector's log, so the collector spends its time formatting log lines and the log backend receives a second copy of everything the collector was meant to be forwarding.
- **Info** — a `debug` exporter at any other verbosity. `basic` costs a line per batch rather than per record, which is cheap enough not to be a warning, but it is still a diagnostic tool left running, and upstream keeps no stable output format, so nothing downstream should be parsing it either.

```
config.yaml:19:19: warning: exporter "debug/verbose" runs at verbosity: detailed in pipeline "traces", logging every record it receives [debug-exporter-verbosity]
    hint: set verbosity: basic, or remove the exporter from service.pipelines.traces.exporters; sampling_initial and sampling_thereafter bound the rate if it has to stay at detailed
    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md
```

Checklist from the issue: matched on type so `debug/verbose` counts; only pipelines that reference the exporter, so no overlap with `unused-component`; the message names the pipeline; `logging` is left to `deprecated-component`; the hint mentions `sampling_initial`/`sampling_thereafter` rather than the rule trying to soften the finding for them; listed under **Practice** in the README with a paragraph of its own.

## Decisions worth a look

- **Reported per pipeline reference, anchored at the reference.** The message names the pipeline because that is where the exporter is removed from, so an exporter shared by three pipelines reports in the three places it is wired in rather than three times on the one `verbosity:` line.
- **The verbosity is folded before it is compared**, as `configtelemetry`'s own decoder folds it, so `Detailed` is the same level here as it is to the collector. A value only the collector can resolve — a `${env:...}` expansion, a merge key — is read as *not* detailed: the `info` note is true of a debug exporter at any verbosity, a warning quoting a verbosity nobody wrote is not.
- **`verbosity: none` is not special-cased.** Upstream's `Validate()` rejects it outright and the field schema's enum has only `basic`/`normal`/`detailed`, so `invalid-value` already has it.

## Unrelated bug spotted while writing this

`config.Ref.Path` already carries the `service.` prefix, so `"service." + ref.Path` in `processor-order`, `undefined-reference`, `duplicate-reference` and `signal-support` emits paths like `service.service.pipelines.traces.receivers[1]`. This rule uses `ref.Path` directly and so emits `service.pipelines.traces.exporters[0]`. The four existing call sites are left alone here to keep this PR to one rule — happy to send the one-line-each fix separately.

## Tests

`go test ./...` and `make lint` pass. New tests cover each verbosity level and the default, capitals, an expansion, a named instance, the per-pipeline count and positions, both messages and hints in full, and the four configs the rule stays quiet on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)