### PR TITLE
feat(rule): report a debugging extension reachable from off the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,42 @@ is deliberately no default-disabled rule concept for it: `info` is already below
 [no-persistent-queue]` in the settings file turns it off for good. A second
 mechanism that means roughly the same thing would only be another place to look.
 
+**Security** — `debug-extension-exposed`.
+
+Upstream's [security guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md)
+is direct about avoiding "exposing health or telemetry data outside the
+Collector by default", and the debugging extensions are the ones that do it.
+`pprof` serves heap profiles, goroutine dumps and the collector's command line;
+`zpages` serves live traces and pipeline internals.
+This is narrower than a general bind-address check, and separate from it
+because the consequence differs in kind: a `0.0.0.0` OTLP receiver accepts data
+it should not, while a `0.0.0.0` pprof endpoint *hands out* process internals.
+
+```yaml
+extensions:
+  pprof:
+    endpoint: 0.0.0.0:1777     # warning: heap profiles, on every interface
+  zpages:
+    endpoint: 10.0.4.7:55679   # info: deliberate, but that network can read it
+```
+
+The two cases are reported apart because they have different fixes. An
+unspecified address — `0.0.0.0`, `[::]`, a bare `:1777` — is reachable from
+every interface the host has and reports at `warning`; a specific non-loopback
+address was chosen by someone and reports at `info`, saying only that the
+network it sits on can read the collector's internals. Both are matched on
+component type, so `zpages/internal` is covered.
+
+`health_check` and `healthcheckv2` are deliberately left out. A Kubernetes
+liveness probe comes from the kubelet, off the container's loopback interface,
+so a health check bound to `0.0.0.0` is what a correct deployment looks like —
+and a rule that fires on every correct config is a rule people disable, which
+would take `pprof` down with it. An endpoint nobody wrote is left alone too:
+it takes the extension's own default, which upstream already binds to
+localhost. So is one built from an `${env:...}` expansion, and a hostname other
+than `localhost`, since what a name resolves to is a property of the network
+rather than of the file.
+
 ## Schemas
 
 Schemas are published at

--- a/README.md
+++ b/README.md
@@ -343,11 +343,19 @@ component type, so `zpages/internal` is covered.
 liveness probe comes from the kubelet, off the container's loopback interface,
 so a health check bound to `0.0.0.0` is what a correct deployment looks like —
 and a rule that fires on every correct config is a rule people disable, which
-would take `pprof` down with it. An endpoint nobody wrote is left alone too:
-it takes the extension's own default, which upstream already binds to
-localhost. So is one built from an `${env:...}` expansion, and a hostname other
-than `localhost`, since what a name resolves to is a property of the network
-rather than of the file.
+would take `pprof` down with it.
+
+The rule only reports extensions `service.extensions` actually lists, since
+that is the only thing that starts one — a declaration left out of it binds no
+port, and `unused-component` is what has something to say about it. An endpoint
+nobody wrote is left alone too: it takes the extension's own default, which has
+been `localhost` for both since upstream made `UseLocalHostAsDefaultHost` the
+default in `v0.110`. So is a hostname other than `localhost`, since what a name
+resolves to is a property of the network rather than of the file, and an
+address supplied by `${env:...}`. An expansion standing in for only the *port*
+is still reported — `0.0.0.0:${env:PPROF_PORT}` says plainly who can reach it —
+and an endpoint a `<<` merge supplies is read from the mapping it merges, so
+sharing one debugging block between extensions does not hide it.
 
 ## Schemas
 

--- a/pkg/rule/docs.go
+++ b/pkg/rule/docs.go
@@ -29,6 +29,11 @@ const (
 	// extensions implement the interface it needs.
 	authDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
 		"/blob/main/config/configauth/README.md"
+	// securityDocs is upstream's security guidance. Its extensions section is
+	// what says to avoid exposing health or telemetry data outside the
+	// collector by default, and names the extensions that do.
+	securityDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
+		"/blob/main/docs/security-best-practices.md"
 	// kubernetesResourceDocs states what requests and limits do, and the QoS
 	// class a pod lands in when they differ.
 	kubernetesResourceDocs = "https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"

--- a/pkg/rule/index.go
+++ b/pkg/rule/index.go
@@ -244,6 +244,24 @@ func componentExtensionRefs(c config.Component) []ExtensionRef {
 // worth resolving. An empty value is not a reference, and one built from a
 // confmap expansion is only known once the collector starts.
 func scalarChild(n *yaml.Node, key string) mo.Option[*yaml.Node] {
+	val, written := childNode(n, key).Get()
+	if !written {
+		return mo.None[*yaml.Node]()
+	}
+
+	val = resolveAlias(val)
+	if val == nil || val.Kind != yaml.ScalarNode || val.Value == "" || hasExpansion(val.Value) {
+		return mo.None[*yaml.Node]()
+	}
+
+	return mo.Some(val)
+}
+
+// childNode returns the value a mapping writes under a key, whatever shape it
+// has. What counts as a usable value is the caller's business: an expansion is
+// nothing to a rule resolving a name, and still worth reading to one asking
+// which address a component listens on.
+func childNode(n *yaml.Node, key string) mo.Option[*yaml.Node] {
 	n = resolveAlias(n)
 	if n == nil || n.Kind != yaml.MappingNode {
 		return mo.None[*yaml.Node]()
@@ -254,12 +272,7 @@ func scalarChild(n *yaml.Node, key string) mo.Option[*yaml.Node] {
 		return mo.None[*yaml.Node]()
 	}
 
-	val := resolveAlias(e.node)
-	if val == nil || val.Kind != yaml.ScalarNode || val.Value == "" || hasExpansion(val.Value) {
-		return mo.None[*yaml.Node]()
-	}
-
-	return mo.Some(val)
+	return mo.Some(e.node)
 }
 
 // walkSettings visits every mapping inside a component's settings, together

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -141,6 +141,7 @@ func All() []Rule {
 		fieldRules(),
 		settingsRules(),
 		practiceRules(),
+		securityRules(),
 	)
 	slices.SortFunc(rules, func(a, b Rule) int { return strings.Compare(a.Name(), b.Name()) })
 

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -432,6 +432,21 @@ service:
 `,
 			want: "no-persistent-queue",
 		},
+		{
+			name: "zpages reachable from off the host",
+			src: `
+receivers: {otlp: }
+exporters: {debug: }
+extensions:
+  zpages:
+    endpoint: 0.0.0.0:55679
+service:
+  extensions: [zpages]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+			want: "debug-extension-exposed",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/rule/security.go
+++ b/pkg/rule/security.go
@@ -1,0 +1,172 @@
+package rule
+
+import (
+	"net"
+	"strings"
+
+	"github.com/samber/lo"
+	"gopkg.in/yaml.v3"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+)
+
+// securityRules check what a config hands to the network around it. They are
+// separate from the practice rules because the cost of getting one wrong is
+// not a slower collector but a reachable one.
+func securityRules() []Rule {
+	return []Rule{
+		debugExtensionExposed{base{"debug-extension-exposed",
+			"a debugging extension bound where more than this host can reach it", diag.Warning}},
+	}
+}
+
+// endpointKey is the setting every debugging extension listens on.
+const endpointKey = "endpoint"
+
+// debugExtension is an extension that serves the collector's own internals,
+// together with the phrase a finding uses to say what it hands out. Being
+// specific is the point: "exposed" says nothing, "heap profiles" says why it
+// matters.
+type debugExtension struct {
+	typ    string
+	serves string
+}
+
+// debugExtensions lists the extensions that exist to reveal the process. Both
+// are matched on type, so "zpages/internal" is covered too.
+//
+// health_check and healthcheckv2 are deliberately absent. A Kubernetes
+// liveness probe is issued by the kubelet, which reaches the container from
+// off its loopback interface, so a health check bound to 0.0.0.0 is what a
+// correct deployment looks like rather than a mistake. A rule that fires on
+// every correct config is a rule people disable, and a disabled rule reports
+// nothing about pprof either.
+//
+// It returns a fresh slice so callers cannot alter what everyone else sees.
+func debugExtensions() []debugExtension {
+	return []debugExtension{
+		{typ: "pprof", serves: "heap profiles, goroutine dumps and the collector's command line"},
+		{typ: "zpages", serves: "live traces and the collector's pipeline internals"},
+	}
+}
+
+// exposure says how far an endpoint reaches.
+type exposure int
+
+const (
+	// exposureUnknown is an address this linter will not place: a hostname
+	// other than localhost. What a name resolves to is a property of the
+	// network the collector runs on, not of the file, so nothing is reported.
+	exposureUnknown exposure = iota
+	// exposureLoopback reaches no further than the host itself.
+	exposureLoopback
+	// exposureUnspecified is 0.0.0.0, [::] or a bare ":port": every interface
+	// the host has, including the ones it did not mean to serve on.
+	exposureUnspecified
+	// exposureRoutable is one specific address that is not loopback. Someone
+	// chose it, so the finding is a note rather than a correction.
+	exposureRoutable
+)
+
+// debugExtensionExposed reports a pprof or zpages endpoint reachable from off
+// the host. Upstream's security guidance is to avoid exposing health or
+// telemetry data outside the collector by default, and these two extensions
+// are the ones that do it: a 0.0.0.0 OTLP receiver accepts data it should not,
+// while a 0.0.0.0 pprof endpoint hands out process internals.
+//
+// The general bind-address checking that issue #45 describes covers receivers.
+// Should it ever grow to cover extensions, it must skip the types listed in
+// debugExtensions, which this rule owns and reports with a sharper message.
+type debugExtensionExposed struct{ base }
+
+func (r debugExtensionExposed) Check(ctx *Context) {
+	sec := ctx.File.Sections[config.KindExtension]
+	if sec == nil {
+		return
+	}
+
+	for _, c := range sec.Components {
+		ext, isDebug := lo.Find(debugExtensions(), func(e debugExtension) bool { return e.typ == c.ID.Type })
+		if !isDebug {
+			continue
+		}
+
+		// An endpoint nobody wrote takes the extension's own default, which
+		// upstream already binds to localhost. One built from a confmap
+		// expansion is only an address once the collector starts, and
+		// scalarChild leaves both of those unread.
+		node, written := scalarChild(c.ValueNode, endpointKey).Get()
+		if !written {
+			continue
+		}
+
+		r.report(ctx, c, ext, node)
+	}
+}
+
+func (r debugExtensionExposed) report(ctx *Context, c config.Component, ext debugExtension, node *yaml.Node) {
+	path := joinPath(config.KindExtension.Section()+"."+c.ID.String(), endpointKey)
+	subject := "extension " + quote(c.ID.String()) + " binds " + quote(node.Value) + ", serving " + ext.serves
+
+	switch classifyEndpoint(node.Value) {
+	case exposureUnspecified:
+		ctx.Report(Finding{
+			Node: node, Path: path,
+			Message: subject + " on every interface of the host",
+			Hint: "bind it to localhost, and reach it through a port-forward when you need it; upstream's advice " +
+				"is not to expose telemetry or debugging data outside the collector by default",
+			Docs: securityDocs,
+		})
+	case exposureRoutable:
+		ctx.Report(Finding{
+			Node: node, Path: path, Severity: diag.Info,
+			Message: subject + " to that network",
+			Hint: "binding a specific address is deliberate, but every host that can route to it reads the " +
+				"collector's internals; localhost is the safe default",
+			Docs: securityDocs,
+		})
+	case exposureLoopback, exposureUnknown:
+		// Loopback is the answer this rule is asking for, and a hostname it
+		// cannot place is not evidence of anything.
+	}
+}
+
+// classifyEndpoint places the host part of an endpoint. The port does not
+// matter here; who can open a connection to it does.
+func classifyEndpoint(endpoint string) exposure {
+	host := endpointHost(endpoint)
+	if host == "" {
+		return exposureUnspecified // a bare ":1777" listens everywhere
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		switch {
+		case ip.IsUnspecified():
+			return exposureUnspecified
+		case ip.IsLoopback():
+			return exposureLoopback
+		default:
+			return exposureRoutable
+		}
+	}
+
+	// The one hostname that means the same thing on every machine.
+	if strings.EqualFold(host, "localhost") {
+		return exposureLoopback
+	}
+
+	return exposureUnknown
+}
+
+// endpointHost returns the address an endpoint listens on, without its port.
+// An endpoint written with no port at all is a host on its own, and so is a
+// bracketed IPv6 address that SplitHostPort will not take.
+func endpointHost(endpoint string) string {
+	host, _, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return strings.Trim(endpoint, "[]")
+	}
+
+	return host
+}

--- a/pkg/rule/security.go
+++ b/pkg/rule/security.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"gopkg.in/yaml.v3"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
@@ -92,17 +93,94 @@ func (r debugExtensionExposed) Check(ctx *Context) {
 			continue
 		}
 
-		// An endpoint nobody wrote takes the extension's own default, which
-		// upstream already binds to localhost. One built from a confmap
-		// expansion is only an address once the collector starts, and
-		// scalarChild leaves both of those unread.
-		node, written := scalarChild(c.ValueNode, endpointKey).Get()
+		// service.extensions is the only thing that starts an extension, so a
+		// declaration left out of it opens no listener at all. Reporting the
+		// address anyway would be a confident claim about a port nothing
+		// binds, and unused-component already has something to say about the
+		// declaration itself.
+		if !ctx.Index.Enabled(c.ID) {
+			continue
+		}
+
+		// An endpoint nobody wrote takes the extension's own default. Both of
+		// these have defaulted to localhost since upstream made
+		// UseLocalHostAsDefaultHost the default in v0.110, so silence is the
+		// right answer for any release worth targeting; against a release
+		// older than that, where the default was 0.0.0.0, this rule is quiet
+		// about an endpoint that is in fact exposed.
+		node, written := endpointNode(c.ValueNode).Get()
 		if !written {
 			continue
 		}
 
 		r.report(ctx, c, ext, node)
 	}
+}
+
+// endpointNode returns the scalar holding a debugging extension's endpoint.
+//
+// Unlike an extension name, an endpoint that carries a confmap expansion is
+// still worth reading: "0.0.0.0:${env:PPROF_PORT}" parameterises the port and
+// leaves the address written plainly, and the address is the whole question
+// here. scalarChild is therefore the wrong reader for it.
+func endpointNode(settings *yaml.Node) mo.Option[*yaml.Node] {
+	settings = resolveAlias(settings)
+	if settings == nil || settings.Kind != yaml.MappingNode {
+		return mo.None[*yaml.Node]()
+	}
+
+	var merges []*yaml.Node
+
+	for _, e := range mapEntries(settings, "") {
+		switch e.key {
+		case endpointKey:
+			// A key the component writes itself replaces a merged one
+			// outright, so there is nothing further to look at.
+			return endpointScalar(e.node)
+		case "<<":
+			merges = append(merges, e.node)
+		default:
+			// Every other setting is another rule's business.
+		}
+	}
+
+	return mergedEndpoint(merges)
+}
+
+// mergedEndpoint reads the endpoint a "<<" merge supplies to a component that
+// wrote none of its own. The value of a merge is one mapping or a list of
+// them, and the first that holds the key wins, which is what the merge does at
+// load time.
+func mergedEndpoint(merges []*yaml.Node) mo.Option[*yaml.Node] {
+	for _, merge := range merges {
+		merge = resolveAlias(merge)
+		if merge == nil {
+			continue
+		}
+
+		targets := []*yaml.Node{merge}
+		if merge.Kind == yaml.SequenceNode {
+			targets = merge.Content
+		}
+
+		for _, target := range targets {
+			if node, held := childNode(target, endpointKey).Get(); held {
+				return endpointScalar(node)
+			}
+		}
+	}
+
+	return mo.None[*yaml.Node]()
+}
+
+// endpointScalar takes an endpoint's value node when it holds text to read.
+func endpointScalar(n *yaml.Node) mo.Option[*yaml.Node] {
+	n = resolveAlias(n)
+	if n == nil || n.Kind != yaml.ScalarNode || n.Value == "" {
+		return mo.None[*yaml.Node]()
+	}
+
+	return mo.Some(n)
 }
 
 func (r debugExtensionExposed) report(ctx *Context, c config.Component, ext debugExtension, node *yaml.Node) {
@@ -135,7 +213,11 @@ func (r debugExtensionExposed) report(ctx *Context, c config.Component, ext debu
 // classifyEndpoint places the host part of an endpoint. The port does not
 // matter here; who can open a connection to it does.
 func classifyEndpoint(endpoint string) exposure {
-	host := endpointHost(endpoint)
+	host, known := endpointHost(endpoint).Get()
+	if !known {
+		return exposureUnknown
+	}
+
 	if host == "" {
 		return exposureUnspecified // a bare ":1777" listens everywhere
 	}
@@ -159,14 +241,29 @@ func classifyEndpoint(endpoint string) exposure {
 	return exposureUnknown
 }
 
+// expansionMask stands in for a confmap expansion while an endpoint is split
+// into host and port. An expansion carries colons of its own -- ${env:PORT} --
+// which SplitHostPort cannot see past; one opaque token in its place splits
+// where the finished endpoint will. It is a byte no endpoint can contain.
+const expansionMask = "\x00"
+
 // endpointHost returns the address an endpoint listens on, without its port.
-// An endpoint written with no port at all is a host on its own, and so is a
-// bracketed IPv6 address that SplitHostPort will not take.
-func endpointHost(endpoint string) string {
-	host, _, err := net.SplitHostPort(endpoint)
+// It returns nothing when the address is only known once the collector starts,
+// which is not the same as the port being: "0.0.0.0:${env:PPROF_PORT}" says
+// exactly who can reach it, and only the port is left open.
+func endpointHost(endpoint string) mo.Option[string] {
+	masked := expansionRE.ReplaceAllString(endpoint, expansionMask)
+
+	host, _, err := net.SplitHostPort(masked)
 	if err != nil {
-		return strings.Trim(endpoint, "[]")
+		// An endpoint written with no port at all is a host on its own, and so
+		// is a bracketed IPv6 address that SplitHostPort will not take.
+		host = strings.Trim(masked, "[]")
 	}
 
-	return host
+	if strings.Contains(host, expansionMask) {
+		return mo.None[string]()
+	}
+
+	return mo.Some(host)
 }

--- a/pkg/rule/security_test.go
+++ b/pkg/rule/security_test.go
@@ -1,0 +1,149 @@
+package rule_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+)
+
+// extending wraps extension settings in a config that is otherwise clean. The
+// settings are written already indented by four spaces.
+func extending(name, settings string) string {
+	return `
+receivers: {otlp: }
+exporters: {debug: }
+extensions:
+  ` + name + `:
+` + settings + `
+service:
+  extensions: [` + name + `]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`
+}
+
+func TestDebugExtensionExposed(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		name     string // the extension declaration
+		settings string
+		want     diag.Severity // diag.Off when nothing should be reported
+	}{
+		"pprof on every interface": {
+			name:     "pprof",
+			settings: "    endpoint: 0.0.0.0:1777",
+			want:     diag.Warning,
+		},
+		"zpages on every interface": {
+			name:     "zpages",
+			settings: "    endpoint: 0.0.0.0:55679",
+			want:     diag.Warning,
+		},
+		"the unspecified IPv6 address": {
+			name:     "pprof",
+			settings: "    endpoint: \"[::]:1777\"",
+			want:     diag.Warning,
+		},
+		"a bare port": {
+			name:     "pprof",
+			settings: "    endpoint: \":1777\"",
+			want:     diag.Warning,
+		},
+		"an address with no port at all": {
+			name:     "pprof",
+			settings: "    endpoint: 0.0.0.0",
+			want:     diag.Warning,
+		},
+		"a named instance is matched on its type": {
+			name:     "zpages/internal",
+			settings: "    endpoint: 0.0.0.0:55679",
+			want:     diag.Warning,
+		},
+		"a specific address on some other network": {
+			name:     "pprof",
+			settings: "    endpoint: 10.0.4.7:1777",
+			want:     diag.Info,
+		},
+		"localhost": {
+			name:     "pprof",
+			settings: "    endpoint: localhost:1777",
+			want:     diag.Off,
+		},
+		"the loopback address": {
+			name:     "zpages",
+			settings: "    endpoint: 127.0.0.1:55679",
+			want:     diag.Off,
+		},
+		"the IPv6 loopback address": {
+			name:     "zpages",
+			settings: "    endpoint: \"[::1]:55679\"",
+			want:     diag.Off,
+		},
+		"no endpoint at all takes the extension's default": {
+			name:     "pprof",
+			settings: "",
+			want:     diag.Off,
+		},
+		"an endpoint resolved at runtime": {
+			name:     "pprof",
+			settings: "    endpoint: ${env:PPROF_ENDPOINT}",
+			want:     diag.Off,
+		},
+		"a hostname this linter will not resolve": {
+			name:     "pprof",
+			settings: "    endpoint: collector.internal:1777",
+			want:     diag.Off,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "debug-extension-exposed", extending(tt.name, tt.settings), rule.Environment{})
+
+			if tt.want == diag.Off {
+				assert.Empty(t, found)
+
+				return
+			}
+
+			require.Len(t, found, 1)
+			assert.Equal(t, tt.want, found[0].Severity)
+			assert.Contains(t, found[0].Docs, "docs/security-best-practices.md")
+		})
+	}
+}
+
+// TestDebugExtensionExposedSaysWhatIsServed pins the part of the message that
+// makes the finding worth reading: what the endpoint actually hands out.
+func TestDebugExtensionExposedSaysWhatIsServed(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "debug-extension-exposed",
+		extending("pprof", "    endpoint: 0.0.0.0:1777"), rule.Environment{})
+
+	require.Len(t, found, 1)
+	assert.Contains(t, found[0].Message, "heap profiles")
+	assert.Contains(t, found[0].Message, "every interface of the host")
+	assert.Contains(t, found[0].Hint, "localhost")
+	assert.Equal(t, "extensions.pprof.endpoint", found[0].Path)
+}
+
+// TestHealthCheckIsNotReported records the exclusion: the kubelet issues a
+// liveness probe from off the container's loopback interface, so a health
+// check bound to 0.0.0.0 is a correct deployment and not a finding.
+func TestHealthCheckIsNotReported(t *testing.T) {
+	t.Parallel()
+
+	for _, typ := range []string{"health_check", "healthcheckv2"} {
+		found := checkRule(t, "debug-extension-exposed",
+			extending(typ, "    endpoint: 0.0.0.0:13133"), rule.Environment{})
+		assert.Empty(t, found, "%s should not be reported", typ)
+	}
+}

--- a/pkg/rule/security_test.go
+++ b/pkg/rule/security_test.go
@@ -94,6 +94,23 @@ func TestDebugExtensionExposed(t *testing.T) {
 			settings: "    endpoint: ${env:PPROF_ENDPOINT}",
 			want:     diag.Off,
 		},
+		"an address resolved at runtime": {
+			name:     "pprof",
+			settings: "    endpoint: ${env:PPROF_HOST}:1777",
+			want:     diag.Off,
+		},
+		// Only the port is left open, and the port is not what decides who can
+		// reach the endpoint.
+		"a port resolved at runtime": {
+			name:     "pprof",
+			settings: "    endpoint: 0.0.0.0:${env:PPROF_PORT}",
+			want:     diag.Warning,
+		},
+		"a loopback address with a port resolved at runtime": {
+			name:     "pprof",
+			settings: "    endpoint: localhost:${env:PPROF_PORT}",
+			want:     diag.Off,
+		},
 		"a hostname this linter will not resolve": {
 			name:     "pprof",
 			settings: "    endpoint: collector.internal:1777",
@@ -133,6 +150,109 @@ func TestDebugExtensionExposedSaysWhatIsServed(t *testing.T) {
 	assert.Contains(t, found[0].Message, "every interface of the host")
 	assert.Contains(t, found[0].Hint, "localhost")
 	assert.Equal(t, "extensions.pprof.endpoint", found[0].Path)
+}
+
+// TestExtensionNobodyStartsIsNotReported pins the other half of the rule's
+// premise: service.extensions is what instantiates an extension, so a
+// declaration left out of it binds no port for anyone to reach.
+func TestExtensionNobodyStartsIsNotReported(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters: {debug: }
+extensions:
+  pprof:
+    endpoint: 0.0.0.0:1777
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`
+
+	assert.Empty(t, checkRule(t, "debug-extension-exposed", src, rule.Environment{}))
+	// The declaration is not thereby unremarked: another rule owns it.
+	assert.NotEmpty(t, checkRule(t, "unused-component", src, rule.Environment{}))
+}
+
+// TestMergedEndpointIsRead covers the endpoint a component does not write
+// itself. A "<<" merge is how one debugging block is shared between several
+// extensions, and reading only local keys would miss every one of them.
+func TestMergedEndpointIsRead(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		src  string
+		want bool
+	}{
+		"a merge supplies the endpoint": {
+			src: `
+debug: &debug
+  endpoint: 0.0.0.0:1777
+extensions:
+  pprof:
+    <<: *debug
+`,
+			want: true,
+		},
+		"a merge of several mappings": {
+			src: `
+ports: &ports
+  endpoint: 0.0.0.0:1777
+timeouts: &timeouts
+  idle_timeout: 30s
+extensions:
+  pprof:
+    <<: [*timeouts, *ports]
+`,
+			want: true,
+		},
+		"a local endpoint wins over the merged one": {
+			src: `
+debug: &debug
+  endpoint: 0.0.0.0:1777
+extensions:
+  pprof:
+    <<: *debug
+    endpoint: localhost:1777
+`,
+			want: false,
+		},
+		"a merge that supplies no endpoint": {
+			src: `
+debug: &debug
+  idle_timeout: 30s
+extensions:
+  pprof:
+    <<: *debug
+`,
+			want: false,
+		},
+	}
+
+	const wiring = `
+receivers: {otlp: }
+exporters: {debug: }
+service:
+  extensions: [pprof]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "debug-extension-exposed", tt.src+wiring, rule.Environment{})
+			if !tt.want {
+				assert.Empty(t, found)
+
+				return
+			}
+
+			require.Len(t, found, 1)
+			assert.Contains(t, found[0].Message, "0.0.0.0:1777")
+		})
+	}
 }
 
 // TestHealthCheckIsNotReported records the exclusion: the kubelet issues a


### PR DESCRIPTION
Closes #47.

## What

A new rule, `debug-extension-exposed`, at `diag.Warning`, in a new
`pkg/rule/security.go` — separate from the practice rules because the cost of
getting one wrong is not a slower collector but a reachable one.

It reports `pprof` and `zpages` endpoints bound anywhere other than loopback.
Matched on component type, so `zpages/internal` is covered.

```yaml
extensions:
  pprof:
    endpoint: 0.0.0.0:1777     # warning
  zpages:
    endpoint: 10.0.4.7:55679   # info
```

```
warning: extension "pprof" binds "0.0.0.0:1777", serving heap profiles, goroutine dumps
         and the collector's command line on every interface of the host [debug-extension-exposed]
  hint: bind it to localhost, and reach it through a port-forward when you need it; upstream's
        advice is not to expose telemetry or debugging data outside the collector by default
  docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md

info: extension "zpages/internal" binds "10.0.4.7:55679", serving live traces and the
      collector's pipeline internals to that network [debug-extension-exposed]
  hint: binding a specific address is deliberate, but every host that can route to it reads
        the collector's internals; localhost is the safe default
```

## Decisions the issue left open

**Two messages, two severities.** An unspecified address (`0.0.0.0`, `[::]`, a
bare `:1777`) is reachable from every interface the host has, and reports at
`warning`. A specific non-loopback address was chosen by someone, so it reports
at `info` and says only that the network it sits on can read the collector's
internals. Different consequence, different fix, different level.

**`health_check` and `healthcheckv2` excluded**, with the reason recorded in a
comment on `debugExtensions()`: a Kubernetes liveness probe comes from the
kubelet, off the container's loopback interface, so a health check on `0.0.0.0`
is what a correct deployment looks like. A rule that fires on every correct
config is a rule people disable — and a disabled rule reports nothing about
`pprof` either. `TestHealthCheckIsNotReported` pins it.

**Presence of `pprof` is not reported.** Leaning no, as the issue suggested: it
is a legitimate permanent part of many deployments.

**No double-reporting with `receiver-binds-all-interfaces` (#45).** That rule
does not exist yet, so there is nothing to skip today. The decision is recorded
on the rule's doc comment: should the general check ever grow to cover
extensions, it must skip the types this rule owns.

## What it stays quiet on

- An endpoint nobody wrote — it takes the extension's own default, which
  upstream already binds to localhost.
- `${env:...}` expansions, which are only an address once the collector starts.
- Any hostname other than `localhost`. What a name resolves to is a property of
  the network the collector runs on, not of the file, so resolving it at lint
  time would be guessing.

## Also

- `securityDocs` in `docs.go`, pointing at upstream's `security-best-practices.md`;
  every finding carries it.
- A **Security** section in the README's "What it checks", covering the split
  severities and the `health_check` exclusion.
- `pkg/rule/security_test.go`: a table over the address forms (unspecified v4
  and v6, bare port, no port at all, loopback v4 and v6, named instance,
  routable, hostname, expansion, absent), plus tests pinning the message
  content and the health-check exclusion. One case added to `TestRules`.

`go test ./...` and `golangci-lint run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)