### PR TITLE
fix(rule): write the service prefix into a path once

### DIFF
--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -93,7 +93,10 @@ func (p Pipeline) Refs(k Kind) []Ref {
 type Ref struct {
 	ID   ID
 	Node *yaml.Node
-	// Path is the dotted YAML path of the reference.
+	// Path is the dotted YAML path of the reference, from the root of the
+	// document rather than from the service block: a pipeline's first exporter
+	// is "service.pipelines.traces.exporters[0]". A caller reporting one has
+	// nothing to prepend.
 	Path string
 }
 

--- a/pkg/rule/component.go
+++ b/pkg/rule/component.go
@@ -145,7 +145,7 @@ func (r signalSupport) Check(ctx *Context) {
 				}
 
 				ctx.Report(Finding{
-					Node: ref.Node, Path: "service." + ref.Path,
+					Node: ref.Node, Path: ref.Path,
 					Message: string(decl.Kind) + " " + quote(ref.ID.Type) + " does not support " +
 						string(p.Signal) + " in pipeline " + quote(p.Key),
 					Hint: "it supports: " + comp.SignalList(),

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -46,7 +46,7 @@ func (r processorOrder) Check(ctx *Context) {
 		for i, ref := range p.Processors {
 			if ref.ID.Type == memoryLimiterType && i != 0 {
 				ctx.Report(Finding{
-					Node: ref.Node, Path: "service." + ref.Path,
+					Node: ref.Node, Path: ref.Path,
 					Message: "memory_limiter is processor " + itoa(i+1) + " in pipeline " + quote(p.Key) +
 						"; it must be first",
 					Hint: "move " + quote(ref.ID.String()) + " to the front of " + path,
@@ -60,7 +60,7 @@ func (r processorOrder) Check(ctx *Context) {
 				}
 
 				ctx.Report(Finding{
-					Node: ref.Node, Path: "service." + ref.Path,
+					Node: ref.Node, Path: ref.Path,
 					Message:  "batch runs before other processors in pipeline " + quote(p.Key),
 					Hint:     "put batch last so upstream processors see individual items and cannot drop whole batches",
 					Docs:     batchDocs,

--- a/pkg/rule/reference.go
+++ b/pkg/rule/reference.go
@@ -34,7 +34,7 @@ func (r undefinedReference) Check(ctx *Context) {
 		}
 
 		ctx.Report(Finding{
-			Node: ref.Node, Path: "service." + ref.Path,
+			Node: ref.Node, Path: ref.Path,
 			Message: "service.extensions references " + quote(ref.ID.String()) + " which is not declared under extensions",
 			Hint:    misplacedHint(ctx, ref.ID, config.KindExtension),
 		})
@@ -48,7 +48,7 @@ func (r undefinedReference) Check(ctx *Context) {
 				}
 
 				ctx.Report(Finding{
-					Node: ref.Node, Path: "service." + ref.Path,
+					Node: ref.Node, Path: ref.Path,
 					Message: "pipeline " + quote(p.Key) + " references " + string(slot) + " " +
 						quote(ref.ID.String()) + " which is not declared under " + slot.Section(),
 					Hint: misplacedHint(ctx, ref.ID, slot),
@@ -173,7 +173,7 @@ func (r duplicateReference) Check(ctx *Context) {
 			for _, ref := range p.Refs(slot) {
 				if seen[ref.ID] {
 					ctx.Report(Finding{
-						Node: ref.Node, Path: "service." + ref.Path,
+						Node: ref.Node, Path: ref.Path,
 						Message: quote(ref.ID.String()) + " is listed twice in " + p.Key + "." + slot.Section(),
 					})
 				}

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -515,6 +515,20 @@ service:
 `,
 			path: "service.pipelines.traces.processors[1]",
 		},
+		// processor-order's other clause, which reports a different processor
+		// in the same slot and so is a second place the prefix could come back.
+		"a batch that runs before another processor": {
+			rule: "processor-order",
+			src: `
+receivers: {otlp: }
+processors: {batch: , batch/second: }
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [batch, batch/second], exporters: [debug]}
+`,
+			path: "service.pipelines.traces.processors[0]",
+		},
 	}
 
 	for name, tt := range tests {

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -446,6 +446,88 @@ service:
 	}
 }
 
+// config.Ref.Path is the path from the root of the document, so a rule
+// reporting a reference has nothing to prepend to it. Every rule that reports
+// one is here, since the mistake is the kind that spreads by being copied from
+// the rule next door.
+func TestServiceReferencePathsAreWrittenOnce(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		rule string
+		src  string
+		path string
+	}{
+		"an extension the service block enables but nobody declares": {
+			rule: "undefined-reference",
+			src: `
+receivers: {otlp: }
+exporters: {debug: }
+service:
+  extensions: [zpages]
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+			path: "service.extensions[0]",
+		},
+		"a receiver a pipeline names but nobody declares": {
+			rule: "undefined-reference",
+			src: `
+receivers: {otlp: }
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp, jaeger], exporters: [debug]}
+`,
+			path: "service.pipelines.traces.receivers[1]",
+		},
+		"a receiver listed twice in one slot": {
+			rule: "duplicate-reference",
+			src: `
+receivers: {otlp: }
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp, otlp], exporters: [debug]}
+`,
+			path: "service.pipelines.traces.receivers[1]",
+		},
+		"a receiver that does not carry the pipeline's signal": {
+			rule: "signal-support",
+			src: `
+receivers: {jaeger: }
+exporters: {debug: }
+service:
+  pipelines:
+    metrics: {receivers: [jaeger], exporters: [debug]}
+`,
+			path: "service.pipelines.metrics.receivers[0]",
+		},
+		"a memory_limiter that is not the first processor": {
+			rule: "processor-order",
+			src: `
+receivers: {otlp: }
+processors: {batch: , memory_limiter: }
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [batch, memory_limiter], exporters: [debug]}
+`,
+			path: "service.pipelines.traces.processors[1]",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, tt.rule, tt.src, rule.Environment{})
+			require.NotEmpty(t, found)
+			assert.Equal(t, tt.path, found[0].Path)
+		})
+	}
+}
+
 func TestEnvExpansionSkipsValueChecks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Spotted while writing #78.

## The bug

`config.Ref.Path` is built from the entry path the parser walks, which starts at the root of the document — a pipeline's first exporter is already `service.pipelines.traces.exporters[0]`. Six call sites prepended `service.` to it anyway:

```json
{
  "rule": "undefined-reference",
  "message": "pipeline \"traces\" references receiver \"jaeger\" which is not declared under receivers",
  "path": "service.service.pipelines.traces.receivers[1]"
}
```

That path is in the JSON, JUnit and GitHub output, and it resolves against nothing in the file it came from. `undefined-extension-reference` builds its paths the other way and has always been right, which is how the two shapes sat next to each other without either looking wrong.

## The fix

The prefix comes off `undefined-reference` (both the `service.extensions` and the pipeline-slot clauses), `duplicate-reference`, `signal-support` and `processor-order`. Positions, messages, hints and severities are untouched — only the `path` field of those findings changes.

`config.Ref.Path`'s doc comment now says which end it starts from, and `TestServiceReferencePathsAreWrittenOnce` covers every rule that reports a service-block reference: this is the kind of mistake that spreads by being copied from the rule next door.

## Compatibility

Anything consuming `path` from the JSON output for these four rules sees a changed value — a corrected one. Positions are what editors and the GitHub annotations use, and those do not move.

## Tests

`go test ./...` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)