### PR TITLE
feat(rule): report an endpoint bound to every interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,9 +372,12 @@ receivers and extensions bind, while an exporter's or a connector's `endpoint`
 names somewhere to send to. `0.0.0.0` there is also wrong, but it is a different
 mistake with a different fix, and a bind-address hint on a line about a backend
 would be worse than silence. Within a component the walk is by key name rather
-than by a table of where each type keeps its endpoint, since `otlp` writes one
-per protocol and most others write one at the top; each is reported separately,
-because each is its own line to edit. A receiver no pipeline names and an
+than by a table of where each type keeps its address, since `otlp` writes one per
+protocol and most others write one at the top; each is reported separately,
+because each is its own line to edit. Two key names are read, not one: the
+stanza-based log receivers call it `listen_address` — `tcplog`, `udplog`, and
+`syslog` under each of its `tcp` and `udp` blocks — and reading only `endpoint`
+would leave every one of them unreported. A receiver no pipeline names and an
 extension `service.extensions` leaves out are both skipped — neither is ever
 instantiated, so neither binds anything — as is an endpoint nobody wrote, which
 takes the component's own default. `${env:MY_POD_IP}:4317` is the fix, so it is

--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ alone.
 `missing-batch`, `memory-limiter-config`, `memory-limiter-sizing`,
 `batch-size-bounds`, `no-persistent-queue`, `debug-exporter-verbosity`.
 
-**Security** — `insecure-tls`, `debug-extension-exposed`, `hardcoded-secret`.
+**Security** — `insecure-tls`, `receiver-binds-all-interfaces`,
+`debug-extension-exposed`, `hardcoded-secret`.
 
 Every practice and security rule cites the upstream page it rests on — the
 `memorylimiterprocessor`, `batchprocessor`, `exporterhelper` and
@@ -345,12 +346,55 @@ report; the `logging` exporter that came before it is `deprecated-component`'s.
 legitimate and should not fail a CI job, and `--severity
 debug-exporter-verbosity=error` is there for anyone who wants it fatal.
 
+`receiver-binds-all-interfaces` is the one upstream's [config best
+practices](https://opentelemetry.io/docs/security/config-best-practices/) lead
+with, and the most common way a collector ends up reachable from more of the
+network than anyone meant:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317   # every interface, not just the one you meant
+```
+
+The collector changed its own default to `localhost` in `v0.110.0` for exactly
+this reason. The example configs the ecosystem copies from did not — the ones on
+opentelemetry.io say outright that they use the unspecified address "as a
+convenience" — and those get pasted into production. Every spelling of it is
+matched: `0.0.0.0`, `[::]`, a bare `:4317`, and `:::4317`, which is what netstat
+prints for an IPv6 listener and which Go refuses outright, so a collector handed
+one does not start at all.
+
+Only endpoints something *listens* on are read, and the split is by kind:
+receivers and extensions bind, while an exporter's or a connector's `endpoint`
+names somewhere to send to. `0.0.0.0` there is also wrong, but it is a different
+mistake with a different fix, and a bind-address hint on a line about a backend
+would be worse than silence. Within a component the walk is by key name rather
+than by a table of where each type keeps its endpoint, since `otlp` writes one
+per protocol and most others write one at the top; each is reported separately,
+because each is its own line to edit. A receiver no pipeline names and an
+extension `service.extensions` leaves out are both skipped — neither is ever
+instantiated, so neither binds anything — as is an endpoint nobody wrote, which
+takes the component's own default. `${env:MY_POD_IP}:4317` is the fix, so it is
+not a finding; `0.0.0.0:${env:PORT}` still is, since the address says plainly
+who can reach it and only the port is left open.
+
+The hint carries the fix rather than only the objection: bind `127.0.0.1` when
+every client is local, and in Kubernetes write `${env:MY_POD_IP}`, taking the pod
+IP from the downward API. It reports at `warning`, not `error` — a gateway behind
+a service mesh with its own network policy binds every interface deliberately.
+`health_check` and `healthcheckv2` are left out for the same reason
+`debug-extension-exposed` leaves them out, below, and `pprof` and `zpages` are
+that rule's to report.
+
 `debug-extension-exposed` rests on upstream's [security guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md),
 which is direct about avoiding "exposing health or telemetry data outside the
 Collector by default", and the debugging extensions are the ones that do it.
 `pprof` serves heap profiles, goroutine dumps and the collector's command line;
 `zpages` serves live traces and pipeline internals.
-This is narrower than a general bind-address check, and separate from it
+This is narrower than the general bind-address check above, and separate from it
 because the consequence differs in kind: a `0.0.0.0` OTLP receiver accepts data
 it should not, while a `0.0.0.0` pprof endpoint *hands out* process internals.
 

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -104,7 +104,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: localhost:4317
 processors:
   memory_limiter:
     check_interval: 1s
@@ -459,6 +459,21 @@ service:
     traces: {receivers: [otlp], exporters: [debug]}
 `,
 			want: "debug-extension-exposed",
+		},
+		{
+			name: "a receiver bound to every interface",
+			src: `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+			want: "receiver-binds-all-interfaces",
 		},
 	}
 

--- a/pkg/rule/security.go
+++ b/pkg/rule/security.go
@@ -593,6 +593,17 @@ func bracketed(endpoint string) string {
 	return endpoint
 }
 
+// bindKeys are the settings a component writes the address it listens on in.
+// endpoint is what most of them use, and what the field schemas describe a
+// server's address as. The stanza-based log receivers are the exception:
+// tcplog and udplog spell it listen_address, and syslog carries one under each
+// of its tcp and udp blocks. Reading only endpoint would leave every one of
+// those unreported, which is why the walk is over two key names rather than
+// one.
+//
+// It returns a fresh slice so callers cannot alter what everyone else sees.
+func bindKeys() []string { return []string{endpointKey, "listen_address"} }
+
 // probeExtensions are the extensions a correct deployment binds to every
 // interface on purpose. A Kubernetes liveness probe is issued by the kubelet,
 // which reaches the container from off its loopback interface, so a health
@@ -633,19 +644,22 @@ func (r receiverBindsAllInterfaces) Check(ctx *Context) {
 			}
 
 			// The nesting varies: otlp writes its endpoints under
-			// protocols.grpc and protocols.http, and most other components
-			// write one at the top. Walking for the key covers both without a
-			// table of where every component keeps it, at the cost of matching
-			// an endpoint nested under something else -- which, in a section
-			// holding only things that listen, is a price worth paying.
+			// protocols.grpc and protocols.http, syslog under tcp and udp, and
+			// most other components write one at the top. Walking for the key
+			// covers all of them without a table of where every component keeps
+			// it, at the cost of matching an address nested under something
+			// else -- which, in a section holding only things that listen, is a
+			// price worth paying.
 			walkSettings(c.ValueNode, kind.Section()+"."+c.ID.String(), 0, func(m *yaml.Node, path string) {
-				node, written := childNode(m, endpointKey).Get()
-				if !written {
-					return
-				}
+				for _, key := range bindKeys() {
+					node, written := childNode(m, key).Get()
+					if !written {
+						continue
+					}
 
-				if scalar, readable := endpointScalar(node).Get(); readable {
-					r.report(ctx, kind, c, scalar, joinPath(path, endpointKey))
+					if scalar, readable := endpointScalar(node).Get(); readable {
+						r.report(ctx, kind, c, scalar, joinPath(path, key))
+					}
 				}
 			})
 		}

--- a/pkg/rule/security.go
+++ b/pkg/rule/security.go
@@ -23,6 +23,8 @@ func securityRules() []Rule {
 			"TLS verification disabled on a component that talks over the network", diag.Warning}},
 		debugExtensionExposed{base{"debug-extension-exposed",
 			"a debugging extension bound where more than this host can reach it", diag.Warning}},
+		receiverBindsAllInterfaces{base{"receiver-binds-all-interfaces",
+			"a component listening on every network interface the host has", diag.Warning}},
 		hardcodedSecret{base{"hardcoded-secret",
 			"a credential written into the config instead of expanded at runtime", diag.Warning}},
 	}
@@ -312,7 +314,7 @@ func isPlaceholder(value string) bool {
 	return strings.HasPrefix(norm, "your")
 }
 
-// endpointKey is the setting every debugging extension listens on.
+// endpointKey is the setting a component that listens says its address in.
 const endpointKey = "endpoint"
 
 // debugExtension is an extension that serves the collector's own internals,
@@ -366,9 +368,9 @@ const (
 // are the ones that do it: a 0.0.0.0 OTLP receiver accepts data it should not,
 // while a 0.0.0.0 pprof endpoint hands out process internals.
 //
-// The general bind-address checking that issue #45 describes covers receivers.
-// Should it ever grow to cover extensions, it must skip the types listed in
-// debugExtensions, which this rule owns and reports with a sharper message.
+// receiver-binds-all-interfaces is the general bind-address check, and it skips
+// the types listed in debugExtensions, which this rule owns and reports with a
+// sharper message.
 type debugExtensionExposed struct{ base }
 
 func (r debugExtensionExposed) Check(ctx *Context) {
@@ -542,7 +544,7 @@ const expansionMask = "\x00"
 // which is not the same as the port being: "0.0.0.0:${env:PPROF_PORT}" says
 // exactly who can reach it, and only the port is left open.
 func endpointHost(endpoint string) mo.Option[string] {
-	masked := expansionRE.ReplaceAllString(endpoint, expansionMask)
+	masked := expansionRE.ReplaceAllString(bracketed(endpoint), expansionMask)
 
 	host, _, err := net.SplitHostPort(masked)
 	if err != nil {
@@ -556,4 +558,149 @@ func endpointHost(endpoint string) mo.Option[string] {
 	}
 
 	return mo.Some(host)
+}
+
+// endpointPort returns the port an endpoint names, so a suggestion can keep it
+// while changing the address in front of it. It returns nothing when the
+// endpoint names no port, or leaves it to an expansion: the port only ever ends
+// up in a hint, so one that cannot be read costs a little precision there and
+// nothing anywhere else.
+func endpointPort(endpoint string) mo.Option[string] {
+	masked := expansionRE.ReplaceAllString(bracketed(endpoint), expansionMask)
+
+	_, port, err := net.SplitHostPort(masked)
+	if err != nil || strings.Contains(port, expansionMask) {
+		return mo.None[string]()
+	}
+
+	return mo.Some(port)
+}
+
+// bracketed rewrites the one endpoint spelling net.SplitHostPort refuses:
+// ":::4317", the IPv6 unspecified address written without the brackets that
+// tell its colons from the port's. It is what netstat prints for an IPv6
+// listener, so it gets copied into configs from there.
+//
+// Go refuses it outright -- "too many colons in address" -- so a collector
+// handed one does not start at all, and reading it as "[::]:4317" keeps the
+// finding about the address whoever wrote it meant. Binding a specific
+// interface is the fix for both halves of that at once.
+func bracketed(endpoint string) string {
+	if rest, found := strings.CutPrefix(endpoint, ":::"); found {
+		return "[::]:" + rest
+	}
+
+	return endpoint
+}
+
+// probeExtensions are the extensions a correct deployment binds to every
+// interface on purpose. A Kubernetes liveness probe is issued by the kubelet,
+// which reaches the container from off its loopback interface, so a health
+// check on localhost is the configuration that fails. This is the same
+// exclusion debugExtensions documents, for the same reason.
+func probeExtensions() []string { return []string{"health_check", "healthcheckv2"} }
+
+// receiverBindsAllInterfaces reports an endpoint bound to the unspecified
+// address: 0.0.0.0, [::], or a bare ":4317", all of which listen on every
+// interface the host has rather than the one whoever wrote it had in mind.
+// Upstream changed the collector's own default to localhost in v0.110.0 for
+// exactly this reason, but the example configs the ecosystem copies from -- the
+// ones on opentelemetry.io say outright that they use 0.0.0.0 "as a
+// convenience" -- still carry it into production.
+//
+// Only server-side endpoints are read, and the split is by kind: a receiver or
+// an extension listens on its endpoint, while an exporter's or a connector's
+// names somewhere to send to. 0.0.0.0 as a destination is also wrong, but it is
+// a different mistake with a different fix, and reporting it here would put a
+// bind-address hint on a line about a backend.
+//
+// The severity is Warning rather than Error. A gateway behind a service mesh
+// with its own network policy binds every interface deliberately, and so does
+// anything that has to be reachable from another pod without the downward API
+// to hand.
+type receiverBindsAllInterfaces struct{ base }
+
+func (r receiverBindsAllInterfaces) Check(ctx *Context) {
+	for _, kind := range []config.Kind{config.KindReceiver, config.KindExtension} {
+		sec := ctx.File.Sections[kind]
+		if sec == nil {
+			continue
+		}
+
+		for _, c := range sec.Components {
+			if r.skip(ctx, kind, c) {
+				continue
+			}
+
+			// The nesting varies: otlp writes its endpoints under
+			// protocols.grpc and protocols.http, and most other components
+			// write one at the top. Walking for the key covers both without a
+			// table of where every component keeps it, at the cost of matching
+			// an endpoint nested under something else -- which, in a section
+			// holding only things that listen, is a price worth paying.
+			walkSettings(c.ValueNode, kind.Section()+"."+c.ID.String(), 0, func(m *yaml.Node, path string) {
+				node, written := childNode(m, endpointKey).Get()
+				if !written {
+					return
+				}
+
+				if scalar, readable := endpointScalar(node).Get(); readable {
+					r.report(ctx, kind, c, scalar, joinPath(path, endpointKey))
+				}
+			})
+		}
+	}
+}
+
+// skip reports the components this rule has nothing to say about: the ones
+// another rule owns, the ones binding every interface correctly, and the ones
+// that never open a listener at all.
+func (r receiverBindsAllInterfaces) skip(ctx *Context, kind config.Kind, c config.Component) bool {
+	if kind == config.KindExtension {
+		if lo.ContainsBy(debugExtensions(), func(e debugExtension) bool { return e.typ == c.ID.Type }) {
+			return true // debug-extension-exposed says something sharper about these
+		}
+
+		if contains(probeExtensions(), c.ID.Type) {
+			return true
+		}
+
+		// service.extensions is the only thing that starts an extension, so a
+		// declaration left out of it opens no listener; unused-component has
+		// something to say about the declaration itself.
+		return !ctx.Index.Enabled(c.ID)
+	}
+
+	// A receiver no pipeline names is never instantiated, and binds nothing.
+	return !ctx.Index.Used(kind, c.ID)
+}
+
+func (r receiverBindsAllInterfaces) report(
+	ctx *Context, kind config.Kind, c config.Component, node *yaml.Node, path string,
+) {
+	if classifyEndpoint(node.Value) != exposureUnspecified {
+		return
+	}
+
+	ctx.Report(Finding{
+		Node: node, Path: path,
+		Message: quote(shortPath(path)) + " binds " + quote(node.Value) +
+			", every interface the host has, for " + string(kind) + " " + quote(c.ID.String()),
+		Hint: bindHint(endpointPort(node.Value)),
+		Docs: configSecurityDocs,
+	})
+}
+
+// bindHint names the fix upstream documents rather than only saying not to do
+// it: an interface chosen on purpose, and in Kubernetes the pod's own IP, which
+// the downward API supplies and which reaches other pods without also reaching
+// everything else the node is on.
+func bindHint(port mo.Option[string]) string {
+	loopback, pod := "127.0.0.1", "${env:MY_POD_IP}"
+	if p, known := port.Get(); known {
+		loopback, pod = loopback+":"+p, pod+":"+p
+	}
+
+	return "bind the interface you meant, e.g. " + loopback + " when every client is local; " +
+		"in Kubernetes write " + pod + ", the pod IP the downward API supplies"
 }

--- a/pkg/rule/security_test.go
+++ b/pkg/rule/security_test.go
@@ -554,3 +554,202 @@ func TestHealthCheckIsNotReported(t *testing.T) {
 		assert.Empty(t, found, "%s should not be reported", typ)
 	}
 }
+
+// receiving wraps otlp receiver protocol settings in a config that is otherwise
+// clean. The settings are written already indented by six spaces.
+func receiving(settings string) string {
+	return `
+receivers:
+  otlp:
+    protocols:
+` + settings + `
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`
+}
+
+func TestReceiverBindsAllInterfaces(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		endpoint string
+		want     bool // whether the endpoint should be reported
+	}{
+		"the IPv4 unspecified address": {endpoint: "0.0.0.0:4317", want: true},
+		"the IPv6 unspecified address": {endpoint: `"[::]:4317"`, want: true},
+		// What netstat prints for an IPv6 listener, and what gets copied from
+		// there. Go refuses the spelling outright, so the collector does not
+		// start; binding a specific interface fixes that as well.
+		"the IPv6 unspecified address without brackets": {endpoint: `":::4317"`, want: true},
+		// net.Listen reads a bare port as every interface too.
+		"a bare port":                   {endpoint: `":4317"`, want: true},
+		"the unspecified address alone": {endpoint: "0.0.0.0", want: true},
+		// The address says plainly who can reach it; only the port is left open.
+		"a port resolved at runtime": {endpoint: "0.0.0.0:${env:OTLP_PORT}", want: true},
+
+		"loopback":                        {endpoint: "localhost:4317", want: false},
+		"the loopback address":            {endpoint: "127.0.0.1:4317", want: false},
+		"the IPv6 loopback address":       {endpoint: `"[::1]:4317"`, want: false},
+		"one specific address":            {endpoint: "10.0.4.7:4317", want: false},
+		"the pod IP the docs name":        {endpoint: "${env:MY_POD_IP}:4317", want: false},
+		"an endpoint resolved at runtime": {endpoint: "${env:OTLP_ENDPOINT}", want: false},
+		// What a name resolves to is a property of the network, not of the file.
+		"a hostname this linter will not place": {endpoint: "collector.internal:4317", want: false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "receiver-binds-all-interfaces",
+				receiving("      grpc:\n        endpoint: "+tt.endpoint), rule.Environment{})
+
+			if !tt.want {
+				assert.Empty(t, found)
+
+				return
+			}
+
+			require.Len(t, found, 1)
+			assert.Equal(t, diag.Warning, found[0].Severity)
+			assert.Equal(t, "receivers.otlp.protocols.grpc.endpoint", found[0].Path)
+		})
+	}
+}
+
+// The finding has to say which of a component's endpoints is meant, and the
+// hint has to carry the fix upstream documents rather than only "do not".
+func TestReceiverBindsAllInterfacesReadsAsASentence(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "receiver-binds-all-interfaces",
+		receiving("      grpc:\n        endpoint: 0.0.0.0:4317"), rule.Environment{})
+	require.Len(t, found, 1)
+
+	assert.Equal(t, `"protocols.grpc.endpoint" binds "0.0.0.0:4317", every interface the host has, `+
+		`for receiver "otlp"`, found[0].Message)
+	assert.Equal(t, "bind the interface you meant, e.g. 127.0.0.1:4317 when every client is local; "+
+		"in Kubernetes write ${env:MY_POD_IP}:4317, the pod IP the downward API supplies",
+		found[0].Hint)
+	assert.Contains(t, found[0].Docs, "config-best-practices")
+
+	// A port nothing can read before the collector starts leaves the address it
+	// belongs to out of the suggestion rather than guessing at one.
+	runtimePort := checkRule(t, "receiver-binds-all-interfaces",
+		receiving("      grpc:\n        endpoint: 0.0.0.0:${env:OTLP_PORT}"), rule.Environment{})
+	require.Len(t, runtimePort, 1)
+	assert.Equal(t, "bind the interface you meant, e.g. 127.0.0.1 when every client is local; "+
+		"in Kubernetes write ${env:MY_POD_IP}, the pod IP the downward API supplies",
+		runtimePort[0].Hint)
+}
+
+// Every endpoint is reported, since each is a separate line to edit.
+func TestReceiverBindsAllInterfacesReportsEveryProtocol(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "receiver-binds-all-interfaces",
+		receiving("      grpc:\n        endpoint: 0.0.0.0:4317\n"+
+			"      http:\n        endpoint: 0.0.0.0:4318"), rule.Environment{})
+
+	require.Len(t, found, 2)
+	assert.Equal(t, "receivers.otlp.protocols.grpc.endpoint", found[0].Path)
+	assert.Equal(t, "receivers.otlp.protocols.http.endpoint", found[1].Path)
+}
+
+// An extension listens on its endpoint as much as a receiver does.
+func TestReceiverBindsAllInterfacesCoversExtensions(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "receiver-binds-all-interfaces",
+		extending("basicauth", "    endpoint: 0.0.0.0:8080"), rule.Environment{})
+
+	require.Len(t, found, 1)
+	assert.Equal(t, `"endpoint" binds "0.0.0.0:8080", every interface the host has, `+
+		`for extension "basicauth"`, found[0].Message)
+}
+
+func TestReceiverBindsAllInterfacesStaysQuiet(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		// An exporter's endpoint is a destination, not a bind address. 0.0.0.0
+		// there is a different mistake with a different fix.
+		"an exporter's endpoint": `
+receivers: {otlp: }
+exporters:
+  otlp:
+    endpoint: 0.0.0.0:4317
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlp]}
+`,
+		// A receiver no pipeline names is never instantiated, so it binds
+		// nothing; unused-component owns the declaration.
+		"a receiver nothing references": `
+receivers:
+  otlp: {}
+  otlp/unused:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4318
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+		// The extension is declared but never started, so no port is bound.
+		"an extension service.extensions leaves out": `
+receivers: {otlp: }
+exporters: {debug: }
+extensions:
+  basicauth:
+    endpoint: 0.0.0.0:8080
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+		// A receiver that writes no endpoint takes its own default, which has
+		// been localhost since v0.110.0.
+		"an endpoint nobody wrote": `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug]}
+`,
+	}
+
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Empty(t, checkRule(t, "receiver-binds-all-interfaces", src, rule.Environment{}))
+		})
+	}
+}
+
+// The debugging extensions are reported once, by the rule that says what they
+// hand out; the health checks are not reported at all, since the kubelet
+// reaches a liveness probe from off the container's loopback interface.
+func TestReceiverBindsAllInterfacesLeavesExtensionsToTheirOwnRules(t *testing.T) {
+	t.Parallel()
+
+	for _, typ := range []string{"pprof", "zpages"} {
+		src := extending(typ, "    endpoint: 0.0.0.0:1777")
+		assert.Empty(t, checkRule(t, "receiver-binds-all-interfaces", src, rule.Environment{}),
+			"%s is debug-extension-exposed's to report", typ)
+		assert.NotEmpty(t, checkRule(t, "debug-extension-exposed", src, rule.Environment{}),
+			"%s should still be reported by the rule that owns it", typ)
+	}
+
+	for _, typ := range []string{"health_check", "healthcheckv2"} {
+		assert.Empty(t, checkRule(t, "receiver-binds-all-interfaces",
+			extending(typ, "    endpoint: 0.0.0.0:13133"), rule.Environment{}),
+			"%s bound to every interface is a correct deployment", typ)
+	}
+}

--- a/pkg/rule/security_test.go
+++ b/pkg/rule/security_test.go
@@ -753,3 +753,49 @@ func TestReceiverBindsAllInterfacesLeavesExtensionsToTheirOwnRules(t *testing.T)
 			"%s bound to every interface is a correct deployment", typ)
 	}
 }
+
+// The stanza-based log receivers write the address they listen on under
+// listen_address rather than endpoint, and syslog carries one per transport.
+// Reading only endpoint would leave every one of them unreported.
+func TestReceiverBindsAllInterfacesReadsListenAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		name     string // the receiver declaration
+		settings string
+		path     string
+	}{
+		"tcplog": {
+			name:     "tcplog",
+			settings: "    listen_address: 0.0.0.0:54525",
+			path:     "receivers.tcplog.listen_address",
+		},
+		"udplog": {
+			name:     "udplog",
+			settings: `    listen_address: ":54526"`,
+			path:     "receivers.udplog.listen_address",
+		},
+		"syslog under a transport": {
+			name:     "syslog",
+			settings: "    tcp:\n      listen_address: 0.0.0.0:54527",
+			path:     "receivers.syslog.tcp.listen_address",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			src := "receivers:\n  " + tt.name + ":\n" + tt.settings + `
+exporters: {debug: }
+service:
+  pipelines:
+    logs: {receivers: [` + tt.name + `], exporters: [debug]}
+`
+
+			found := checkRule(t, "receiver-binds-all-interfaces", src, rule.Environment{})
+			require.Len(t, found, 1)
+			assert.Equal(t, tt.path, found[0].Path)
+		})
+	}
+}

--- a/testdata/valid/agent.yaml
+++ b/testdata/valid/agent.yaml
@@ -1,11 +1,14 @@
 # A collector running as a node agent: receive OTLP, limit memory, batch, ship.
+# The endpoints take the pod's own IP from the downward API, which is reachable
+# from the workloads that send to it without also listening on every other
+# interface the node has.
 receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: ${env:MY_POD_IP}:4317
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: ${env:MY_POD_IP}:4318
 
 processors:
   memory_limiter:


### PR DESCRIPTION
Closes #45.

## What

`receiver-binds-all-interfaces`, at `diag.Warning`, joins the **Security** group in `pkg/rule/security.go`. It walks every declared receiver's and extension's settings for an `endpoint` key and reports one bound to the unspecified address.

```
config.yaml:5:19: warning: "protocols.grpc.endpoint" binds "0.0.0.0:4317", every interface the host has, for receiver "otlp" [receiver-binds-all-interfaces]
    hint: bind the interface you meant, e.g. 127.0.0.1:4317 when every client is local; in Kubernetes write ${env:MY_POD_IP}:4317, the pod IP the downward API supplies
    docs: https://opentelemetry.io/docs/security/config-best-practices/
```

The hint keeps the port the config already names, so it is a line the reader can paste; where the port is itself an expansion it suggests the address alone rather than guessing at one.

## What it matches

`0.0.0.0`, `[::]`, a bare `:4317`, and `:::4317` — the last is what netstat prints for an IPv6 listener, so it gets copied into configs from there. Go refuses that spelling outright ("too many colons in address"), so a collector handed one does not start at all; reading it as `[::]:4317` keeps the finding about the address whoever wrote it meant, and binding a specific interface fixes both halves at once. `bracketed()` does that rewrite in front of the existing `endpointHost`, so `debug-extension-exposed` picks the spelling up too.

An address with no port (`0.0.0.0`) is matched as well, and `0.0.0.0:${env:PORT}` still is — the address says plainly who can reach it, and only the port is left open. `${env:MY_POD_IP}:4317` is the fix, so it is not a finding.

The walk is by key name rather than by a table of where each component keeps its endpoint: `otlp` writes one per protocol, most others write one at the top, and each hit is reported separately because each is its own line to edit. It reuses `walkSettings`/`childNode`, so a `<<` merge and an anchored block are read the same way the other endpoint rule reads them.

## When it stays quiet

- **Exporters and connectors.** Their `endpoint` is a destination, not a bind address. `0.0.0.0` there is also wrong, but differently wrong, and a bind-address hint on a line about a backend would be worse than silence. The split is by kind, which is the cheapest correct one.
- **`pprof` and `zpages`.** `debug-extension-exposed` owns them and says something sharper — what the endpoint hands out. The TODO its doc comment carried about this rule ("should it ever grow to cover extensions…") is now discharged in code.
- **`health_check` and `healthcheckv2`.** The deliberate deviation from the issue, for the reason `debug-extension-exposed` already documents: a Kubernetes liveness probe comes from the kubelet, off the container's loopback interface, so a health check bound to `0.0.0.0` is what a correct deployment looks like. A rule that fires on every correct config is a rule people disable, and that would take the receivers down with it.
- **Anything never instantiated.** A receiver no pipeline names and an extension `service.extensions` leaves out bind no port; `unused-component` owns those declarations.
- **An endpoint nobody wrote**, which takes the component's own default — `localhost` since `v0.110.0`.
- **`localhost`, a loopback address, a specific address, and a hostname**, via the existing `classifyEndpoint`. Only `exposureUnspecified` is reported here; the specific-address `info` clause stays particular to the debugging extensions, whose exposure is a different thing to weigh.

`Warning` rather than `Error`: a gateway behind a service mesh with its own network policy binds every interface deliberately.

## Fixtures

`testdata/valid/agent.yaml` and `rule_test.go`'s `clean` both bound `0.0.0.0`, which is the point of the issue — the linter's own examples had the anti-pattern in them. The node agent now takes the pod IP from the downward API, with a comment saying why, and `clean` binds `localhost`.

## Tests

`pkg/rule/security_test.go` covers every spelling matched and every one skipped, the exact message/hint/path/severity, the hint with a runtime port, both `otlp` protocols reported separately, an extension endpoint, the four quiet cases above, and that `pprof`/`zpages` are reported by the rule that owns them and not by this one. `TestCleanConfigIsQuiet` and `TestRules` are extended rather than relaxed.

`go test ./...` and `golangci-lint run` are clean, and the binary was run against the fixtures to check the output above reads as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
