### PR TITLE
feat(rule): report enrichment that runs after sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,16 +241,40 @@ such as Prometheus's own — is left open rather than reported, so partial
 coverage never produces false positives. `${env:...}` expansions are left
 alone.
 
-**Practice** — `processor-order` (memory_limiter first), `missing-memory-limiter`,
+**Practice** — `processor-order` (`memory_limiter` first, enrichment before
+sampling, `batch` last), `missing-memory-limiter`,
 `missing-batch`, `memory-limiter-config`, `memory-limiter-sizing`,
 `batch-size-bounds`, `no-persistent-queue`, `debug-exporter-verbosity`.
 
 **Security** — `insecure-tls`, `debug-extension-exposed`, `hardcoded-secret`.
 
 Every practice and security rule cites the upstream page it rests on — the
-`memorylimiterprocessor`, `batchprocessor`, `exporterhelper` and
-`debugexporter` READMEs, `configtls`, upstream's security best practices, and
-the Kubernetes resource docs for the container's request and limit.
+`memorylimiterprocessor`, `batchprocessor`, `exporterhelper`, `debugexporter`,
+`tailsamplingprocessor` and `probabilisticsamplerprocessor` READMEs,
+`configtls`, upstream's security best practices, and the Kubernetes resource
+docs for the container's request and limit.
+
+`processor-order` is about where a processor stands rather than what it is set
+to. Two of its clauses are the ends of the chain: `memory_limiter` first, so
+backpressure is applied before any work is done, and `batch` last, so the
+processors ahead of it see individual items. The third is the middle, where the
+two orders are equally valid YAML and only one of them works.
+
+```yaml
+processors: [memory_limiter, tail_sampling, k8sattributes, batch]
+#                            ^^^^^^^^^^^^^ decides before the pod and namespace are on the span
+```
+
+`k8sattributes` — and `k8s_attributes`, the name upstream renamed it to —
+`resourcedetection` and `resource` add the attributes a sampling policy is
+written against, so a policy matching one of them from behind
+`tail_sampling` or `probabilistic_sampler` matches nothing at all — no error, no
+crash, just the spans it was meant to keep going missing. `tail_sampling`'s own
+README states the other half of it: the processor reassembles spans into new
+batches, so anything reading the request context has to have run already.
+`attributes` is deliberately left out of the group, because it redacts as often
+as it enriches and stripping fields from what a sampler kept is the right order
+to do that in.
 
 `memory_limiter` is the one processor this linter tells people to add, and two
 of its constraints cannot be written as a field schema:

--- a/README.md
+++ b/README.md
@@ -265,9 +265,10 @@ processors: [memory_limiter, tail_sampling, k8sattributes, batch]
 #                            ^^^^^^^^^^^^^ decides before the pod and namespace are on the span
 ```
 
-`k8sattributes` — and `k8s_attributes`, the name upstream renamed it to —
-`resourcedetection` and `resource` add the attributes a sampling policy is
-written against, so a policy matching one of them from behind
+`k8sattributes`, `resourcedetection` and `resource` add the attributes a
+sampling policy is written against — as do `k8s_attributes` and
+`resource_detection`, the names upstream renamed the first two to, which both
+count — so a policy matching one of them from behind
 `tail_sampling` or `probabilistic_sampler` matches nothing at all — no error, no
 crash, just the spans it was meant to keep going missing. `tail_sampling`'s own
 README states the other half of it: the processor reassembles spans into new

--- a/pkg/rule/docs.go
+++ b/pkg/rule/docs.go
@@ -18,6 +18,18 @@ const (
 	// batchDocs states what batching is for and where it belongs.
 	batchDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
 		"/blob/main/processor/batchprocessor/README.md"
+	// tailSamplingDocs states that the processor must be placed after any
+	// processor that relies on request context, k8sattributes among them,
+	// because it reassembles spans into new batches and the original context
+	// is lost. It is also where the policies that read attributes are
+	// documented.
+	tailSamplingDocs = "https://github.com/open-telemetry/opentelemetry-collector-contrib" +
+		"/blob/main/processor/tailsamplingprocessor/README.md"
+	// probabilisticSamplerDocs states which attributes the sampler can decide
+	// on -- from_attribute, sampling_priority, and the resource attribute a
+	// hash seed is taken from.
+	probabilisticSamplerDocs = "https://github.com/open-telemetry/opentelemetry-collector-contrib" +
+		"/blob/main/processor/probabilisticsamplerprocessor/README.md"
 	// debugDocs states what each verbosity prints, that detailed writes
 	// multiple lines per record, that sampling_initial and sampling_thereafter
 	// bound the rate, and that the output format is not stable.

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -41,16 +41,19 @@ const (
 // against, and sampling decides what is kept. These are matched on type too,
 // so k8sattributes/pods and tail_sampling/errors are covered.
 //
-// k8s_attributes is the name upstream renamed k8sattributes to. Both resolve,
-// and which one a file writes is deprecated-component's to say, so the group
-// carries both.
+// Two of the enrichment processors have been renamed upstream, and both
+// spellings still resolve, so the group carries both of each: a config written
+// against a recent release uses the new name, one written before v0.157.0 the
+// old one, and which of them a file should say is deprecated-component's
+// business rather than this rule's.
 const (
-	k8sattributesType        = "k8sattributes"
-	k8sAttributesType        = "k8s_attributes"
-	resourcedetectionType    = "resourcedetection"
-	resourceType             = "resource"
-	tailSamplingType         = "tail_sampling"
-	probabilisticSamplerType = "probabilistic_sampler"
+	k8sattributesType            = "k8sattributes"
+	k8sAttributesRenamedType     = "k8s_attributes"
+	resourcedetectionType        = "resourcedetection"
+	resourcedetectionRenamedType = "resource_detection"
+	resourceType                 = "resource"
+	tailSamplingType             = "tail_sampling"
+	probabilisticSamplerType     = "probabilistic_sampler"
 )
 
 // verbosityKey is the debug exporter's setting for how much of every record it
@@ -107,7 +110,7 @@ func (r processorOrder) Check(ctx *Context) {
 				})
 			}
 
-			if sampler, decided := samplerBefore(p.Processors, i); decided {
+			if sampler, docs, decided := samplerBefore(p.Processors, i); decided {
 				ctx.Report(Finding{
 					Node: ref.Node, Path: ref.Path,
 					Message: quote(ref.ID.String()) + " runs after " + quote(sampler.ID.String()) +
@@ -115,7 +118,7 @@ func (r processorOrder) Check(ctx *Context) {
 						", so sampling policies cannot match the attributes it adds",
 					Hint: "move " + quote(ref.ID.String()) + " ahead of " + quote(sampler.ID.String()) +
 						" in " + path + " so the decision is made against enriched telemetry",
-					Docs: samplerDocs(sampler.ID.Type),
+					Docs: docs,
 				})
 			}
 		}
@@ -141,41 +144,59 @@ func (r processorOrder) Check(ctx *Context) {
 //
 // The first sampler is the one named because it is the one to move past;
 // getting ahead of it clears any that follow.
-func samplerBefore(refs []config.Ref, i int) (config.Ref, bool) {
+func samplerBefore(refs []config.Ref, i int) (config.Ref, string, bool) {
 	if !enriches(refs[i].ID.Type) {
-		return config.Ref{}, false
+		return config.Ref{}, "", false
 	}
 
 	for _, before := range refs[:i] {
-		if samples(before.ID.Type) {
-			return before, true
+		if docs, decides := samplerDocs(before.ID.Type); decides {
+			return before, docs, true
 		}
 	}
 
-	return config.Ref{}, false
+	return config.Ref{}, "", false
 }
 
 // enriches reports whether the processor type adds attributes a sampling
 // decision could be written against.
+//
+// resource is in the group for the attributes it writes rather than for where
+// it reads them from: service.name, deployment.environment and the cluster are
+// what a policy selecting one environment's traces matches on, and a resource
+// processor behind the sampler leaves that policy matching nothing. It can
+// delete as well as write, which is the argument that keeps attributes out, but
+// deleting a resource-level attribute after sampling is rare enough that the
+// grouping is worth the occasional false positive; attributes, whose whole
+// second job is stripping fields off what was kept, is not.
 func enriches(typ string) bool {
 	return slices.Contains([]string{
-		k8sattributesType, k8sAttributesType, resourcedetectionType, resourceType,
+		k8sattributesType, k8sAttributesRenamedType,
+		resourcedetectionType, resourcedetectionRenamedType,
+		resourceType,
 	}, typ)
 }
 
-// samples reports whether the processor type decides what is kept.
-func samples(typ string) bool {
-	return slices.Contains([]string{tailSamplingType, probabilisticSamplerType}, typ)
-}
-
-// samplerDocs returns the page stating what the sampler decides on, which is
-// what says why the enrichment has to come first.
-func samplerDocs(typ string) string {
-	if typ == probabilisticSamplerType {
-		return probabilisticSamplerDocs
+// samplerDocs reports whether the processor type decides what is kept, and
+// returns the page documenting what that decision is made of -- which is also
+// the page that says why the enrichment has to come first.
+//
+// Both answers come out of one switch on purpose: a sampler added to the group
+// has to bring its own page with it rather than inheriting the one next to it,
+// so a third type cannot quietly cite tail_sampling's README.
+//
+// dynamic_sampling is deliberately absent. It is at development stability in
+// contrib, and reporting the ordering of a component whose settings are still
+// moving would be guessing.
+func samplerDocs(typ string) (string, bool) {
+	switch typ {
+	case tailSamplingType:
+		return tailSamplingDocs, true
+	case probabilisticSamplerType:
+		return probabilisticSamplerDocs, true
+	default:
+		return "", false
 	}
-
-	return tailSamplingDocs
 }
 
 type missingMemoryLimiter struct{ base }

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -14,7 +15,8 @@ import (
 func practiceRules() []Rule {
 	return []Rule{
 		processorOrder{base{"processor-order",
-			"memory_limiter must run first so backpressure is applied before any work", diag.Warning}},
+			"processors run in the order they are listed, and some of them have one place they work",
+			diag.Warning}},
 		missingMemoryLimiter{base{"missing-memory-limiter",
 			"a pipeline without memory_limiter can be OOM-killed under load", diag.Info}},
 		missingBatch{base{"missing-batch",
@@ -34,6 +36,23 @@ const (
 	debugType         = "debug"
 )
 
+// The two groups processor-order has something to say about between the ends
+// of the chain: enrichment adds the attributes a sampling decision is written
+// against, and sampling decides what is kept. These are matched on type too,
+// so k8sattributes/pods and tail_sampling/errors are covered.
+//
+// k8s_attributes is the name upstream renamed k8sattributes to. Both resolve,
+// and which one a file writes is deprecated-component's to say, so the group
+// carries both.
+const (
+	k8sattributesType        = "k8sattributes"
+	k8sAttributesType        = "k8s_attributes"
+	resourcedetectionType    = "resourcedetection"
+	resourceType             = "resource"
+	tailSamplingType         = "tail_sampling"
+	probabilisticSamplerType = "probabilistic_sampler"
+)
+
 // verbosityKey is the debug exporter's setting for how much of every record it
 // writes, and detailedLevel the value that writes all of it.
 const (
@@ -48,6 +67,16 @@ const (
 	storageKey      = "storage"
 )
 
+// processorOrder reports a processor standing in the wrong place in a
+// pipeline. Its three clauses are the same finding in three positions: the
+// config loads, the collector runs, and what comes out the far end is not what
+// the author asked for.
+//
+// Two of them are about the ends of the chain -- memory_limiter first so
+// backpressure is applied before any work is done, batch last so the
+// processors ahead of it see individual items. The third is about the middle,
+// where enrichment and sampling can be written in either order and only one of
+// them is the order that works.
 type processorOrder struct{ base }
 
 func (r processorOrder) Check(ctx *Context) {
@@ -77,8 +106,76 @@ func (r processorOrder) Check(ctx *Context) {
 					Severity: diag.Info,
 				})
 			}
+
+			if sampler, decided := samplerBefore(p.Processors, i); decided {
+				ctx.Report(Finding{
+					Node: ref.Node, Path: ref.Path,
+					Message: quote(ref.ID.String()) + " runs after " + quote(sampler.ID.String()) +
+						" in pipeline " + quote(p.Key) +
+						", so sampling policies cannot match the attributes it adds",
+					Hint: "move " + quote(ref.ID.String()) + " ahead of " + quote(sampler.ID.String()) +
+						" in " + path + " so the decision is made against enriched telemetry",
+					Docs: samplerDocs(sampler.ID.Type),
+				})
+			}
 		}
 	}
+}
+
+// samplerBefore returns the first sampling processor standing ahead of the
+// processor at i, when that processor is one that enriches.
+//
+// A sampler decides what to keep from what it can see. k8sattributes,
+// resourcedetection and resource each add attributes -- the pod and namespace,
+// the cloud region and host, whatever the config writes -- and a policy
+// matching on one of them behind the sampler matches nothing at all. Nothing
+// errors: the policy is valid, the attribute is simply not there yet, and the
+// spans it was meant to keep are dropped. tail_sampling has a second reason,
+// which its README states outright: it reassembles spans into new batches, so
+// anything reading the request context has to have run already.
+//
+// attributes is deliberately not in the group. It enriches and it redacts, and
+// redaction after sampling is the sensible order -- sample first, then strip
+// what is kept -- so including it would report a correct config as often as a
+// wrong one.
+//
+// The first sampler is the one named because it is the one to move past;
+// getting ahead of it clears any that follow.
+func samplerBefore(refs []config.Ref, i int) (config.Ref, bool) {
+	if !enriches(refs[i].ID.Type) {
+		return config.Ref{}, false
+	}
+
+	for _, before := range refs[:i] {
+		if samples(before.ID.Type) {
+			return before, true
+		}
+	}
+
+	return config.Ref{}, false
+}
+
+// enriches reports whether the processor type adds attributes a sampling
+// decision could be written against.
+func enriches(typ string) bool {
+	return slices.Contains([]string{
+		k8sattributesType, k8sAttributesType, resourcedetectionType, resourceType,
+	}, typ)
+}
+
+// samples reports whether the processor type decides what is kept.
+func samples(typ string) bool {
+	return slices.Contains([]string{tailSamplingType, probabilisticSamplerType}, typ)
+}
+
+// samplerDocs returns the page stating what the sampler decides on, which is
+// what says why the enrichment has to come first.
+func samplerDocs(typ string) string {
+	if typ == probabilisticSamplerType {
+		return probabilisticSamplerDocs
+	}
+
+	return tailSamplingDocs
 }
 
 type missingMemoryLimiter struct{ base }

--- a/pkg/rule/practice_test.go
+++ b/pkg/rule/practice_test.go
@@ -79,10 +79,14 @@ func TestProcessorOrderEnrichmentAfterSampling(t *testing.T) {
 			processors: []string{"tail_sampling", "k8sattributes"},
 			want:       1,
 		},
-		// The same processor under the name upstream renamed it to, which is
-		// what a config written against a recent release carries.
+		// The same two processors under the names upstream renamed them to,
+		// which is what a config written against a recent release carries.
 		"the k8s attributes processor under its new name": {
 			processors: []string{"tail_sampling", "k8s_attributes"},
+			want:       1,
+		},
+		"the resource detection processor under its new name": {
+			processors: []string{"probabilistic_sampler", "resource_detection"},
 			want:       1,
 		},
 		"the same two the way round that works": {

--- a/pkg/rule/practice_test.go
+++ b/pkg/rule/practice_test.go
@@ -1,6 +1,7 @@
 package rule_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,134 @@ service:
   pipelines:
     traces: {receivers: [otlp], exporters: [debug]}
 `
+}
+
+// ordering wraps a processor list in a config that is otherwise clean, with
+// every processor in the list declared so the pipeline references nothing that
+// does not exist.
+func ordering(processors ...string) string {
+	var declared strings.Builder
+	for _, p := range processors {
+		declared.WriteString("  " + p + ":\n")
+	}
+
+	return `
+receivers: {otlp: }
+processors:
+` + declared.String() + `exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [` + strings.Join(processors, ", ") + `], exporters: [debug]}
+`
+}
+
+// A sampler decides on what it can see, so an enrichment processor behind one
+// is a policy matching attributes that are not there yet. None of these lists
+// carry a memory_limiter or a batch, so what the rule reports is the middle of
+// the chain and nothing else.
+func TestProcessorOrderEnrichmentAfterSampling(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		processors []string
+		want       int
+	}{
+		"k8s attributes added after the sampling decision": {
+			processors: []string{"tail_sampling", "k8sattributes"},
+			want:       1,
+		},
+		// The same processor under the name upstream renamed it to, which is
+		// what a config written against a recent release carries.
+		"the k8s attributes processor under its new name": {
+			processors: []string{"tail_sampling", "k8s_attributes"},
+			want:       1,
+		},
+		"the same two the way round that works": {
+			processors: []string{"k8sattributes", "tail_sampling"},
+			want:       0,
+		},
+		"cloud and host attributes added after the decision": {
+			processors: []string{"probabilistic_sampler", "resourcedetection"},
+			want:       1,
+		},
+		"attributes the config writes itself, added after the decision": {
+			processors: []string{"tail_sampling", "resource"},
+			want:       1,
+		},
+		// attributes is left out of the group on purpose: stripping fields
+		// from what a sampler kept is the right order to do it in.
+		"an attributes processor after the decision": {
+			processors: []string{"tail_sampling", "attributes"},
+			want:       0,
+		},
+		// filter belongs between enrichment and sampling in the documented
+		// order, but a filter that drops early is a filter doing its job.
+		"a filter after the decision": {
+			processors: []string{"tail_sampling", "filter"},
+			want:       0,
+		},
+		"two enrichment processors behind one sampler": {
+			processors: []string{"tail_sampling", "k8sattributes", "resource"},
+			want:       2,
+		},
+		"a pipeline with no sampler in it at all": {
+			processors: []string{"resource", "k8sattributes"},
+			want:       0,
+		},
+		// Matching on the type is what covers the named instances, which is
+		// how a second sampling policy set is usually written.
+		"named instances of both": {
+			processors: []string{"tail_sampling/errors", "k8sattributes/pods"},
+			want:       1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "processor-order", ordering(tt.processors...), rule.Environment{})
+			assert.Len(t, found, tt.want)
+
+			for _, d := range found {
+				assert.Equal(t, diag.Warning, d.Severity)
+			}
+		})
+	}
+}
+
+// The finding has to name both processors, since neither one on its own says
+// what is wrong, and it reports at the rule's own severity rather than at the
+// batch clause's info.
+func TestProcessorOrderEnrichmentReadsAsASentence(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "processor-order",
+		ordering("memory_limiter", "tail_sampling", "k8sattributes/pods"), rule.Environment{})
+	require.Len(t, found, 1)
+
+	assert.Equal(t, diag.Warning, found[0].Severity)
+	assert.Equal(t, `"k8sattributes/pods" runs after "tail_sampling" in pipeline "traces", `+
+		"so sampling policies cannot match the attributes it adds", found[0].Message)
+	assert.Equal(t, `move "k8sattributes/pods" ahead of "tail_sampling" in `+
+		"service.pipelines.traces.processors so the decision is made against enriched telemetry",
+		found[0].Hint)
+	assert.Equal(t, "service.pipelines.traces.processors[2]", found[0].Path)
+	assert.Contains(t, found[0].Docs, "processor/tailsamplingprocessor/README.md")
+}
+
+// Getting ahead of the first sampler clears the ones behind it, so that is the
+// one the finding names -- and the page it cites is the one that sampler's
+// decision is documented on.
+func TestProcessorOrderNamesTheFirstSampler(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "processor-order",
+		ordering("probabilistic_sampler", "tail_sampling", "resourcedetection"), rule.Environment{})
+	require.Len(t, found, 1)
+
+	assert.Contains(t, found[0].Message, `runs after "probabilistic_sampler"`)
+	assert.Contains(t, found[0].Docs, "processor/probabilisticsamplerprocessor/README.md")
 }
 
 func TestDebugExporterVerbosity(t *testing.T) {

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -557,6 +557,20 @@ service:
 `,
 			path: "service.pipelines.traces.processors[0]",
 		},
+		// The third clause, which reports the processor in the middle of the
+		// chain rather than at either end of it.
+		"an enrichment processor behind a sampler": {
+			rule: "processor-order",
+			src: `
+receivers: {otlp: }
+processors: {tail_sampling: , k8sattributes: }
+exporters: {debug: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [tail_sampling, k8sattributes], exporters: [debug]}
+`,
+			path: "service.pipelines.traces.processors[1]",
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
Closes #49

## What

`processor-order` gets a third clause, for the middle of the chain rather than its ends.

`k8sattributes`, `resourcedetection` and `resource` add the attributes a sampling policy is written against. Put one of them behind `tail_sampling` or `probabilistic_sampler` and the config loads, the collector runs, and the policy matches nothing — the attribute is not on the span yet, so the spans it was meant to keep are dropped with the rest.

```yaml
processors: [memory_limiter, tail_sampling, k8sattributes, batch]
#                            ^^^^^^^^^^^^^ decides before the pod and namespace are on the span
```

```
order.yaml:24:51: warning: "k8sattributes/pods" runs after "tail_sampling" in pipeline "traces", so sampling policies cannot match the attributes it adds [processor-order]
    hint: move "k8sattributes/pods" ahead of "tail_sampling" in service.pipelines.traces.processors so the decision is made against enriched telemetry
    docs: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/tailsamplingprocessor/README.md
```

Reports at the rule's default `warning`, not the batch clause's `info`.

## Decisions

- **`attributes` is out of the group**, as the issue suggested: it redacts as often as it enriches, and stripping fields from what a sampler kept is the right order to do that in.
- **`filter` is out too.** The issue floated filtering-before-enrichment as the same rule shape, but it is not the same call — upstream's own [processor ordering guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md#recommended-processors) puts anything that drops data early, so a `filter` behind an enricher is often deliberate. Left for a follow-up if you want it.
- **`k8s_attributes` is in the group** alongside `k8sattributes`. Upstream renamed the processor and both names resolve in v0.157.0; a config written against a recent release would otherwise slip past.
- **Docs link follows the sampler.** `tail_sampling`'s README states the ordering outright ("must be placed in pipelines after any processors that rely on context, e.g. `k8sattributes`"), and the probabilistic sampler's is where `from_attribute` and `sampling_priority` are documented.
- **The first sampler ahead of the processor is the one named**, since getting past it clears any that follow.
- `processor-order`'s one-line description no longer says only "memory_limiter must run first", because the rule no longer does.

## Tests

New table in `practice_test.go` covering both orders, all four enrichment types, both samplers, named instances, two enrichers behind one sampler, and the deliberate misses (`attributes`, `filter`, no sampler at all); message/hint/path/docs asserted verbatim; a path case added to `TestServiceReferencePathsAreWrittenOnce` for the third clause. Existing `processor-order` tests unchanged and passing. `golangci-lint run` clean, `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)