### PR TITLE
feat(rule): recognise batching an exporter does in its own queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,41 @@ case-insensitively, so `tenant` and `Tenant` are one key. Both sizes are
 negative or over-large count is reported here too — it fails to load rather than
 to validate, and saying so beats hinting at a fix that still will not start.
 
+`missing-batch` reports a pipeline that batches nothing on its way out, and
+there are now two ways not to be one. `exporterhelper` batches inside the
+sending queue, under `sending_queue.batch`, which sits behind the queue and the
+retry logic rather than in front of them; the `batch` processor
+[drops the data in a batch that fails to send](https://github.com/open-telemetry/opentelemetry-collector/issues/12443),
+and the queue batcher does not. That is why the hint leads with the exporter
+setting and names the processor as what also works. The processor is not
+deprecated — upstream has explicitly not decided that — so a pipeline that uses
+it is a pipeline that batches, and nothing here says to take it out.
+
+```yaml
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue:
+      batch:                   # off by default; writing the block turns it on
+        flush_timeout: 200ms
+```
+
+A pipeline whose exporters all do that gets no finding: it batches, and a
+`batch` processor added on top would be a second layer with a flush timing of
+its own. Where only some of them do, the pipeline is under-batched on the legs
+that do not, so the finding names the exporter and sits on the line that wires
+it in — that exporter's settings are where the fix is written. A connector in
+the exporter slot is not a leg out of the collector and is not counted; it feeds
+another pipeline, which has exporters of its own. An exporter whose settings
+come from a merge key or an expansion, and one whose type the field schema does
+not describe, count as unknown rather than as not batching, for the same reason
+the field rules leave what they cannot resolve alone.
+
+The hint follows the schema rather than the other way round: where the exporters
+have no `sending_queue` to hold a batcher — `nop`, and `debug` on a release
+before upstream gave it a queue — it names the processor instead, because a fix
+the component has no setting for is no fix.
+
 `no-persistent-queue` is the one opinionated rule, and it reports at `info` for
 that reason. The sending queue is on by default and lives in memory, so a
 deploy, an OOM kill or a node drain takes everything still in it — and nothing

--- a/pkg/rule/docs.go
+++ b/pkg/rule/docs.go
@@ -27,7 +27,8 @@ const (
 	tlsDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
 		"/blob/main/config/configtls/README.md"
 	// exporterQueueDocs states that sending_queue.storage names the storage
-	// extension a persistent queue writes through.
+	// extension a persistent queue writes through, and that sending_queue.batch
+	// batches behind the queue, with the defaults flush_timeout takes.
 	exporterQueueDocs = "https://github.com/open-telemetry/opentelemetry-collector" +
 		"/blob/main/exporter/exporterhelper/README.md"
 	// authDocs states that auth.authenticator names an extension, and which

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -41,11 +41,13 @@ const (
 	detailedLevel = "detailed"
 )
 
-// sendingQueueKey is the exporter setting holding the queue, and storageKey the
-// field inside it that makes the queue persistent.
+// sendingQueueKey is the exporter setting holding the queue, storageKey the
+// field inside it that makes the queue persistent, and batchKey the one that
+// batches behind it.
 const (
 	sendingQueueKey = "sending_queue"
 	storageKey      = "storage"
+	batchKey        = "batch"
 )
 
 type processorOrder struct{ base }
@@ -98,6 +100,25 @@ func (r missingMemoryLimiter) Check(ctx *Context) {
 	}
 }
 
+// missingBatch reports a pipeline that batches nothing on its way out.
+//
+// The batch processor is one way to do it and no longer the only one:
+// exporterhelper batches inside the sending queue, under sending_queue.batch,
+// which sits behind the queue and the retry logic rather than in front of them.
+// That is the difference the hint leads with. The processor drops the data in a
+// batch that fails to send, upstream issue 12443, and the queue batcher does
+// not; upstream is steering towards the latter and taking the processor out of
+// its own documentation.
+//
+// It is not steering people away from the processor -- that has explicitly not
+// been decided -- so a pipeline that uses it is still a pipeline that batches
+// and nothing here says otherwise.
+//
+// A pipeline whose exporters all batch in their own queues gets no finding: it
+// batches, and a batch processor added on top of it would be a second layer
+// with a flush timing of its own. A pipeline where only some of them do is
+// under-batched on the legs that do not, so the finding names the exporter
+// rather than the pipeline.
 type missingBatch struct{ base }
 
 func (r missingBatch) Check(ctx *Context) {
@@ -106,13 +127,231 @@ func (r missingBatch) Check(ctx *Context) {
 			continue
 		}
 
-		ctx.Report(Finding{
-			Node: nodeOr(p.ProcessorsNode, p.KeyNode), Path: "service.pipelines." + p.Key + ".processors",
-			Message: "pipeline " + quote(p.Key) + " has no batch processor",
-			Hint:    "add batch before the exporters to reduce the number of outgoing requests",
-			Docs:    batchDocs,
-		})
+		legs, unbatched := exportLegs(ctx, p)
+		if len(unbatched) == 0 {
+			continue
+		}
+
+		// Only when every leg is one this rule can read, and none of them
+		// batches, is "the pipeline batches nothing" a claim the file supports.
+		if len(unbatched) == legs {
+			queued := anyQueued(unbatched)
+
+			ctx.Report(Finding{
+				Node: nodeOr(p.ProcessorsNode, p.KeyNode), Path: "service.pipelines." + p.Key + ".processors",
+				Message: "pipeline " + quote(p.Key) + " has no batch processor, and none of its exporters " +
+					"batches in " + sendingQueueKey,
+				Hint: batchHint("the exporters", "these exporters have", queued),
+				Docs: batchDocsFor(queued),
+			})
+
+			continue
+		}
+
+		for _, leg := range unbatched {
+			ctx.Report(Finding{
+				Node: leg.ref.Node, Path: leg.ref.Path,
+				Message: "exporter " + quote(leg.ref.ID.String()) + " sends unbatched in pipeline " +
+					quote(p.Key) + ", which has no batch processor",
+				Hint: batchHint("this exporter", "this exporter has", leg.queued),
+				Docs: batchDocsFor(leg.queued),
+			})
+		}
 	}
+}
+
+// batchHint renders the fix. It leads with the queue batcher, which is where
+// upstream is steering and which sits behind the retry logic rather than in
+// front of it -- unless the exporters have no queue to put it in, and then the
+// processor is the only batching on offer. "target" names what to configure
+// and "subject" agrees with the verb after it.
+func batchHint(target, subject string, queued bool) string {
+	if !queued {
+		return "add batch before the exporters to reduce the number of outgoing requests; " +
+			subject + " no " + sendingQueueKey + " to batch in"
+	}
+
+	return "configure " + sendingQueueKey + "." + batchKey + " on " + target + ", which batches behind the " +
+		"retry queue; the batch processor also works but drops data that fails to send"
+}
+
+// batchDocsFor points at the page the hint rests on: the queue batcher's
+// settings, or the processor's where the exporters have no queue to hold one.
+func batchDocsFor(queued bool) string {
+	if !queued {
+		return batchDocs
+	}
+
+	return exporterQueueDocs
+}
+
+// unbatchedLeg is an exporter reference whose exporter batches nothing, and
+// whether that exporter has a sending queue to batch in at all. One that does
+// not -- debug and nop among them -- can only be batched in front of, and a
+// hint naming a setting it does not have would be no fix.
+type unbatchedLeg struct {
+	ref    config.Ref
+	queued bool
+}
+
+// anyQueued reports whether any of the legs has a queue to batch in, which is
+// what decides the wording of a finding that covers all of them at once.
+func anyQueued(legs []unbatchedLeg) bool {
+	for _, leg := range legs {
+		if leg.queued {
+			return true
+		}
+	}
+
+	return false
+}
+
+// exportLegs reads what each of a pipeline's exporters does about batching. It
+// returns how many legs leave the collector here -- a connector is not one, it
+// feeds another pipeline that has exporters of its own -- and the ones whose
+// exporter demonstrably batches nothing.
+func exportLegs(ctx *Context, p config.Pipeline) (int, []unbatchedLeg) {
+	legs, unbatched := 0, []unbatchedLeg(nil)
+
+	for _, ref := range p.Exporters {
+		c, declared := ctx.Index.Resolve(config.KindExporter, ref.ID)
+		if declared && c.Kind == config.KindConnector {
+			continue
+		}
+
+		legs++
+
+		// An exporter nobody declared has no settings to read, and the collector
+		// does not start at all; undefined-reference is what reports it.
+		if !declared {
+			continue
+		}
+
+		if state, queued := queueBatching(ctx, c); state == batchNone {
+			unbatched = append(unbatched, unbatchedLeg{ref: ref, queued: queued})
+		}
+	}
+
+	return legs, unbatched
+}
+
+// batching is what a config settles about an exporter's own batching.
+type batching int
+
+const (
+	// batchUnknown is an exporter this rule cannot read: one whose settings a
+	// merge key or an expansion supplies, or a type the field schema does not
+	// describe. Neither a finding against it nor one that counts it as batching
+	// would rest on anything.
+	batchUnknown batching = iota
+	// batchNone is an exporter that batches nothing before it sends.
+	batchNone
+	// batchQueue is an exporter batching inside its sending queue.
+	batchQueue
+)
+
+// queueBatching reports whether an exporter batches what it sends, and whether
+// it has a sending queue to batch in at all.
+//
+// The queue batcher is off by default, so an exporter that does not write it is
+// an exporter that does not batch -- but only where the field schema describes
+// the type at all. Where it does not, the same principle the field rules follow
+// applies: what cannot be resolved says nothing rather than something wrong,
+// and an exporter this linter knows nothing about is not one it can say sends a
+// span at a time.
+func queueBatching(ctx *Context, c config.Component) (batching, bool) {
+	state, written := readQueueBatching(c)
+	queued := acceptsQueue(ctx, c.ID.Type, written)
+
+	if state == batchNone && !describedExporter(ctx, c.ID.Type) {
+		return batchUnknown, queued
+	}
+
+	return state, queued
+}
+
+// readQueueBatching reads an exporter's queue as the document writes it, and
+// reports whether a queue is written at all. Only the top level is read, which
+// is where the queue sits, the same as readSendingQueue reads it.
+func readQueueBatching(c config.Component) (batching, bool) {
+	var block *yaml.Node
+
+	merged := false
+
+	settings := resolveAlias(c.ValueNode)
+	if settings != nil && settings.Kind == yaml.MappingNode {
+		for _, e := range mapEntries(settings, "") {
+			switch e.key {
+			case sendingQueueKey:
+				block = resolveAlias(e.node)
+			case "<<":
+				// The merge may be what supplies the whole block.
+				merged = true
+			default:
+				// Every other setting is another rule's business.
+			}
+		}
+	}
+
+	switch {
+	case block != nil && block.Kind == yaml.MappingNode:
+		// A merge outside the block cannot reach into one the exporter writes
+		// itself: a key present locally replaces the merged value outright.
+		return readBatchBlock(block), true
+	case block != nil && !isNull(block):
+		// A queue the collector builds from an expansion may well be one that
+		// batches, and nothing here can see what it holds.
+		return batchUnknown, true
+	case merged:
+		return batchUnknown, false
+	}
+
+	// An empty queue, or none written at all, takes the defaults, and the
+	// batcher is not one of them.
+	return batchNone, block != nil
+}
+
+// readBatchBlock reads the one queue setting that decides whether the exporter
+// batches. Writing the key is what turns the batcher on: the block is optional
+// upstream, and an empty one takes flush_timeout, min_size and max_size at
+// their defaults. Whether what is written inside it is a batcher the collector
+// accepts is the field rules' business, and so is the queue's own enabled flag:
+// an exporter that names a batcher has said what it wants, and telling it to
+// batch would be advising the setting it already writes.
+func readBatchBlock(block *yaml.Node) batching {
+	merged := false
+
+	for _, e := range mapEntries(block, "") {
+		switch e.key {
+		case batchKey:
+			return batchQueue
+		case "<<":
+			merged = true
+		default:
+			// Every other queue setting is another rule's business.
+		}
+	}
+
+	if merged {
+		return batchUnknown
+	}
+
+	return batchNone
+}
+
+// describedExporter reports whether the field schema describes the exporter
+// type's settings at all. Where it does, a queue batch nobody wrote is a queue
+// batch that does not run, and a queue the type has no field for is a queue it
+// does not have. Where it does not, neither claim holds, and that covers four
+// shapes: no schema was resolved at all, the type is not in it, the type is in
+// it with its settings left open, and the type is in it with no fields -- which
+// reads as "nothing could be resolved for this component" rather than "this
+// component has no settings", since the datadog exporter, which has a queue and
+// a great many other settings, sits in that bucket next to nop.
+func describedExporter(ctx *Context, typ string) bool {
+	fields := exporterFields(ctx, typ)
+
+	return fields != nil && !fields.Open && len(fields.Children) > 0
 }
 
 func hasProcessorType(p config.Pipeline, typ string) bool {
@@ -286,23 +525,18 @@ func readQueueBlock(block *yaml.Node, queue *sendingQueue) {
 // Plenty do not -- debug and nop among them -- and telling them they lose a
 // queue they never had is worse than saying nothing.
 //
-// The field schema is the authority wherever it describes the type's settings
-// completely, which is what keeps debug quiet. Where it does not, a queue the
-// config writes is the only evidence there is. That covers three shapes:
-// no schema was resolved at all, the type is not in it, and the type is in it
-// with no fields -- which reads as "nothing could be resolved for this
-// component" rather than "this component has no settings", since the datadog
-// exporter, which has a queue and a great many other settings, sits in that
-// bucket next to nop. A queue written under an exporter that really has none
-// is then reported here as well as by unknown-field, which is the price of not
-// staying silent about datadog.
+// The field schema is the authority wherever it describes the type's settings,
+// which is what keeps debug quiet. Where it does not -- see describedExporter
+// for the shapes that covers -- a queue the config writes is the only evidence
+// there is. A queue written under an exporter that really has none is then
+// reported here as well as by unknown-field, which is the price of not staying
+// silent about datadog.
 func acceptsQueue(ctx *Context, typ string, written bool) bool {
-	fields := exporterFields(ctx, typ)
-	if fields == nil || fields.Open || len(fields.Children) == 0 {
+	if !describedExporter(ctx, typ) {
 		return written
 	}
 
-	_, held := fields.Children[sendingQueueKey]
+	_, held := exporterFields(ctx, typ).Children[sendingQueueKey]
 
 	return held
 }

--- a/pkg/rule/practice_test.go
+++ b/pkg/rule/practice_test.go
@@ -225,6 +225,286 @@ exporters:
 	}
 }
 
+func TestMissingBatch(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		settings string
+		want     bool // whether the pipeline should be reported
+	}{
+		"no queue settings at all": {
+			settings: "",
+			want:     true,
+		},
+		"a queue that does not batch": {
+			settings: "    sending_queue:\n      queue_size: 5000",
+			want:     true,
+		},
+		// The block is optional upstream, so writing the key is what turns the
+		// batcher on and an empty one takes the defaults.
+		"a queue that batches": {
+			settings: "    sending_queue:\n      batch: {}",
+			want:     false,
+		},
+		"a batch key with nothing under it": {
+			settings: "    sending_queue:\n      batch:",
+			want:     false,
+		},
+		"a batch with settings of its own": {
+			settings: "    sending_queue:\n      batch:\n        flush_timeout: 200ms\n        min_size: 8192",
+			want:     false,
+		},
+		// The queue is on by default and batching is not, so an exporter that
+		// only turns the queue on still sends a span at a time.
+		"a queue turned on and nothing else": {
+			settings: "    sending_queue:\n      enabled: true",
+			want:     true,
+		},
+		// Nothing here can see what the variable holds, and telling an exporter
+		// that already batches to batch is the finding this rule must not make.
+		"a queue built from an expansion": {
+			settings: "    sending_queue: ${env:QUEUE}",
+			want:     false,
+		},
+		"a queue built from a merge key": {
+			settings: "    sending_queue:\n      <<: &queue {queue_size: 5000}\n      storage: file_storage",
+			want:     false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := checkRule(t, "missing-batch", exporting(tt.settings), rule.Environment{})
+			assert.Len(t, found, map[bool]int{true: 1, false: 0}[tt.want])
+		})
+	}
+}
+
+// The hint is the whole point of the change: exporter-side batching first, with
+// the reason it comes first, and the processor named as what also works.
+func TestMissingBatchReadsAsASentence(t *testing.T) {
+	t.Parallel()
+
+	const hint = "the batch processor also works but drops data that fails to send"
+
+	found := checkRule(t, "missing-batch", exporting(""), rule.Environment{})
+	require.Len(t, found, 1)
+
+	assert.Equal(t, `pipeline "traces" has no batch processor, and none of its exporters batches in sending_queue`,
+		found[0].Message)
+	assert.Equal(t, "configure sending_queue.batch on the exporters, which batches behind the retry queue; "+
+		hint, found[0].Hint)
+	assert.Equal(t, "service.pipelines.traces.processors", found[0].Path)
+	assert.Equal(t, diag.Info, found[0].Severity)
+	assert.Contains(t, found[0].Docs, "exporter/exporterhelper/README.md")
+}
+
+// A pipeline where only some exporters batch is under-batched on the legs that
+// do not, so the finding names the exporter rather than the pipeline: the fix
+// is written in that exporter's settings and nowhere else.
+func TestMissingBatchReportsPerExporter(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue:
+      batch: {}
+  otlphttp/second:
+    endpoint: http://other:4318
+  otlphttp/third:
+    endpoint: http://third:4318
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp, otlphttp/second, otlphttp/third]}
+`
+
+	found := checkRule(t, "missing-batch", src, rule.Environment{})
+	require.Len(t, found, 1)
+
+	assert.Equal(t, `exporter "otlphttp/second" sends unbatched in pipeline "traces", `+
+		"which has no batch processor", found[0].Message)
+	assert.Equal(t, "configure sending_queue.batch on this exporter, which batches behind the retry queue; "+
+		"the batch processor also works but drops data that fails to send", found[0].Hint)
+	assert.Equal(t, "service.pipelines.traces.exporters[1]", found[0].Path)
+}
+
+// An exporter the schema says has no sending queue -- debug and nop among them
+// -- can only be batched in front of, and a hint naming a setting it does not
+// have would be no fix.
+func TestMissingBatchWithoutASendingQueue(t *testing.T) {
+	t.Parallel()
+
+	const processorFirst = "add batch before the exporters to reduce the number of outgoing requests; "
+
+	pipeline := checkRule(t, "missing-batch", debugging(""), rule.Environment{})
+	require.Len(t, pipeline, 1)
+	assert.Equal(t, processorFirst+"these exporters have no sending_queue to batch in", pipeline[0].Hint)
+	assert.Contains(t, pipeline[0].Docs, "processor/batchprocessor/README.md")
+
+	mixed := checkRule(t, "missing-batch", `
+receivers: {otlp: }
+exporters:
+  debug:
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue: {batch: {}}
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug, otlphttp]}
+`, rule.Environment{})
+	require.Len(t, mixed, 1)
+	assert.Equal(t, `exporter "debug" sends unbatched in pipeline "traces", which has no batch processor`,
+		mixed[0].Message)
+	assert.Equal(t, processorFirst+"this exporter has no sending_queue to batch in", mixed[0].Hint)
+}
+
+func TestMissingBatchStaysQuiet(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		// The processor is not deprecated, so a pipeline that uses it batches
+		// and this rule has nothing to say about it.
+		"a batch processor": `
+receivers: {otlp: }
+processors: {batch: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [batch], exporters: [otlphttp]}
+`,
+		// A named instance is the same processor.
+		"a batch processor under another name": `
+receivers: {otlp: }
+processors: {batch/large: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], processors: [batch/large], exporters: [otlphttp]}
+`,
+		// Every leg batches in its own queue, and a batch processor on top
+		// would be a second layer with a flush timing of its own.
+		"every exporter batching in its queue": `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue: {batch: {}}
+  otlphttp/second:
+    endpoint: http://other:4318
+    sending_queue: {batch: {flush_timeout: 1s}}
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp, otlphttp/second]}
+`,
+		// An anchor is the same queue written once and used twice.
+		"a queue behind an anchor": `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue: &queue
+      batch: {}
+  otlphttp/second:
+    endpoint: http://other:4318
+    sending_queue: *queue
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp, otlphttp/second]}
+`,
+		// A merge may be what supplies the batcher, and the document is read as
+		// written.
+		"settings built from a merge key": `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    <<: &base {sending_queue: {batch: {}}}
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp]}
+`,
+		// The schema resolved no fields for this one, so there is nothing to
+		// say what it does before it sends. testSchema's logging exporter has
+		// the same shape as the datadog exporter's entry.
+		"an exporter the schema does not describe": `
+receivers: {otlp: }
+exporters: {logging: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [logging]}
+`,
+		// A connector is not a leg out of the collector: it feeds another
+		// pipeline, which has exporters of its own to batch on.
+		"a pipeline that only feeds a connector": `
+receivers: {otlp: }
+connectors: {spanmetrics: }
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue: {batch: {}}
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [spanmetrics]}
+    metrics: {receivers: [spanmetrics], exporters: [otlphttp]}
+`,
+		// Nothing declares it, so the collector does not start at all and
+		// undefined-reference is the finding worth having.
+		"an exporter nobody declared": `
+receivers: {otlp: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp]}
+`,
+		"a pipeline with no exporters": `
+receivers: {otlp: }
+service:
+  pipelines:
+    traces: {receivers: [otlp]}
+`,
+		"no service block": `
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+`,
+	}
+
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Empty(t, checkRule(t, "missing-batch", src, rule.Environment{}))
+		})
+	}
+}
+
+// Without a schema there is nothing to say what an exporter does before it
+// sends, and the field rules' principle applies: partial coverage says nothing
+// rather than something wrong.
+func TestMissingBatchWithoutASchema(t *testing.T) {
+	t.Parallel()
+
+	f, err := config.Parse("test.yaml", []byte(exporting("")))
+	require.NoError(t, err, "parse")
+
+	r, ok := rule.Lookup("missing-batch")
+	require.True(t, ok, "rule is not registered")
+
+	found := rule.Run(r, rule.Context{File: f, Schema: &schema.Schema{}, Index: rule.NewIndex(f)}, r.Severity())
+	assert.Empty(t, found)
+}
+
 func TestNoPersistentQueue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #48.

## Why

`missing-batch` told every pipeline with exporters to add a `batch` processor. `exporterhelper` now batches inside the sending queue, under `sending_queue.batch`, so that advice was wrong for a pipeline whose exporters already do it — the fix it asked for would have been a second batching layer with a flush timing of its own.

## What

**The false positive is gone.** The rule reads each exporter a pipeline exports through:

- every leg batching in its queue → quiet;
- only some of them → the pipeline is under-batched on the legs that do not, and the finding names that exporter and sits on the line that wires it in, since the fix is written in that exporter's settings;
- every leg readable and none batching → the pipeline-level finding, as before.

**Unknown is not not-batching.** Settings supplied by a merge key or an expansion, an exporter nobody declared, and a type the field schema does not describe (no schema resolved, the type absent, its settings left open, or present with no fields — where `datadog` sits next to `nop`) all count as unknown, the principle the field rules already follow. A connector in the exporter slot is not a leg out of the collector; it feeds another pipeline, which has exporters of its own.

**The hint leads with the exporter setting**:

> configure `sending_queue.batch` on the exporters, which batches behind the retry queue; the `batch` processor also works but drops data that fails to send

with the docs link moved to the `exporterhelper` README. Where the exporters have no `sending_queue` to hold a batcher — `nop`, and `debug` on a release before upstream gave it one — the hint names the processor instead and links its README, because a fix the component has no setting for is no fix. The `batch` processor is **not** deprecated and nothing here tells anyone to remove one.

`acceptsQueue` and the new reader share `describedExporter`, which is the schema question both were asking in their own words.

## Checklist from the issue

- [x] `missing-batch` stays quiet when every exporter in the pipeline sets `sending_queue.batch`
- [x] Components with no resolvable settings count as unknown, not as not-batching
- [x] Mixed pipelines report against the specific exporter
- [x] Hint leads with `sending_queue.batch` and gives the reason
- [x] README "Practice" paragraph updated to match
- [x] Test covering a pipeline that batches only in the exporter

Left for a follow-up, as the issue suggests: the companion `Info` rule for a config that enables both the processor and `sending_queue.batch`.

## Verification

`make lint` (0 issues) and `go test -race ./...` pass. Checked against the real registry schemas as well: on contrib v0.158.0 an `otlp` exporter without a queue batch is still reported while an `otlphttp` one with `sending_queue.batch` is not, and on v0.110.0 — where `debug` has no queue — the finding falls back to the processor hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)