### PR TITLE
fix(rule): name a fix the targeted release actually has

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,15 +332,20 @@ its own. Where only some of them do, the pipeline is under-batched on the legs
 that do not, so the finding names the exporter and sits on the line that wires
 it in — that exporter's settings are where the fix is written. A connector in
 the exporter slot is not a leg out of the collector and is not counted; it feeds
-another pipeline, which has exporters of its own. An exporter whose settings
-come from a merge key or an expansion, and one whose type the field schema does
-not describe, count as unknown rather than as not batching, for the same reason
-the field rules leave what they cannot resolve alone.
+another pipeline, which has exporters of its own. An exporter whose settings, or
+whose queue, come from a merge key or an expansion counts as unknown rather than
+as not batching, for the same reason the field rules leave what they cannot
+resolve alone. The batcher is off by default, so everything else the document
+settles on its own: an exporter that does not write one does not have one,
+whatever the schema knows about the type.
 
-The hint follows the schema rather than the other way round: where the exporters
-have no `sending_queue` to hold a batcher — `nop`, and `debug` on a release
-before upstream gave it a queue — it names the processor instead, because a fix
-the component has no setting for is no fix.
+What the schema is asked is which fix to name. Where it describes the exporter's
+queue in full and there is no `batch` in it — upstream added the batcher in
+`v0.123`, and `debug` had no queue at all for longer than that — the hint names
+the processor instead and links its README, because writing a setting the
+release has no field for does not batch, it fails to load. Where the schema
+resolved nothing for the type, as it has not for `datadog`, the queue batcher is
+still the advice to give.
 
 `no-persistent-queue` is the one opinionated rule, and it reports at `info` for
 that reason. The sending queue is on by default and lives in memory, so a

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -253,75 +253,90 @@ func (r missingBatch) Check(ctx *Context) {
 		// Only when every leg is one this rule can read, and none of them
 		// batches, is "the pipeline batches nothing" a claim the file supports.
 		if len(unbatched) == legs {
-			queued := anyQueued(unbatched)
+			hint, docs := pipelineHint(unbatched)
 
 			ctx.Report(Finding{
 				Node: nodeOr(p.ProcessorsNode, p.KeyNode), Path: "service.pipelines." + p.Key + ".processors",
 				Message: "pipeline " + quote(p.Key) + " has no batch processor, and none of its exporters " +
 					"batches in " + sendingQueueKey,
-				Hint: batchHint("the exporters", "these exporters have", queued),
-				Docs: batchDocsFor(queued),
+				Hint: hint, Docs: docs,
 			})
 
 			continue
 		}
 
 		for _, leg := range unbatched {
+			hint, docs := exporterHint(leg.queued)
+
 			ctx.Report(Finding{
 				Node: leg.ref.Node, Path: leg.ref.Path,
 				Message: "exporter " + quote(leg.ref.ID.String()) + " sends unbatched in pipeline " +
 					quote(p.Key) + ", which has no batch processor",
-				Hint: batchHint("this exporter", "this exporter has", leg.queued),
-				Docs: batchDocsFor(leg.queued),
+				Hint: hint, Docs: docs,
 			})
 		}
 	}
 }
 
-// batchHint renders the fix. It leads with the queue batcher, which is where
-// upstream is steering and which sits behind the retry logic rather than in
-// front of it -- unless the exporters have no queue to put it in, and then the
-// processor is the only batching on offer. "target" names what to configure
-// and "subject" agrees with the verb after it.
-func batchHint(target, subject string, queued bool) string {
-	if !queued {
-		return "add batch before the exporters to reduce the number of outgoing requests; " +
-			subject + " no " + sendingQueueKey + " to batch in"
-	}
-
+// queueFirst is the fix this rule leads with, and the page it rests on: the
+// batcher sits behind the retry queue, where the processor drops the batch that
+// fails to send. "target" names what to configure, so one finding can say "the
+// exporters" and another "this exporter".
+func queueFirst(target string) (string, string) {
 	return "configure " + sendingQueueKey + "." + batchKey + " on " + target + ", which batches behind the " +
-		"retry queue; the batch processor also works but drops data that fails to send"
+		"retry queue; the batch processor also works but drops data that fails to send", exporterQueueDocs
 }
 
-// batchDocsFor points at the page the hint rests on: the queue batcher's
-// settings, or the processor's where the exporters have no queue to hold one.
-func batchDocsFor(queued bool) string {
+// processorFirst is the fix for exporters that cannot take the other one --
+// either they have no sending queue or the release's queue has no batcher in
+// it. A hint naming a setting the component has no field for is no fix: writing
+// one does not batch, it fails to load. "why" says which of them it is.
+func processorFirst(why string) (string, string) {
+	return "add batch before the exporters to reduce the number of outgoing requests; " + why, batchDocs
+}
+
+// pipelineHint renders the fix for a finding covering every leg at once. It
+// leads with the queue batcher only where every one of those exporters can take
+// it, since this finding has one hint for all of them.
+func pipelineHint(legs []unbatchedLeg) (string, string) {
+	switch queued := queuedLegs(legs); {
+	case queued == len(legs):
+		return queueFirst("the exporters")
+	case queued == 0:
+		return processorFirst("these exporters cannot take a " + sendingQueueKey + "." + batchKey)
+	default:
+		return processorFirst("only some of them can take a " + sendingQueueKey + "." + batchKey + " of their own")
+	}
+}
+
+// exporterHint renders the fix for a finding that names one exporter.
+func exporterHint(queued bool) (string, string) {
 	if !queued {
-		return batchDocs
+		return processorFirst("this exporter cannot take a " + sendingQueueKey + "." + batchKey)
 	}
 
-	return exporterQueueDocs
+	return queueFirst("this exporter")
 }
 
 // unbatchedLeg is an exporter reference whose exporter batches nothing, and
-// whether that exporter has a sending queue to batch in at all. One that does
-// not -- debug and nop among them -- can only be batched in front of, and a
-// hint naming a setting it does not have would be no fix.
+// whether that exporter can be given a queue batcher at all. One that cannot --
+// an exporter with no sending queue, or a release whose queue has no batcher --
+// can only be batched in front of.
 type unbatchedLeg struct {
 	ref    config.Ref
 	queued bool
 }
 
-// anyQueued reports whether any of the legs has a queue to batch in, which is
-// what decides the wording of a finding that covers all of them at once.
-func anyQueued(legs []unbatchedLeg) bool {
+func queuedLegs(legs []unbatchedLeg) int {
+	queued := 0
+
 	for _, leg := range legs {
 		if leg.queued {
-			return true
+			queued++
 		}
 	}
 
-	return false
+	return queued
 }
 
 // exportLegs reads what each of a pipeline's exporters does about batching. It
@@ -357,10 +372,9 @@ func exportLegs(ctx *Context, p config.Pipeline) (int, []unbatchedLeg) {
 type batching int
 
 const (
-	// batchUnknown is an exporter this rule cannot read: one whose settings a
-	// merge key or an expansion supplies, or a type the field schema does not
-	// describe. Neither a finding against it nor one that counts it as batching
-	// would rest on anything.
+	// batchUnknown is an exporter this rule cannot read: one whose settings, or
+	// whose queue, a merge key or an expansion supplies. Neither a finding
+	// against it nor one that counts it as batching would rest on anything.
 	batchUnknown batching = iota
 	// batchNone is an exporter that batches nothing before it sends.
 	batchNone
@@ -369,29 +383,49 @@ const (
 )
 
 // queueBatching reports whether an exporter batches what it sends, and whether
-// it has a sending queue to batch in at all.
+// it could be given a queue batcher.
 //
-// The queue batcher is off by default, so an exporter that does not write it is
-// an exporter that does not batch -- but only where the field schema describes
-// the type at all. Where it does not, the same principle the field rules follow
-// applies: what cannot be resolved says nothing rather than something wrong,
-// and an exporter this linter knows nothing about is not one it can say sends a
-// span at a time.
+// The batcher is off by default, so the document settles the first question on
+// its own: an exporter that does not write one does not have one, whatever the
+// schema knows about the type. The schema is only asked what to advise, which
+// is the question it can answer.
 func queueBatching(ctx *Context, c config.Component) (batching, bool) {
-	state, written := readQueueBatching(c)
-	queued := acceptsQueue(ctx, c.ID.Type, written)
-
-	if state == batchNone && !describedExporter(ctx, c.ID.Type) {
-		return batchUnknown, queued
-	}
-
-	return state, queued
+	return readQueueBatching(c), takesQueueBatch(ctx, c.ID.Type)
 }
 
-// readQueueBatching reads an exporter's queue as the document writes it, and
-// reports whether a queue is written at all. Only the top level is read, which
-// is where the queue sits, the same as readSendingQueue reads it.
-func readQueueBatching(c config.Component) (batching, bool) {
+// takesQueueBatch reports whether the release being targeted lets the exporter
+// type carry a sending_queue.batch.
+//
+// Only a schema that describes the queue and does not carry the field is
+// evidence that it cannot: upstream added the batcher to the queue in v0.123,
+// and before that writing one under an exporter whose queue the schema
+// describes in full does not batch, it fails to load. Everywhere else --
+// nothing resolved for the type, its settings or its queue left open, a queue
+// with no fields resolved under it -- the setting is still the advice to give,
+// because the alternative is telling the datadog exporter it has no queue.
+func takesQueueBatch(ctx *Context, typ string) bool {
+	if !describedExporter(ctx, typ) {
+		return true
+	}
+
+	queue, held := exporterFields(ctx, typ).Children[sendingQueueKey]
+	if !held {
+		return false
+	}
+
+	if queue.Open || len(queue.Children) == 0 {
+		return true
+	}
+
+	_, batches := queue.Children[batchKey]
+
+	return batches
+}
+
+// readQueueBatching reads an exporter's queue as the document writes it. Only
+// the top level is read, which is where the queue sits, the same as
+// readSendingQueue reads it.
+func readQueueBatching(c config.Component) batching {
 	var block *yaml.Node
 
 	merged := false
@@ -415,18 +449,18 @@ func readQueueBatching(c config.Component) (batching, bool) {
 	case block != nil && block.Kind == yaml.MappingNode:
 		// A merge outside the block cannot reach into one the exporter writes
 		// itself: a key present locally replaces the merged value outright.
-		return readBatchBlock(block), true
+		return readBatchBlock(block)
 	case block != nil && !isNull(block):
 		// A queue the collector builds from an expansion may well be one that
 		// batches, and nothing here can see what it holds.
-		return batchUnknown, true
+		return batchUnknown
 	case merged:
-		return batchUnknown, false
+		return batchUnknown
 	}
 
 	// An empty queue, or none written at all, takes the defaults, and the
 	// batcher is not one of them.
-	return batchNone, block != nil
+	return batchNone
 }
 
 // readBatchBlock reads the one queue setting that decides whether the exporter

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -413,6 +413,10 @@ func takesQueueBatch(ctx *Context, typ string) bool {
 		return false
 	}
 
+	if queue == nil {
+		return true
+	}
+
 	if queue.Open || len(queue.Children) == 0 {
 		return true
 	}

--- a/pkg/rule/practice_test.go
+++ b/pkg/rule/practice_test.go
@@ -479,7 +479,7 @@ func TestMissingBatchWithoutASendingQueue(t *testing.T) {
 
 	pipeline := checkRule(t, "missing-batch", debugging(""), rule.Environment{})
 	require.Len(t, pipeline, 1)
-	assert.Equal(t, processorFirst+"these exporters have no sending_queue to batch in", pipeline[0].Hint)
+	assert.Equal(t, processorFirst+"these exporters cannot take a sending_queue.batch", pipeline[0].Hint)
 	assert.Contains(t, pipeline[0].Docs, "processor/batchprocessor/README.md")
 
 	mixed := checkRule(t, "missing-batch", `
@@ -496,7 +496,7 @@ service:
 	require.Len(t, mixed, 1)
 	assert.Equal(t, `exporter "debug" sends unbatched in pipeline "traces", which has no batch processor`,
 		mixed[0].Message)
-	assert.Equal(t, processorFirst+"this exporter has no sending_queue to batch in", mixed[0].Hint)
+	assert.Equal(t, processorFirst+"this exporter cannot take a sending_queue.batch", mixed[0].Hint)
 }
 
 func TestMissingBatchStaysQuiet(t *testing.T) {
@@ -568,16 +568,6 @@ service:
   pipelines:
     traces: {receivers: [otlp], exporters: [otlphttp]}
 `,
-		// The schema resolved no fields for this one, so there is nothing to
-		// say what it does before it sends. testSchema's logging exporter has
-		// the same shape as the datadog exporter's entry.
-		"an exporter the schema does not describe": `
-receivers: {otlp: }
-exporters: {logging: }
-service:
-  pipelines:
-    traces: {receivers: [otlp], exporters: [logging]}
-`,
 		// A connector is not a leg out of the collector: it feeds another
 		// pipeline, which has exporters of its own to batch on.
 		"a pipeline that only feeds a connector": `
@@ -622,20 +612,110 @@ exporters:
 	}
 }
 
-// Without a schema there is nothing to say what an exporter does before it
-// sends, and the field rules' principle applies: partial coverage says nothing
-// rather than something wrong.
+// checkWithSchema runs one rule against a schema the test builds itself, for
+// the releases and component shapes testSchema does not stand in for.
+func checkWithSchema(t *testing.T, name, src string, s *schema.Schema) diag.Diagnostics {
+	t.Helper()
+
+	f, err := config.Parse("test.yaml", []byte(src))
+	require.NoError(t, err, "parse")
+
+	r, ok := rule.Lookup(name)
+	require.Truef(t, ok, "rule %q is not registered", name)
+
+	return rule.Run(r, rule.Context{File: f, Schema: s, Index: rule.NewIndex(f)}, r.Severity())
+}
+
+// The batcher is off by default, so an exporter that does not write one does
+// not have one, and the document settles that with no schema at all. What the
+// schema is asked is what to advise, and with nothing to go on the answer is
+// the setting upstream is steering towards.
 func TestMissingBatchWithoutASchema(t *testing.T) {
 	t.Parallel()
 
-	f, err := config.Parse("test.yaml", []byte(exporting("")))
-	require.NoError(t, err, "parse")
+	found := checkWithSchema(t, "missing-batch", exporting(""), &schema.Schema{})
+	require.Len(t, found, 1)
+	assert.Contains(t, found[0].Hint, "configure sending_queue.batch on the exporters")
+}
 
-	r, ok := rule.Lookup("missing-batch")
-	require.True(t, ok, "rule is not registered")
+// An exporter the schema resolved no fields for is still an exporter that
+// batches nothing when nothing writes a batcher under it. testSchema's logging
+// entry has the shape the datadog exporter's has, and datadog is a production
+// exporter that batching is exactly the advice for.
+func TestMissingBatchWithoutFields(t *testing.T) {
+	t.Parallel()
 
-	found := rule.Run(r, rule.Context{File: f, Schema: &schema.Schema{}, Index: rule.NewIndex(f)}, r.Severity())
-	assert.Empty(t, found)
+	const declared = `
+receivers: {otlp: }
+exporters:
+  logging:
+`
+
+	const wired = `
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [logging]}
+`
+
+	found := checkRule(t, "missing-batch", declared+wired, rule.Environment{})
+	require.Len(t, found, 1)
+	assert.Contains(t, found[0].Hint, "configure sending_queue.batch on the exporters")
+
+	batching := checkRule(t, "missing-batch",
+		declared+"    sending_queue:\n      batch: {}\n"+wired, rule.Environment{})
+	assert.Empty(t, batching, "a batcher the config writes is a batcher whatever the schema knows")
+}
+
+// The queue grew its batcher in v0.123. Advising it on a release whose queue
+// has no such field would be advising a config that fails to load, which is
+// what unknown-field would then report against the linter's own hint.
+func TestMissingBatchBeforeTheQueueBatched(t *testing.T) {
+	t.Parallel()
+
+	older := &schema.Schema{
+		CollectorVersion: "v0.110.0",
+		Components: map[config.Kind]map[string]*schema.Component{
+			config.KindReceiver: {"otlp": {Type: "otlp", Signals: []config.Signal{"traces"}}},
+			config.KindExporter: {"otlphttp": {Type: "otlphttp", Signals: []config.Signal{"traces"},
+				Fields: &schema.Field{Type: "map", Children: map[string]*schema.Field{
+					"endpoint": {Type: "string"},
+					"sending_queue": {Type: "map", Children: map[string]*schema.Field{
+						"enabled":    {Type: "bool"},
+						"queue_size": {Type: "int"},
+						"storage":    {Type: "string"},
+					}},
+				}}}},
+		},
+	}
+
+	found := checkWithSchema(t, "missing-batch", exporting(""), older)
+	require.Len(t, found, 1)
+	assert.Equal(t, "add batch before the exporters to reduce the number of outgoing requests; "+
+		"these exporters cannot take a sending_queue.batch", found[0].Hint)
+	assert.Contains(t, found[0].Docs, "processor/batchprocessor/README.md")
+}
+
+// A finding covering exporters that cannot all take the same fix says so
+// instead of naming a setting half of them have no field for.
+func TestMissingBatchWhereOnlySomeExportersHaveAQueue(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters:
+  debug:
+  otlphttp:
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug, otlphttp]}
+`
+
+	found := checkRule(t, "missing-batch", src, rule.Environment{})
+	require.Len(t, found, 1)
+	assert.Equal(t, "add batch before the exporters to reduce the number of outgoing requests; "+
+		"only some of them can take a sending_queue.batch of their own", found[0].Hint)
+	assert.Contains(t, found[0].Docs, "processor/batchprocessor/README.md")
 }
 
 func TestNoPersistentQueue(t *testing.T) {


### PR DESCRIPTION
Follow-up to #84, which merged while the review of it was still running. Four findings, each reproduced against the schemas in `testdata/schemas/` before and after.

## 1. The hint advised a setting the release did not have

`queued` came from "does this exporter type have a `sending_queue`", which is not the question. Upstream added the batcher to the queue in v0.123. On core v0.110 the `otlphttp` queue is described in full with no `batch` among its fields, so the linter said:

```
hint: configure sending_queue.batch on the exporters, ...
```

and following it produced, from the same run:

```
warning: unknown setting "batch" for exporters.otlphttp [unknown-field]
    hint: accepted settings: enabled, num_consumers, queue_size, storage
```

`takesQueueBatch` now asks whether the queue carries the field. Only a schema that describes the queue *in full* and has no batcher in it is evidence the exporter cannot take one — an open queue, a queue with nothing resolved under it, and a type the schema does not describe are not.

## 2. "Schema does not describe the type" silenced the rule where it was most wanted

The first pass downgraded those legs to unknown, so `missing-batch` reported nothing for a `datadog` pipeline (contrib v0.157 resolves no fields for `datadog` or `nop`), and nothing at all when no schema resolved.

The gate never bought what it cost: an exporter that batches in its queue *writes* `sending_queue.batch`, which is read whatever the schema knows, and a described type can batch internally just as well as an undescribed one. The document now settles whether a batcher is configured; the schema is asked only what to advise. Unknown still covers what it should — settings or a queue supplied by a merge key or an expansion, and an exporter nobody declared — so the issue's checklist item ("components with no resolvable settings count as unknown") still holds.

## 3. One hint for exporters that could not all take it

When every leg was unbatched but only some had a queue, the pipeline-level finding said "configure `sending_queue.batch` on the exporters" — on `[debug, otlphttp]` that is advice that fails to load on one of the two. The collapsed finding now leads with the queue batcher only when every one of those exporters can take it, and otherwise says only some of them can.

## 4. Wording and README

The processor-first hint claimed "these exporters have no `sending_queue`", which is wrong for a release whose queue simply has no batcher; it now says they cannot take a `sending_queue.batch`, which is the claim being made either way. The README said `nop` gets the processor hint — it gets the queue one, for the same reason `datadog` does — and the paragraph now describes what the code does.

## Tests

Three new: a release whose queue has no batcher, an exporter the schema resolved no fields for (reports, and stays quiet once it writes a batcher), and a pipeline where only some exporters can take one. `TestMissingBatchWithoutASchema` now asserts the finding it should have been asserting. `go test -race ./...` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)