### PR TITLE
fix(rule): ask the schema for the batcher, not for the queue holding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,12 +351,16 @@ is younger than the queue: on a release from before it moved in, every exporter
 has a `sending_queue` and none of them has a `batch` under it, and a hint naming
 one there would be advising a setting the collector rejects on startup —
 `unknown-field`, reading the same schema, would say so in the same run. So
-where the field is not there to write — `nop` and `debug`, which have no queue
-at all; any exporter on a release that predates the batcher; anything the schema
-does not describe — the hint names the processor instead, because a fix the
-release has no setting for is no fix. Where one finding covers several exporters
-at once it names the queue batcher only if all of them accept it, and falls back
-to the processor alone when they disagree.
+where the field is not there to write — an exporter with no `sending_queue` on
+the targeted release, `debug` on `v0.157` among them; any exporter on a release
+that predates the batcher; anything the schema does not describe, `nop` and
+`datadog` among them — the hint names the processor instead, because a fix the
+release has no setting for is no fix. Which exporters those are is the schema's
+answer and moves with the release, which is the point of asking it. Where one finding covers several exporters
+at once it names the queue batcher only if all of them accept it; where they
+disagree it names the processor and says that only some of them can take a
+`sending_queue.batch`, since the reason it gives otherwise would be false of
+half of them.
 
 `no-persistent-queue` is the one opinionated rule, and it reports at `info` for
 that reason. The sending queue is on by default and lives in memory, so a

--- a/README.md
+++ b/README.md
@@ -333,14 +333,30 @@ that do not, so the finding names the exporter and sits on the line that wires
 it in — that exporter's settings are where the fix is written. A connector in
 the exporter slot is not a leg out of the collector and is not counted; it feeds
 another pipeline, which has exporters of its own. An exporter whose settings
-come from a merge key or an expansion, and one whose type the field schema does
-not describe, count as unknown rather than as not batching, for the same reason
-the field rules leave what they cannot resolve alone.
+come from a merge key or an expansion counts as unknown rather than as not
+batching, for the same reason the field rules leave what they cannot resolve
+alone.
 
-The hint follows the schema rather than the other way round: where the exporters
-have no `sending_queue` to hold a batcher — `nop`, and `debug` on a release
-before upstream gave it a queue — it names the processor instead, because a fix
-the component has no setting for is no fix.
+What the document writes decides whether there is a finding; what the field
+schema describes decides only which fix the hint may name. The queue batcher is
+off until something turns it on, so a config that writes no
+`sending_queue.batch` is not batching there whatever the schema knows about the
+type — which is why an exporter it describes no settings for, `nop` and
+`datadog` among them, is reported like any other rather than passed over in
+silence.
+
+The hint is the half that follows the schema, and it asks for
+`sending_queue.batch` itself rather than for the queue holding it. The batcher
+is younger than the queue: on a release from before it moved in, every exporter
+has a `sending_queue` and none of them has a `batch` under it, and a hint naming
+one there would be advising a setting the collector rejects on startup —
+`unknown-field`, reading the same schema, would say so in the same run. So
+where the field is not there to write — `nop` and `debug`, which have no queue
+at all; any exporter on a release that predates the batcher; anything the schema
+does not describe — the hint names the processor instead, because a fix the
+release has no setting for is no fix. Where one finding covers several exporters
+at once it names the queue batcher only if all of them accept it, and falls back
+to the processor alone when they disagree.
 
 `no-persistent-queue` is the one opinionated rule, and it reports at `info` for
 that reason. The sending queue is on by default and lives in memory, so a

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -298,9 +298,10 @@ const (
 	// processorFix is the batch processor, named where none of them has a queue
 	// batcher, so the hint can say why it is the only batching on offer.
 	processorFix
-	// splitFix is the batch processor named without that reason, because the
-	// exporters disagree: some have a queue batcher and some do not, and either
-	// clause about what they have would be wrong about half of them.
+	// splitFix is the batch processor named where the exporters disagree: some
+	// have a queue batcher and some do not, so the reason processorFix gives
+	// would be wrong about half of them. It says that much instead, which is
+	// what tells the reader the other fix is still open to some of these legs.
 	splitFix
 )
 
@@ -353,9 +354,11 @@ func batchHint(target, subject string, fix batchFix) string {
 	case processorFix:
 		return batchProcessorHint + "; " + subject + " no " + sendingQueueKey + "." + batchKey + " to batch in"
 	default:
-		// splitFix, where the exporters disagree: the processor is named on its
-		// own, since the clause explaining why would be false of half of them.
-		return batchProcessorHint
+		// splitFix, where the exporters disagree. The processor is still the one
+		// fix all of them can take, but saying none of them has a queue batcher
+		// would be false of half of them, so the clause says which half.
+		return batchProcessorHint + "; only some of them can take a " +
+			sendingQueueKey + "." + batchKey + " of their own"
 	}
 }
 

--- a/pkg/rule/practice.go
+++ b/pkg/rule/practice.go
@@ -237,6 +237,14 @@ func (r missingMemoryLimiter) Check(ctx *Context) {
 // with a flush timing of its own. A pipeline where only some of them do is
 // under-batched on the legs that do not, so the finding names the exporter
 // rather than the pipeline.
+//
+// What the document writes decides whether there is a finding; what the field
+// schema describes decides only which fix the hint may name. The two are read
+// apart on purpose. An exporter the schema says nothing about -- datadog and
+// nop are both in that bucket -- still has a queue batcher that is off until
+// something writes it, so the finding stands; it is the hint that has to fall
+// back to the processor, because nothing there says sending_queue.batch is a
+// setting the release would accept.
 type missingBatch struct{ base }
 
 func (r missingBatch) Check(ctx *Context) {
@@ -253,75 +261,122 @@ func (r missingBatch) Check(ctx *Context) {
 		// Only when every leg is one this rule can read, and none of them
 		// batches, is "the pipeline batches nothing" a claim the file supports.
 		if len(unbatched) == legs {
-			queued := anyQueued(unbatched)
+			fix := pipelineFix(unbatched)
 
 			ctx.Report(Finding{
 				Node: nodeOr(p.ProcessorsNode, p.KeyNode), Path: "service.pipelines." + p.Key + ".processors",
 				Message: "pipeline " + quote(p.Key) + " has no batch processor, and none of its exporters " +
 					"batches in " + sendingQueueKey,
-				Hint: batchHint("the exporters", "these exporters have", queued),
-				Docs: batchDocsFor(queued),
+				Hint: batchHint("the exporters", "these exporters have", fix),
+				Docs: batchDocsFor(fix),
 			})
 
 			continue
 		}
 
 		for _, leg := range unbatched {
+			fix := exporterFix(leg.queueBatch)
+
 			ctx.Report(Finding{
 				Node: leg.ref.Node, Path: leg.ref.Path,
 				Message: "exporter " + quote(leg.ref.ID.String()) + " sends unbatched in pipeline " +
 					quote(p.Key) + ", which has no batch processor",
-				Hint: batchHint("this exporter", "this exporter has", leg.queued),
-				Docs: batchDocsFor(leg.queued),
+				Hint: batchHint("this exporter", "this exporter has", fix),
+				Docs: batchDocsFor(fix),
 			})
 		}
 	}
 }
 
-// batchHint renders the fix. It leads with the queue batcher, which is where
-// upstream is steering and which sits behind the retry logic rather than in
-// front of it -- unless the exporters have no queue to put it in, and then the
-// processor is the only batching on offer. "target" names what to configure
-// and "subject" agrees with the verb after it.
-func batchHint(target, subject string, queued bool) string {
-	if !queued {
-		return "add batch before the exporters to reduce the number of outgoing requests; " +
-			subject + " no " + sendingQueueKey + " to batch in"
+// batchFix is the batching a finding can tell the reader to write.
+type batchFix int
+
+const (
+	// queueFix is sending_queue.batch, which every exporter the finding covers
+	// has in the targeted release.
+	queueFix batchFix = iota
+	// processorFix is the batch processor, named where none of them has a queue
+	// batcher, so the hint can say why it is the only batching on offer.
+	processorFix
+	// splitFix is the batch processor named without that reason, because the
+	// exporters disagree: some have a queue batcher and some do not, and either
+	// clause about what they have would be wrong about half of them.
+	splitFix
+)
+
+// exporterFix classifies a finding that names one exporter.
+func exporterFix(queueBatch bool) batchFix {
+	if queueBatch {
+		return queueFix
 	}
 
-	return "configure " + sendingQueueKey + "." + batchKey + " on " + target + ", which batches behind the " +
-		"retry queue; the batch processor also works but drops data that fails to send"
+	return processorFix
 }
 
-// batchDocsFor points at the page the hint rests on: the queue batcher's
-// settings, or the processor's where the exporters have no queue to hold one.
-func batchDocsFor(queued bool) string {
-	if !queued {
-		return batchDocs
-	}
+// pipelineFix classifies a finding that covers a pipeline's legs at once. It
+// takes the queue batcher only when every leg has one: a hint naming a setting
+// half the exporters do not accept is a hint half of them cannot follow.
+func pipelineFix(legs []unbatchedLeg) batchFix {
+	queue, processor := 0, 0
 
-	return exporterQueueDocs
-}
-
-// unbatchedLeg is an exporter reference whose exporter batches nothing, and
-// whether that exporter has a sending queue to batch in at all. One that does
-// not -- debug and nop among them -- can only be batched in front of, and a
-// hint naming a setting it does not have would be no fix.
-type unbatchedLeg struct {
-	ref    config.Ref
-	queued bool
-}
-
-// anyQueued reports whether any of the legs has a queue to batch in, which is
-// what decides the wording of a finding that covers all of them at once.
-func anyQueued(legs []unbatchedLeg) bool {
 	for _, leg := range legs {
-		if leg.queued {
-			return true
+		if leg.queueBatch {
+			queue++
+		} else {
+			processor++
 		}
 	}
 
-	return false
+	switch {
+	case processor == 0:
+		return queueFix
+	case queue == 0:
+		return processorFix
+	default:
+		return splitFix
+	}
+}
+
+// batchProcessorHint is the fix that works whatever the exporters accept.
+const batchProcessorHint = "add batch before the exporters to reduce the number of outgoing requests"
+
+// batchHint renders the fix. It leads with the queue batcher, which is where
+// upstream is steering and which sits behind the retry logic rather than in
+// front of it -- unless the exporters have nowhere to write it, and then the
+// processor is the only batching on offer. "target" names what to configure
+// and "subject" agrees with the verb after it.
+func batchHint(target, subject string, fix batchFix) string {
+	switch fix {
+	case queueFix:
+		return "configure " + sendingQueueKey + "." + batchKey + " on " + target + ", which batches behind the " +
+			"retry queue; the batch processor also works but drops data that fails to send"
+	case processorFix:
+		return batchProcessorHint + "; " + subject + " no " + sendingQueueKey + "." + batchKey + " to batch in"
+	default:
+		// splitFix, where the exporters disagree: the processor is named on its
+		// own, since the clause explaining why would be false of half of them.
+		return batchProcessorHint
+	}
+}
+
+// batchDocsFor points at the page the hint rests on: the queue batcher's
+// settings, or the processor's where the hint names the processor.
+func batchDocsFor(fix batchFix) string {
+	if fix == queueFix {
+		return exporterQueueDocs
+	}
+
+	return batchDocs
+}
+
+// unbatchedLeg is an exporter reference whose exporter batches nothing, and
+// whether the targeted release lets that exporter write sending_queue.batch.
+// One that cannot -- debug and nop among them, and every exporter on a release
+// before upstream put a batcher in the queue -- can only be batched in front
+// of, and a hint naming a setting it does not have would be no fix.
+type unbatchedLeg struct {
+	ref        config.Ref
+	queueBatch bool
 }
 
 // exportLegs reads what each of a pipeline's exporters does about batching. It
@@ -345,8 +400,8 @@ func exportLegs(ctx *Context, p config.Pipeline) (int, []unbatchedLeg) {
 			continue
 		}
 
-		if state, queued := queueBatching(ctx, c); state == batchNone {
-			unbatched = append(unbatched, unbatchedLeg{ref: ref, queued: queued})
+		if readQueueBatching(c) == batchNone {
+			unbatched = append(unbatched, unbatchedLeg{ref: ref, queueBatch: acceptsQueueBatch(ctx, c.ID.Type)})
 		}
 	}
 
@@ -357,10 +412,9 @@ func exportLegs(ctx *Context, p config.Pipeline) (int, []unbatchedLeg) {
 type batching int
 
 const (
-	// batchUnknown is an exporter this rule cannot read: one whose settings a
-	// merge key or an expansion supplies, or a type the field schema does not
-	// describe. Neither a finding against it nor one that counts it as batching
-	// would rest on anything.
+	// batchUnknown is an exporter whose settings this rule cannot read: one a
+	// merge key or an expansion supplies. Neither a finding against it nor one
+	// that counts it as batching would rest on anything.
 	batchUnknown batching = iota
 	// batchNone is an exporter that batches nothing before it sends.
 	batchNone
@@ -368,30 +422,15 @@ const (
 	batchQueue
 )
 
-// queueBatching reports whether an exporter batches what it sends, and whether
-// it has a sending queue to batch in at all.
+// readQueueBatching reads an exporter's queue as the document writes it. Only
+// the top level is read, which is where the queue sits, the same as
+// readSendingQueue reads it.
 //
-// The queue batcher is off by default, so an exporter that does not write it is
-// an exporter that does not batch -- but only where the field schema describes
-// the type at all. Where it does not, the same principle the field rules follow
-// applies: what cannot be resolved says nothing rather than something wrong,
-// and an exporter this linter knows nothing about is not one it can say sends a
-// span at a time.
-func queueBatching(ctx *Context, c config.Component) (batching, bool) {
-	state, written := readQueueBatching(c)
-	queued := acceptsQueue(ctx, c.ID.Type, written)
-
-	if state == batchNone && !describedExporter(ctx, c.ID.Type) {
-		return batchUnknown, queued
-	}
-
-	return state, queued
-}
-
-// readQueueBatching reads an exporter's queue as the document writes it, and
-// reports whether a queue is written at all. Only the top level is read, which
-// is where the queue sits, the same as readSendingQueue reads it.
-func readQueueBatching(c config.Component) (batching, bool) {
+// The queue batcher is off by default, so an exporter whose settings do not
+// write it is an exporter that does not batch there. That reading is the
+// document's alone: what the field schema knows about the type decides which
+// fix the hint can name, not whether a batcher nobody wrote is running.
+func readQueueBatching(c config.Component) batching {
 	var block *yaml.Node
 
 	merged := false
@@ -415,18 +454,18 @@ func readQueueBatching(c config.Component) (batching, bool) {
 	case block != nil && block.Kind == yaml.MappingNode:
 		// A merge outside the block cannot reach into one the exporter writes
 		// itself: a key present locally replaces the merged value outright.
-		return readBatchBlock(block), true
+		return readBatchBlock(block)
 	case block != nil && !isNull(block):
 		// A queue the collector builds from an expansion may well be one that
 		// batches, and nothing here can see what it holds.
-		return batchUnknown, true
+		return batchUnknown
 	case merged:
-		return batchUnknown, false
+		return batchUnknown
 	}
 
 	// An empty queue, or none written at all, takes the defaults, and the
 	// batcher is not one of them.
-	return batchNone, block != nil
+	return batchNone
 }
 
 // readBatchBlock reads the one queue setting that decides whether the exporter
@@ -458,18 +497,49 @@ func readBatchBlock(block *yaml.Node) batching {
 }
 
 // describedExporter reports whether the field schema describes the exporter
-// type's settings at all. Where it does, a queue batch nobody wrote is a queue
-// batch that does not run, and a queue the type has no field for is a queue it
-// does not have. Where it does not, neither claim holds, and that covers four
-// shapes: no schema was resolved at all, the type is not in it, the type is in
-// it with its settings left open, and the type is in it with no fields -- which
-// reads as "nothing could be resolved for this component" rather than "this
-// component has no settings", since the datadog exporter, which has a queue and
-// a great many other settings, sits in that bucket next to nop.
+// type's settings at all. Where it does, a queue the type has no field for is a
+// queue it does not have. Where it does not, that claim does not hold, and that
+// covers four shapes: no schema was resolved at all, the type is not in it, the
+// type is in it with its settings left open, and the type is in it with no
+// fields -- which reads as "nothing could be resolved for this component"
+// rather than "this component has no settings", since the datadog exporter,
+// which has a queue and a great many other settings, sits in that bucket next
+// to nop.
 func describedExporter(ctx *Context, typ string) bool {
 	fields := exporterFields(ctx, typ)
 
 	return fields != nil && !fields.Open && len(fields.Children) > 0
+}
+
+// acceptsQueueBatch reports whether the targeted release lets this exporter
+// write sending_queue.batch, which is what decides whether a hint may name it.
+//
+// The queue batcher is younger than the queue: a release before upstream added
+// it has a sending_queue with no batch under it, and telling a config targeting
+// that release to write one names a setting the collector rejects on startup --
+// which unknown-field, reading the same schema, would report in the same run.
+// So the schema is asked for the field itself rather than for the queue holding
+// it, and where it cannot answer -- an exporter it does not describe, or a queue
+// it leaves open, which may hold settings it does not list -- the answer is what
+// keeps the hint honest: no for the first, since nothing says the field is
+// there, and yes for the second, since nothing says it is not.
+func acceptsQueueBatch(ctx *Context, typ string) bool {
+	if !describedExporter(ctx, typ) {
+		return false
+	}
+
+	queue, held := exporterFields(ctx, typ).Children[sendingQueueKey]
+	if !held || queue == nil {
+		return false
+	}
+
+	if queue.Open {
+		return true
+	}
+
+	_, batches := queue.Children[batchKey]
+
+	return batches
 }
 
 func hasProcessorType(p config.Pipeline, typ string) bool {

--- a/pkg/rule/practice_test.go
+++ b/pkg/rule/practice_test.go
@@ -521,7 +521,7 @@ service:
 
 	assert.Equal(t, `pipeline "traces" has no batch processor, and none of its exporters batches in sending_queue`,
 		found[0].Message)
-	assert.Equal(t, "add batch before the exporters to reduce the number of outgoing requests", found[0].Hint)
+	assert.Equal(t, processorFirst+"only some of them can take a sending_queue.batch of their own", found[0].Hint)
 	assert.Contains(t, found[0].Docs, "processor/batchprocessor/README.md")
 }
 

--- a/pkg/rule/practice_test.go
+++ b/pkg/rule/practice_test.go
@@ -469,17 +469,18 @@ service:
 	assert.Equal(t, "service.pipelines.traces.exporters[1]", found[0].Path)
 }
 
+// processorFirst is the opening of every hint that leads with the processor.
+const processorFirst = "add batch before the exporters to reduce the number of outgoing requests; "
+
 // An exporter the schema says has no sending queue -- debug and nop among them
 // -- can only be batched in front of, and a hint naming a setting it does not
 // have would be no fix.
 func TestMissingBatchWithoutASendingQueue(t *testing.T) {
 	t.Parallel()
 
-	const processorFirst = "add batch before the exporters to reduce the number of outgoing requests; "
-
 	pipeline := checkRule(t, "missing-batch", debugging(""), rule.Environment{})
 	require.Len(t, pipeline, 1)
-	assert.Equal(t, processorFirst+"these exporters have no sending_queue to batch in", pipeline[0].Hint)
+	assert.Equal(t, processorFirst+"these exporters have no sending_queue.batch to batch in", pipeline[0].Hint)
 	assert.Contains(t, pipeline[0].Docs, "processor/batchprocessor/README.md")
 
 	mixed := checkRule(t, "missing-batch", `
@@ -496,7 +497,63 @@ service:
 	require.Len(t, mixed, 1)
 	assert.Equal(t, `exporter "debug" sends unbatched in pipeline "traces", which has no batch processor`,
 		mixed[0].Message)
-	assert.Equal(t, processorFirst+"this exporter has no sending_queue to batch in", mixed[0].Hint)
+	assert.Equal(t, processorFirst+"this exporter has no sending_queue.batch to batch in", mixed[0].Hint)
+}
+
+// A finding covering several exporters at once can only name the queue batcher
+// when all of them accept it. Where they disagree, naming it would be advice
+// half of them cannot take, and naming the reason the processor comes first
+// would be a claim that is false of the other half.
+func TestMissingBatchWhereTheExportersDisagree(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "missing-batch", `
+receivers: {otlp: }
+exporters:
+  debug:
+  otlphttp:
+    endpoint: http://backend:4318
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [debug, otlphttp]}
+`, rule.Environment{})
+	require.Len(t, found, 1)
+
+	assert.Equal(t, `pipeline "traces" has no batch processor, and none of its exporters batches in sending_queue`,
+		found[0].Message)
+	assert.Equal(t, "add batch before the exporters to reduce the number of outgoing requests", found[0].Hint)
+	assert.Contains(t, found[0].Docs, "processor/batchprocessor/README.md")
+}
+
+// The queue batcher is younger than the queue. On a release that has the queue
+// and not the batcher, the hint has to name the processor: writing
+// sending_queue.batch there is a setting the collector rejects on startup, and
+// unknown-field reads the same schema and would say so in the same run.
+func TestMissingBatchBeforeTheQueueHadABatcher(t *testing.T) {
+	t.Parallel()
+
+	found := runMissingBatch(t, exporting(""), &schema.Schema{
+		CollectorVersion: "v0.110.0",
+		Components: map[config.Kind]map[string]*schema.Component{
+			config.KindExporter: {
+				// The sending_queue upstream shipped before the batcher moved
+				// into it: closed, and with no batch under it.
+				"otlphttp": {Type: "otlphttp", Fields: &schema.Field{Type: "map",
+					Children: map[string]*schema.Field{
+						"endpoint": {Type: "string"},
+						"sending_queue": {Type: "map", Children: map[string]*schema.Field{
+							"enabled":    {Type: "bool"},
+							"queue_size": {Type: "int"},
+							"storage":    {Type: "string"},
+						}},
+					}}},
+			},
+		},
+	})
+	require.Len(t, found, 1)
+
+	assert.Equal(t, processorFirst+"these exporters have no sending_queue.batch to batch in", found[0].Hint)
+	assert.Contains(t, found[0].Docs, "processor/batchprocessor/README.md")
 }
 
 func TestMissingBatchStaysQuiet(t *testing.T) {
@@ -568,16 +625,6 @@ service:
   pipelines:
     traces: {receivers: [otlp], exporters: [otlphttp]}
 `,
-		// The schema resolved no fields for this one, so there is nothing to
-		// say what it does before it sends. testSchema's logging exporter has
-		// the same shape as the datadog exporter's entry.
-		"an exporter the schema does not describe": `
-receivers: {otlp: }
-exporters: {logging: }
-service:
-  pipelines:
-    traces: {receivers: [otlp], exporters: [logging]}
-`,
 		// A connector is not a leg out of the collector: it feeds another
 		// pipeline, which has exporters of its own to batch on.
 		"a pipeline that only feeds a connector": `
@@ -622,20 +669,73 @@ exporters:
 	}
 }
 
-// Without a schema there is nothing to say what an exporter does before it
-// sends, and the field rules' principle applies: partial coverage says nothing
-// rather than something wrong.
-func TestMissingBatchWithoutASchema(t *testing.T) {
+// What a schema does not describe is still a pipeline with no batch processor
+// and no batcher written under any of its queues, so the finding stands. It is
+// the hint that gives way: nothing says sending_queue.batch is a setting these
+// exporters would accept, so it names the one fix that needs no schema.
+//
+// The exporter with no fields is the shape that matters most. testSchema's
+// logging entry has it, and so does the datadog exporter's, which really does
+// carry a queue and a great many other settings.
+func TestMissingBatchWhereTheSchemaSaysNothing(t *testing.T) {
 	t.Parallel()
 
-	f, err := config.Parse("test.yaml", []byte(exporting("")))
+	tests := map[string]struct {
+		src    string
+		schema *schema.Schema
+	}{
+		"no schema at all":           {src: exporting(""), schema: &schema.Schema{}},
+		"an exporter with no fields": {src: exportingLogging(), schema: testSchema()},
+		"a type the schema misses":   {src: exportingUnknownType(), schema: testSchema()},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			found := runMissingBatch(t, tt.src, tt.schema)
+			require.Len(t, found, 1)
+			assert.Equal(t, processorFirst+"these exporters have no sending_queue.batch to batch in", found[0].Hint)
+			assert.Contains(t, found[0].Docs, "processor/batchprocessor/README.md")
+		})
+	}
+}
+
+// exportingLogging wires up the exporter testSchema describes with no fields,
+// which is the shape the datadog entry has.
+func exportingLogging() string {
+	return `
+receivers: {otlp: }
+exporters: {logging: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [logging]}
+`
+}
+
+// exportingUnknownType wires up an exporter the schema has no entry for at all.
+func exportingUnknownType() string {
+	return `
+receivers: {otlp: }
+exporters: {kafka: }
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [kafka]}
+`
+}
+
+// runMissingBatch runs the rule against a schema the caller chooses, which
+// checkRule does not allow.
+func runMissingBatch(t *testing.T, src string, s *schema.Schema) diag.Diagnostics {
+	t.Helper()
+
+	f, err := config.Parse("test.yaml", []byte(src))
 	require.NoError(t, err, "parse")
 
 	r, ok := rule.Lookup("missing-batch")
 	require.True(t, ok, "rule is not registered")
 
-	found := rule.Run(r, rule.Context{File: f, Schema: &schema.Schema{}, Index: rule.NewIndex(f)}, r.Severity())
-	assert.Empty(t, found)
+	return rule.Run(r, rule.Context{File: f, Schema: s, Index: rule.NewIndex(f)}, r.Severity())
 }
 
 func TestNoPersistentQueue(t *testing.T) {


### PR DESCRIPTION
Follow-up to #84. Four fixes to `missing-batch`, each reproduced against the schemas in `testdata/schemas/`.

### The hint named a setting the targeted release rejects

The hint chose between the queue batcher and the processor by asking whether the exporter type has a `sending_queue`. The batcher is younger than the queue, so on a release from before it moved in — `v0.110.0`, which this repo ships a schema for — every exporter has a `sending_queue`, none of them has a `batch` under it, and the rule recommended one anyway:

```
$ otelcol-config-lint run --distribution core --collector-version v0.110.0 config.yaml
config.yaml:10:5: info: pipeline "traces" has no batch processor, ... [missing-batch]
    hint: configure sending_queue.batch on the exporters, ...
```

Take that advice and the same run answers:

```
config.yaml:9:7: warning: unknown setting "batch" for exporters.otlphttp [unknown-field]
    hint: accepted settings: enabled, num_consumers, queue_size, storage
```

`sending_queue` is a closed map on that release, so the collector refuses to start on the config the linter asked for. The schema is now asked for `sending_queue.batch` itself; a queue it leaves open counts as one that may hold it, so nothing changes on v0.157.

### One finding covering several exporters took the optimistic wording

`anyQueued` picked the exporter-side hint as soon as one leg had a queue, so a pipeline exporting to `debug` and `otlphttp` was told to configure `sending_queue.batch` on both — and `debug` has no queue at all. It now names the queue batcher only when every exporter accepts it, and falls back to the processor on its own where they disagree, since the clause explaining why would be false of half of them.

### The schema decided whether there was a finding at all

An exporter the schema described no settings for was counted as unknown rather than as not batching. In contrib v0.157 that bucket is exactly `datadog` and `nop`, so a datadog-only pipeline got no `missing-batch` finding at all — where before #84 it did — and the rule went silent whenever no schema resolved.

But the queue batcher is off until something turns it on, and that is the document's to say: a config writing no `sending_queue.batch` is not batching there whatever the schema knows about the type. The two readings are now separate — **the document decides the finding, the schema decides which fix the hint may name**. An exporter whose settings a merge key or an expansion supplies stays unknown, since that one really may be batching.

This also settles a contradiction inside #84: the README promised `nop` the processor-named hint, and the code passed over it in silence. The README is now what the code does.

### Tests

- `TestMissingBatchBeforeTheQueueHadABatcher` — a v0.110-shaped queue gets the processor.
- `TestMissingBatchWhereTheExportersDisagree` — mixed legs get the processor without the false clause.
- `TestMissingBatchWhereTheSchemaSaysNothing` — no schema, an exporter with no fields, and a type the schema misses all report, all with the processor hint.
- `TestMissingBatchWithoutASendingQueue` — hint wording is now `no sending_queue.batch to batch in`, which is true both of `debug`, which has no queue, and of a release whose queue has no batcher.

`go test ./...` and `golangci-lint run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)