### PR TITLE
feat(cmd): lay the settings file out the way golangci-lint does, and publish a schema for it

### DIFF
--- a/.github/workflows/config-schema.yaml
+++ b/.github/workflows/config-schema.yaml
@@ -1,0 +1,63 @@
+name: config-schema
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  config-schema:
+    # otelcol-config-lint.schema.json is what an editor checks a settings file
+    # against, and it lists every rule the linter carries. Nothing else notices
+    # when it falls behind: the linter keeps accepting a rule the schema has
+    # never heard of, and the only symptom is an editor underlining a name that
+    # works. So it is generated, and this job is what makes that stick.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: 1.25
+
+      - name: Check the committed schema matches the generator
+        run: |
+          make config-schema
+          git diff --exit-code -- otelcol-config-lint.schema.json ||
+            { echo 'otelcol-config-lint.schema.json is stale; run: make config-schema' >&2; exit 1; }
+
+      - name: Install check-jsonschema
+        run: pipx install check-jsonschema
+
+      # A schema that is not itself valid is worse than none: an editor drops it
+      # silently and checks nothing, which reads exactly like a file with no
+      # mistakes in it.
+      - name: Check the schema against the JSON Schema metaschema
+        run: check-jsonschema --check-metaschema otelcol-config-lint.schema.json
+
+      # The fixtures are the contract between the schema and the loader, and Go
+      # holds the loader to the same two directories -- see
+      # TestTheSettingsFixturesAreWhatTheySayTheyAre. A schema that drifted
+      # would show up as one of the two disagreeing about a file.
+      - name: Check the schema accepts every valid settings file
+        run: |
+          check-jsonschema --schemafile otelcol-config-lint.schema.json \
+            testdata/settings/valid/*.yaml
+
+      - name: Check the schema rejects every invalid settings file
+        run: |
+          rc=0
+
+          for file in testdata/settings/invalid/*.yaml; do
+            if check-jsonschema --schemafile otelcol-config-lint.schema.json "${file}" >/dev/null 2>&1; then
+              echo "${file} should not have validated against the schema" >&2
+              rc=1
+            fi
+          done
+
+          exit "${rc}"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILDERS ?= \
 	k8s=$(RELEASES)/distributions/otelcol-k8s/manifest.yaml \
 	otlp=$(RELEASES)/distributions/otelcol-otlp/manifest.yaml
 
-.PHONY: all build build-snapshot test lint lint-fix fmt schemas release-pin clean
+.PHONY: all build build-snapshot test lint lint-fix fmt schemas config-schema release-pin clean
 
 all: lint test build
 
@@ -60,6 +60,12 @@ release-pin:
 	sed -i.bak -E 's|^(FROM ghcr\.io/minuk-dev/otelcol-config-lint):[^ ]*|\1:$(RELEASE:v%=%)|' Dockerfile
 	@rm -f Dockerfile.bak
 	@echo 'The action now runs $(RELEASE:v%=%); commit that and tag the commit $(RELEASE).'
+
+# Regenerate the JSON Schema an editor checks a settings file against. It lists
+# the rule names, so it moves whenever the rule set does; CI fails on a copy
+# that does not match, since a stale one underlines names that work.
+config-schema:
+	go run ./cmd/otelcol-config-lint config-schema > otelcol-config-lint.schema.json
 
 # Regenerate the component schemas from the distributions' builder manifests.
 schemas:

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ Every input is the `run` flag of the same name, so the flag table below is the
 whole reference: `files` (default `.`, whitespace-separated, globs allowed),
 `collector-version`, `distribution`, `schema-location` (one per line to search
 several in order), `strict`, `ignore-missing-schemas`, `min-severity`,
-`fail-on`, `disable`, `severity`, `exclude`, `output` (default `github`),
-`config`, `summary` (default `true`), `verbose` and `exit-on-error`. Only `-n`
-and `--no-color` are left out: a runner gains nothing from either.
+`fail-on`, `default`, `enable`, `disable`, `severity`, `exclude`, `output`
+(default `github`), `config`, `no-config`, `summary` (default `true`),
+`verbose` and `exit-on-error`. Only `--concurrency` and `--no-color` are left
+out: a runner gains nothing from either.
 
 The counts come back as outputs — `exit-code`, `valid`, `invalid`, `errors`,
 `skipped`, `warnings` and `infos` — so a later step can decide what to do with
@@ -113,23 +114,37 @@ otelcol-config-lint version
 
 The flags below belong to `run`:
 
-| Flag | Meaning |
-| --- | --- |
-| `--collector-version` | release to validate against, e.g. `v0.157.0` (default `latest`) |
-| `--distribution` | collector binary to validate against: `core`, `contrib` (default), `k8s` or `otlp` |
-| `--schema-location` | where to find schemas: a registry directory or URL, a `{{.Version}}`/`{{.Distribution}}` template, or `default`. Repeat to search several in order |
-| `--output` | `text`, `json`, `junit`, `tap` or `github` |
-| `--strict` | unknown component settings become errors instead of warnings |
-| `--ignore-missing-schemas` | do not fail on components absent from the schema (custom distributions) |
-| `--min-severity` | lowest severity to report: `error`, `warning`, `info` |
-| `--fail-on` | severity that makes a file invalid (default `error`) |
-| `--disable` | comma-separated rules to turn off |
-| `--severity` | comma-separated `rule=level` overrides |
-| `--exclude` | glob patterns to skip when walking directories |
-| `--kubernetes` | the config runs in a Kubernetes pod |
-| `--memory-request`, `--memory-limit` | the container's resources, e.g. `256Mi`, `1Gi`, `2G`. Either one implies `--kubernetes` |
-| `-n` | files checked in parallel |
-| `--summary`, `--verbose`, `--no-color`, `--exit-on-error` | output control |
+Every flag mirrors a key of the settings file, and each row below names the key
+it mirrors. The file is what a repository commits; a flag is how one run departs
+from it.
+
+| Flag | Settings key | Meaning |
+| --- | --- | --- |
+| `-c`, `--config` | — | settings file to read (default: `.otelcol-config-lint.yaml`, searched for here and in each parent) |
+| `--no-config` | — | ignore any settings file and use the flags alone |
+| `--collector-version` | `run.collectorVersion` | release to validate against, e.g. `v0.157.0` (default `latest`) |
+| `--distribution` | `run.distribution` | collector binary to validate against: `core`, `contrib` (default), `k8s` or `otlp` |
+| `--schema-location` | `run.schemaLocations` | where to find schemas: a registry directory or URL, a `{{.Version}}`/`{{.Distribution}}` template, or `default`. Repeat to search several in order |
+| `--strict` | `run.strict` | unknown component settings become errors instead of warnings |
+| `--ignore-missing-schemas` | `run.ignoreMissingSchemas` | do not fail on components absent from the schema (custom distributions) |
+| `--exclude` | `run.exclude` | glob patterns to skip when walking directories |
+| `-n`, `--concurrency` | `run.concurrency` | files checked in parallel |
+| `--kubernetes` | `run.kubernetes.enabled` | the config runs in a Kubernetes pod |
+| `--memory-request`, `--memory-limit` | `run.kubernetes.memoryRequest`/`.memoryLimit` | the container's resources, e.g. `256Mi`, `1Gi`, `2G`. Either one implies `--kubernetes` |
+| `--default` | `rules.default` | rule set to start from: `all` (the default) or `none` |
+| `-E`, `--enable` | `rules.enable` | rules to turn on, on top of `--default` |
+| `-D`, `--disable` | `rules.disable` | rules to turn off |
+| `--severity` | `rules.severity` | `rule=level` overrides |
+| `--min-severity` | `issues.minSeverity` | lowest severity to report: `error`, `warning`, `info` |
+| `--fail-on` | `issues.failOn` | severity that makes a file invalid (default `error`) |
+| `--exit-on-error` | `issues.exitOnError` | stop at the first file that fails |
+| `--output` | `output.format` | `text`, `json`, `junit`, `tap` or `github` |
+| `--summary` | `output.summary` | append a count of the outcomes |
+| `--verbose` | `output.verbose` | also report the files that passed, and say which settings file was read |
+| `--no-color` | `output.color` (inverted) | disable coloured output |
+
+`--enable`, `--disable`, `--severity`, `--exclude` and `--schema-location` take
+a comma-separated list, and may also be repeated.
 
 Exit codes: `0` everything passed, `1` at least one file failed, `2` the command
 could not run.
@@ -142,53 +157,136 @@ otelcol-config-lint run --output json ./configs > report.json     # machine-read
 otelcol-config-lint run --output github ./configs                 # PR annotations
 otelcol-config-lint run --collector-version v0.110.0 config.yaml  # target an older release
 otelcol-config-lint run --distribution core config.yaml           # target plain otelcol
+otelcol-config-lint run --default none -E invalid-value ./configs # run one rule and nothing else
+otelcol-config-lint run -c ci.yaml ./configs                      # a settings file of its own
 ```
 
 ### Settings file
 
-Commit the policy instead of repeating flags. `.otelcol-config-lint.yaml` in the
-working directory is picked up automatically; `--config` names another file.
-Explicit flags win over the file.
+Commit the policy instead of repeating flags. The file is laid out the way
+golangci-lint's is: **what to check** under `run`, **which rules** under
+`rules`, **what counts as a failure** under `issues`, and **how it is printed**
+under `output`.
 
 ```yaml
-collectorVersion: v0.157.0
-distribution: contrib
-minSeverity: warning
-strict: true
-exclude:
-  - "*.tmpl.yaml"
-disable:
-  - missing-batch
-severity:
-  missing-memory-limiter: warning
-schemaLocations:
-  - ./schemas      # this project's own schemas first
-  - default         # then the published registry
+version: "1"
+
+run:
+  collectorVersion: v0.157.0
+  distribution: contrib
+  strict: true
+  concurrency: 8
+  exclude:
+    - "*.tmpl.yaml"
+  schemaLocations:
+    - ./schemas       # this project's own schemas first
+    - default         # then the published registry
+
+rules:
+  default: all        # or "none", to run only what enable names
+  enable: []
+  disable:
+    - missing-batch
+  severity:
+    missing-memory-limiter: warning
+  settings: {}        # each rule's own block, keyed by rule name
+
+issues:
+  minSeverity: warning
+  failOn: error
+  exitOnError: false
+
+output:
+  format: text
+  summary: true
+  verbose: false
+  color: true
 ```
+
+Every block is optional, as is every key in it: what a file does not state keeps
+its default. A key the linter does not know is an error rather than a line that
+quietly does nothing.
+
+#### Where the file is found
+
+`.otelcol-config-lint.yaml` — or `.otelcol-config-lint.yml` — is looked for in
+the working directory and then in each parent, stopping at the directory holding
+`.git`, so one file at the repository root governs a run started from any
+subdirectory. `--config` names another file, and an explicitly named file that
+does not exist is an error. `--no-config` runs on the flags alone. `--verbose`
+prints which file was read.
+
+Explicit flags win over the file, with one exception: the rule lists merge, so
+`-D` adds to `rules.disable` rather than replacing it.
+
+#### Choosing the rules
+
+`rules.default` is the set to start from — `all`, which is every rule and what a
+file that says nothing gets, or `none`, which runs only what `enable` names.
+`disable` then takes rules out, and `severity` sets the level a rule reports at.
+Naming a rule in both `enable` and `disable` is an error rather than a silent win
+for one of them.
+
+```yaml
+rules:
+  default: none
+  enable: [unknown-component, invalid-value, undefined-reference]
+```
+
+`otelcol-config-lint list rules` prints what the policy resolves to: a rule that
+will not run is listed at severity `off`.
+
+#### Per-rule settings
+
+`rules.settings` is where a rule's own knobs go, keyed by rule name, the way
+golangci-lint's `linters.settings` works:
+
+```yaml
+rules:
+  settings:
+    some-rule:
+      threshold: 10
+```
+
+No built-in rule reads a block yet — the schema is here so one can be added
+without every settings file having to change shape. Until a rule declares that
+it takes settings, writing a block for it is reported as an error: a knob nobody
+reads is worse than a knob that is missing.
+
+#### The flat form
+
+The keys the first release put at the top level — `collectorVersion`,
+`distribution`, `schemaLocations`, `strict`, `ignoreMissingSchemas`, `summary`,
+`minSeverity`, `failOn`, `disable`, `severity`, `exclude` and `kubernetes` — are
+still read, and folded into the blocks above. A run that finds one says which
+keys to move. `output: json` is not one of them: a bare format name is still the
+shorthand for `output: {format: json}`.
 
 #### The deployment environment
 
 `memory-limiter-sizing` compares a `memory_limiter` against the container it
-runs in, which the config file cannot state. The `kubernetes` block supplies it.
+runs in, which the config file cannot state. The `run.kubernetes` block
+supplies it.
 
 It is resolved **per file**, because a run is not one deployment: an agent
 DaemonSet at `256Mi` and a gateway Deployment at `4Gi` sit in the same directory
 and are checked in the same run.
 
 ```yaml
-kubernetes:
-  enabled: true
-  memoryRequest: 512Mi        # the defaults, for any file no override matches
-  memoryLimit: 512Mi
-  overrides:
-    - paths: ["configs/agent-*.yaml"]
-      memoryRequest: 256Mi
-      memoryLimit: 256Mi
-    - paths: ["configs/gateway/*.yaml"]
-      memoryRequest: 4Gi
-      memoryLimit: 4Gi
-    - paths: ["configs/legacy/*.yaml"]
-      enabled: false          # opt a subtree back out
+run:
+  kubernetes:
+    enabled: true
+    memoryRequest: 512Mi        # the defaults, for any file no override matches
+    memoryLimit: 512Mi
+    overrides:
+      - paths: ["configs/agent-*.yaml"]
+        memoryRequest: 256Mi
+        memoryLimit: 256Mi
+      - paths: ["configs/gateway/*.yaml"]
+        memoryRequest: 4Gi
+        memoryLimit: 4Gi
+      - paths: ["configs/legacy/*.yaml"]
+        enabled: false          # opt a subtree back out
 ```
 
 - Overrides are matched in list order and the **first match wins**. A matching

--- a/README.md
+++ b/README.md
@@ -102,14 +102,16 @@ for a run that cannot change underneath a workflow.
 otelcol-config-lint run [flags] <file|dir|->...
 otelcol-config-lint list rules
 otelcol-config-lint list versions
+otelcol-config-lint config-schema
 otelcol-config-lint version
 ```
 
 | Command | Meaning |
 | --- | --- |
 | `run` | lint the given files, directories, or `-` for stdin |
-| `list rules` | the rules and their default severities, `--disable`/`--severity` applied |
+| `list rules` | the rules and the severities they will run at, the rule flags and settings file applied |
 | `list versions` | the schema versions available, honouring `--schema-location` and `--distribution` |
+| `config-schema` | the JSON Schema for the settings file, for an editor to check one against |
 | `version` | print the linter version (also available as `--version`) |
 
 The flags below belong to `run`:
@@ -252,6 +254,39 @@ No built-in rule reads a block yet — the schema is here so one can be added
 without every settings file having to change shape. Until a rule declares that
 it takes settings, writing a block for it is reported as an error: a knob nobody
 reads is worse than a knob that is missing.
+
+#### Checking the settings file in an editor
+
+`otelcol-config-lint.schema.json` is a JSON Schema for the file, so an editor
+underlines a misspelled key, a severity that is not a level, and a rule name
+that does not exist — the rule list in it is generated from the rules the linter
+carries, and CI fails on a copy that has fallen behind.
+
+Name it from the file itself, which every YAML language server reads:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/minuk-dev/otelcol-config-lint/main/otelcol-config-lint.schema.json
+```
+
+Or map it once, in VS Code's `settings.json`:
+
+```json
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/minuk-dev/otelcol-config-lint/main/otelcol-config-lint.schema.json": [
+      ".otelcol-config-lint.yaml",
+      ".otelcol-config-lint.yml"
+    ]
+  }
+}
+```
+
+`otelcol-config-lint config-schema` prints the same document, so a project that
+vendors it gets the list of rules the binary it pins actually runs:
+
+```sh
+otelcol-config-lint config-schema > otelcol-config-lint.schema.json
+```
 
 #### The flat form
 

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,10 @@ branding:
   icon: check-square
   color: purple
 
-# Every input maps onto the "run" flag of the same name, so there is nothing new
-# to learn: the CLI documentation is the action documentation. Only -n and
-# --no-color are left out; a runner has nothing to gain from either.
+# Every input maps onto the "run" flag of the same name, which in turn mirrors a
+# key of the settings file, so there is nothing new to learn: the CLI
+# documentation is the action documentation. Only --concurrency and --no-color
+# are left out; a runner has nothing to gain from either.
 inputs:
   files:
     description: Files, directories or globs to check, separated by spaces or newlines.
@@ -47,6 +48,14 @@ inputs:
     description: "Severity that makes a file invalid: error, warning or info."
     required: false
     default: error
+  default:
+    description: "Rule set to start from: all (the default) or none."
+    required: false
+    default: ""
+  enable:
+    description: Comma-separated rules to turn on, on top of the set named by "default".
+    required: false
+    default: ""
   disable:
     description: Comma-separated rules to turn off.
     required: false
@@ -64,9 +73,16 @@ inputs:
     required: false
     default: github
   config:
-    description: Settings file to read (default .otelcol-config-lint.yaml if present).
+    description: >-
+      Settings file to read. The default is .otelcol-config-lint.yaml, looked
+      for in the working directory and then in each parent, up to the
+      repository root.
     required: false
     default: ""
+  no-config:
+    description: Ignore any settings file and use the inputs alone.
+    required: false
+    default: "false"
   summary:
     description: Append a count of the outcomes to the output.
     required: false
@@ -112,11 +128,14 @@ runs:
     - --ignore-missing-schemas=${{ inputs.ignore-missing-schemas }}
     - --min-severity=${{ inputs.min-severity }}
     - --fail-on=${{ inputs.fail-on }}
+    - --default=${{ inputs.default }}
+    - --enable=${{ inputs.enable }}
     - --disable=${{ inputs.disable }}
     - --severity=${{ inputs.severity }}
     - --exclude=${{ inputs.exclude }}
     - --output=${{ inputs.output }}
     - --config=${{ inputs.config }}
+    - --no-config=${{ inputs.no-config }}
     - --summary=${{ inputs.summary }}
     - --verbose=${{ inputs.verbose }}
     - --exit-on-error=${{ inputs.exit-on-error }}

--- a/build/docker/action-entrypoint.sh
+++ b/build/docker/action-entrypoint.sh
@@ -16,11 +16,14 @@ in_strict="false"
 in_ignore_missing_schemas="false"
 in_min_severity=""
 in_fail_on=""
+in_default=""
+in_enable=""
 in_disable=""
 in_severity=""
 in_exclude=""
 in_output="github"
 in_config=""
+in_no_config="false"
 in_summary="true"
 in_verbose="false"
 in_exit_on_error="false"
@@ -45,11 +48,14 @@ for arg in "$@"; do
     --ignore-missing-schemas) in_ignore_missing_schemas="${value}" ;;
     --min-severity) in_min_severity="${value}" ;;
     --fail-on) in_fail_on="${value}" ;;
+    --default) in_default="${value}" ;;
+    --enable) in_enable="${value}" ;;
     --disable) in_disable="${value}" ;;
     --severity) in_severity="${value}" ;;
     --exclude) in_exclude="${value}" ;;
     --output) in_output="${value:-github}" ;;
     --config) in_config="${value}" ;;
+    --no-config) in_no_config="${value}" ;;
     --summary) in_summary="${value}" ;;
     --verbose) in_verbose="${value}" ;;
     --exit-on-error) in_exit_on_error="${value}" ;;
@@ -81,10 +87,13 @@ value collector-version "${in_collector_version}"
 value distribution "${in_distribution}"
 value min-severity "${in_min_severity}"
 value fail-on "${in_fail_on}"
+value default "${in_default}"
+value enable "${in_enable}"
 value disable "${in_disable}"
 value severity "${in_severity}"
 value exclude "${in_exclude}"
 value config "${in_config}"
+toggle no-config "${in_no_config}"
 toggle strict "${in_strict}"
 toggle ignore-missing-schemas "${in_ignore_missing_schemas}"
 toggle verbose "${in_verbose}"

--- a/otelcol-config-lint.schema.json
+++ b/otelcol-config-lint.schema.json
@@ -1,0 +1,425 @@
+{
+  "$defs": {
+    "quantity": {
+      "description": "A Kubernetes quantity such as 512Mi, 1Gi or 2G, or a bare byte count.",
+      "pattern": "^[0-9]+(\\.[0-9]+)?(([KMGTPE]i)|[kMGTPE])?$",
+      "type": "string"
+    },
+    "rule": {
+      "description": "A rule the linter carries.",
+      "enum": [
+        "batch-size-bounds",
+        "component-stability",
+        "connector-wiring",
+        "debug-exporter-verbosity",
+        "debug-extension-exposed",
+        "deprecated-component",
+        "deprecated-field",
+        "duplicate-key",
+        "duplicate-reference",
+        "empty-pipeline",
+        "hardcoded-secret",
+        "insecure-tls",
+        "invalid-pipeline-key",
+        "invalid-value",
+        "memory-limiter-config",
+        "memory-limiter-sizing",
+        "missing-batch",
+        "missing-memory-limiter",
+        "no-persistent-queue",
+        "processor-order",
+        "receiver-binds-all-interfaces",
+        "required-field",
+        "service-required",
+        "signal-support",
+        "undefined-extension-reference",
+        "undefined-reference",
+        "unknown-component",
+        "unknown-field",
+        "unknown-pipeline-key",
+        "unknown-service-key",
+        "unknown-top-level-key",
+        "unused-component",
+        "wrong-node-type"
+      ],
+      "type": "string"
+    },
+    "severity": {
+      "description": "A severity level.",
+      "enum": [
+        "error",
+        "warning",
+        "info",
+        "off"
+      ],
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/minuk-dev/otelcol-config-lint/main/otelcol-config-lint.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Settings for otelcol-config-lint, read from .otelcol-config-lint.yaml or --config.",
+  "properties": {
+    "collectorVersion": {
+      "deprecated": true,
+      "description": "Deprecated: moved to run.collectorVersion.",
+      "examples": [
+        "latest",
+        "v0.157.0"
+      ],
+      "type": "string"
+    },
+    "disable": {
+      "deprecated": true,
+      "description": "Deprecated: moved to rules.disable.",
+      "items": {
+        "$ref": "#/$defs/rule"
+      },
+      "type": "array"
+    },
+    "distribution": {
+      "deprecated": true,
+      "description": "Deprecated: moved to run.distribution.",
+      "examples": [
+        "core",
+        "contrib",
+        "k8s",
+        "otlp"
+      ],
+      "type": "string"
+    },
+    "exclude": {
+      "deprecated": true,
+      "description": "Deprecated: moved to run.exclude.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "failOn": {
+      "$ref": "#/$defs/severity",
+      "deprecated": true,
+      "description": "Deprecated: moved to issues.failOn."
+    },
+    "ignoreMissingSchemas": {
+      "deprecated": true,
+      "description": "Deprecated: moved to run.ignoreMissingSchemas.",
+      "type": "boolean"
+    },
+    "issues": {
+      "additionalProperties": false,
+      "description": "Which findings are reported, and which of them fail a file.",
+      "properties": {
+        "exitOnError": {
+          "description": "Stop the run at the first file that fails.",
+          "type": "boolean"
+        },
+        "failOn": {
+          "$ref": "#/$defs/severity",
+          "description": "The severity that makes a file invalid."
+        },
+        "minSeverity": {
+          "$ref": "#/$defs/severity",
+          "description": "The lowest severity worth printing."
+        }
+      },
+      "type": "object"
+    },
+    "kubernetes": {
+      "additionalProperties": false,
+      "deprecated": true,
+      "description": "Deprecated: moved to run.kubernetes.",
+      "properties": {
+        "enabled": {
+          "description": "The configs run in a Kubernetes pod. Defaults to true when either memory number is written.",
+          "type": "boolean"
+        },
+        "memoryLimit": {
+          "$ref": "#/$defs/quantity",
+          "description": "The container's memory limit, e.g. 512Mi."
+        },
+        "memoryRequest": {
+          "$ref": "#/$defs/quantity",
+          "description": "The container's memory request, e.g. 256Mi."
+        },
+        "overrides": {
+          "description": "Per-path environments, matched in list order; the first match wins.",
+          "items": {
+            "additionalProperties": false,
+            "description": "One path-matched environment. It replaces the defaults for the files it matches rather than merging with them.",
+            "properties": {
+              "enabled": {
+                "description": "The configs run in a Kubernetes pod. Defaults to true when either memory number is written.",
+                "type": "boolean"
+              },
+              "memoryLimit": {
+                "$ref": "#/$defs/quantity",
+                "description": "The container's memory limit, e.g. 512Mi."
+              },
+              "memoryRequest": {
+                "$ref": "#/$defs/quantity",
+                "description": "The container's memory request, e.g. 256Mi."
+              },
+              "paths": {
+                "description": "Glob patterns, matched exactly as run.exclude is.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "required": [
+              "paths"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "minSeverity": {
+      "$ref": "#/$defs/severity",
+      "deprecated": true,
+      "description": "Deprecated: moved to issues.minSeverity."
+    },
+    "output": {
+      "description": "How the findings are printed. A bare format name is shorthand for the block.",
+      "oneOf": [
+        {
+          "description": "Output format.",
+          "enum": [
+            "text",
+            "json",
+            "junit",
+            "tap",
+            "github"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "description": "Print in colour when the destination is a terminal.",
+              "type": "boolean"
+            },
+            "format": {
+              "description": "Output format.",
+              "enum": [
+                "text",
+                "json",
+                "junit",
+                "tap",
+                "github"
+              ],
+              "type": "string"
+            },
+            "summary": {
+              "description": "Append a count of the outcomes.",
+              "type": "boolean"
+            },
+            "verbose": {
+              "description": "Also report the files that passed, and say which settings file was read.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "rules": {
+      "additionalProperties": false,
+      "description": "Which rules run and at what level.",
+      "properties": {
+        "default": {
+          "description": "The set to start from: every rule, or only what enable names.",
+          "enum": [
+            "all",
+            "none"
+          ],
+          "type": "string"
+        },
+        "disable": {
+          "description": "Rules to turn off. Naming a rule here and under enable is an error.",
+          "items": {
+            "$ref": "#/$defs/rule"
+          },
+          "type": "array"
+        },
+        "enable": {
+          "description": "Rules to turn on, on top of the set named by default.",
+          "items": {
+            "$ref": "#/$defs/rule"
+          },
+          "type": "array"
+        },
+        "settings": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "description": "Each rule's own settings, keyed by rule name. No built-in rule reads a block yet, so writing one is currently reported as an error.",
+          "propertyNames": {
+            "$ref": "#/$defs/rule"
+          },
+          "type": "object"
+        },
+        "severity": {
+          "additionalProperties": {
+            "$ref": "#/$defs/severity"
+          },
+          "description": "The level a rule reports at. Writing \"off\" disables it, exactly as listing it under disable does.",
+          "propertyNames": {
+            "$ref": "#/$defs/rule"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "run": {
+      "additionalProperties": false,
+      "description": "What to check, and against which collector.",
+      "properties": {
+        "collectorVersion": {
+          "description": "Collector release to validate against. \"latest\" uses the newest schema available.",
+          "examples": [
+            "latest",
+            "v0.157.0"
+          ],
+          "type": "string"
+        },
+        "concurrency": {
+          "description": "How many files to check in parallel.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "distribution": {
+          "description": "Collector binary the config will run on. Any distribution the schema registry carries is accepted, so this is not a closed set.",
+          "examples": [
+            "core",
+            "contrib",
+            "k8s",
+            "otlp"
+          ],
+          "type": "string"
+        },
+        "exclude": {
+          "description": "Glob patterns to skip when walking a directory. Matched against both the whole path and the base name; there is no \"**\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ignoreMissingSchemas": {
+          "description": "Do not fail on components the schema does not describe, for a custom distribution.",
+          "type": "boolean"
+        },
+        "kubernetes": {
+          "additionalProperties": false,
+          "description": "The pods the configs run in, for the rules that cannot judge a config without knowing what it runs in.",
+          "properties": {
+            "enabled": {
+              "description": "The configs run in a Kubernetes pod. Defaults to true when either memory number is written.",
+              "type": "boolean"
+            },
+            "memoryLimit": {
+              "$ref": "#/$defs/quantity",
+              "description": "The container's memory limit, e.g. 512Mi."
+            },
+            "memoryRequest": {
+              "$ref": "#/$defs/quantity",
+              "description": "The container's memory request, e.g. 256Mi."
+            },
+            "overrides": {
+              "description": "Per-path environments, matched in list order; the first match wins.",
+              "items": {
+                "additionalProperties": false,
+                "description": "One path-matched environment. It replaces the defaults for the files it matches rather than merging with them.",
+                "properties": {
+                  "enabled": {
+                    "description": "The configs run in a Kubernetes pod. Defaults to true when either memory number is written.",
+                    "type": "boolean"
+                  },
+                  "memoryLimit": {
+                    "$ref": "#/$defs/quantity",
+                    "description": "The container's memory limit, e.g. 512Mi."
+                  },
+                  "memoryRequest": {
+                    "$ref": "#/$defs/quantity",
+                    "description": "The container's memory request, e.g. 256Mi."
+                  },
+                  "paths": {
+                    "description": "Glob patterns, matched exactly as run.exclude is.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "paths"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "schemaLocations": {
+          "description": "Where to find schemas, searched in order: a directory, a URL, a {{.Version}}/{{.Distribution}} template, or \"default\" for the published registry.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "strict": {
+          "description": "Report unknown component settings as errors instead of warnings.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "schemaLocations": {
+      "deprecated": true,
+      "description": "Deprecated: moved to run.schemaLocations.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "severity": {
+      "additionalProperties": {
+        "$ref": "#/$defs/severity"
+      },
+      "deprecated": true,
+      "description": "Deprecated: moved to rules.severity.",
+      "propertyNames": {
+        "$ref": "#/$defs/rule"
+      },
+      "type": "object"
+    },
+    "strict": {
+      "deprecated": true,
+      "description": "Deprecated: moved to run.strict.",
+      "type": "boolean"
+    },
+    "summary": {
+      "deprecated": true,
+      "description": "Deprecated: moved to output.summary.",
+      "type": "boolean"
+    },
+    "version": {
+      "description": "The schema this file is written against. A file that omits it is read as 1.",
+      "enum": [
+        "1"
+      ],
+      "type": "string"
+    }
+  },
+  "title": "otelcol-config-lint settings",
+  "type": "object"
+}

--- a/pkg/cmd/otelcol-config-lint/configschema.go
+++ b/pkg/cmd/otelcol-config-lint/configschema.go
@@ -1,0 +1,43 @@
+package otelcolconfiglint
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// newConfigSchemaCommand builds "config-schema", which prints the JSON Schema
+// for the settings file. It is a command rather than only a committed file so
+// the copy an editor is pointed at can be regenerated from the binary in hand,
+// and so the rule names it lists are the ones that binary actually runs.
+//
+// It is spelled "config-schema" and not "schema" because a schema in this tool
+// is otherwise a collector's, which --schema-location and "list versions" are
+// about; this one describes the linter's own settings.
+func newConfigSchemaCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config-schema",
+		Short: "Print the JSON Schema for the settings file",
+		Long: "Print the JSON Schema for the settings file, for an editor to check one against\n" +
+			"as it is written.\n\n" +
+			"The same document is committed as " + SettingsSchemaFile + " and served from\n" +
+			SettingsSchemaID + "\n\n" +
+			"A settings file can name it directly, which every YAML language server reads:\n\n" +
+			"  # yaml-language-server: $schema=" + SettingsSchemaID,
+		Example: "  otelcol-config-lint config-schema > " + SettingsSchemaFile,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			doc, err := SettingsSchema()
+			if err != nil {
+				return err
+			}
+
+			_, err = cmd.OutOrStdout().Write(doc)
+			if err != nil {
+				return fmt.Errorf("write schema: %w", err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/pkg/cmd/otelcol-config-lint/environment.go
+++ b/pkg/cmd/otelcol-config-lint/environment.go
@@ -33,6 +33,12 @@ type kubernetesSettings struct {
 	Overrides []kubernetesOverride `yaml:"overrides"`
 }
 
+// written reports whether the block says anything at all, which is how the
+// flat first-release form knows it has nothing to fold in.
+func (k kubernetesSettings) written() bool {
+	return k.Enabled != nil || k.MemoryRequest != "" || k.MemoryLimit != "" || len(k.Overrides) > 0
+}
+
 // kubernetesOverride is one path-matched entry of the kubernetes block. It
 // replaces the defaults for the files it matches rather than merging with
 // them, so what a file resolves to is stated in one place.

--- a/pkg/cmd/otelcol-config-lint/jsonschema.go
+++ b/pkg/cmd/otelcol-config-lint/jsonschema.go
@@ -1,0 +1,347 @@
+package otelcolconfiglint
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/ruleset"
+)
+
+// SettingsSchemaFile is where the generated schema is committed, and the name
+// the published copy is served under.
+const SettingsSchemaFile = "otelcol-config-lint.schema.json"
+
+// SettingsSchemaID is the URL an editor points at. It names the copy on main
+// rather than a release, because the rule names it enumerates track the rules
+// the linter has, and an editor checking a file against a year-old list would
+// underline names that work.
+const SettingsSchemaID = "https://raw.githubusercontent.com/minuk-dev/" +
+	"otelcol-config-lint/main/" + SettingsSchemaFile
+
+// object is one JSON Schema node. The schema is built as data rather than
+// written out by hand so the parts that move -- the rule names, the severity
+// levels -- come from the same declarations the linter itself reads.
+type object = map[string]any
+
+// SettingsSchema returns the JSON Schema for a settings file, indented and
+// newline-terminated, exactly as the committed copy is written.
+func SettingsSchema() ([]byte, error) {
+	doc, err := json.MarshalIndent(settingsSchema(), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode schema: %w", err)
+	}
+
+	return append(doc, '\n'), nil
+}
+
+// settingsSchema builds the whole document. Every block is closed --
+// additionalProperties is false throughout -- because the linter rejects a key
+// it does not know, and an editor that accepted one would be quietly promising
+// that a misspelled setting is in force.
+func settingsSchema() object {
+	properties := object{
+		"version": object{
+			"description": "The schema this file is written against. A file that omits it is read as " +
+				SettingsVersion + ".",
+			"type": "string",
+			"enum": []any{SettingsVersion},
+		},
+		"run":    runSchema(),
+		"rules":  rulesSchema(),
+		"issues": issuesSchema(),
+		"output": outputSchema(),
+	}
+
+	maps.Copy(properties, legacySchema())
+
+	return object{
+		"$schema":              "https://json-schema.org/draft/2020-12/schema",
+		"$id":                  SettingsSchemaID,
+		"title":                "otelcol-config-lint settings",
+		"description":          "Settings for otelcol-config-lint, read from " + DefaultSettingsFile + " or --config.",
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties":           properties,
+		"$defs": object{
+			"rule":     ruleSchema(),
+			"severity": severitySchema(),
+			"quantity": quantitySchema(),
+		},
+	}
+}
+
+// runSchema is the "run" block: which collector the configs target and which
+// files are checked against it.
+func runSchema() object {
+	return block("What to check, and against which collector.", object{
+		"collectorVersion": object{
+			"description": "Collector release to validate against. \"latest\" uses the newest schema available.",
+			"type":        "string",
+			"examples":    []any{"latest", "v0.157.0"},
+		},
+		"distribution": object{
+			"description": "Collector binary the config will run on. Any distribution the schema " +
+				"registry carries is accepted, so this is not a closed set.",
+			"type":     "string",
+			"examples": []any{"core", "contrib", "k8s", "otlp"},
+		},
+		"schemaLocations": object{
+			"description": "Where to find schemas, searched in order: a directory, a URL, a " +
+				"{{.Version}}/{{.Distribution}} template, or \"default\" for the published registry.",
+			"type":  "array",
+			"items": object{"type": "string"},
+		},
+		"strict": object{
+			"description": "Report unknown component settings as errors instead of warnings.",
+			"type":        "boolean",
+		},
+		"ignoreMissingSchemas": object{
+			"description": "Do not fail on components the schema does not describe, for a custom distribution.",
+			"type":        "boolean",
+		},
+		"concurrency": object{
+			"description": "How many files to check in parallel.",
+			"type":        "integer",
+			"minimum":     1,
+		},
+		"exclude": object{
+			"description": "Glob patterns to skip when walking a directory. Matched against both the " +
+				"whole path and the base name; there is no \"**\".",
+			"type":  "array",
+			"items": object{"type": "string"},
+		},
+		"kubernetes": kubernetesSchema(),
+	})
+}
+
+// kubernetesSchema is the deployment environment the sizing rules need, which
+// a config file cannot state about itself.
+func kubernetesSchema() object {
+	defaults := object{
+		"enabled": object{
+			"description": "The configs run in a Kubernetes pod. Defaults to true when either memory number is written.",
+			"type":        "boolean",
+		},
+		"memoryRequest": ref("#/$defs/quantity", "The container's memory request, e.g. 256Mi."),
+		"memoryLimit":   ref("#/$defs/quantity", "The container's memory limit, e.g. 512Mi."),
+	}
+
+	override := object{
+		"description": "One path-matched environment. It replaces the defaults for the files it " +
+			"matches rather than merging with them.",
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"paths"},
+		"properties": object{
+			"paths": object{
+				"description": "Glob patterns, matched exactly as run.exclude is.",
+				"type":        "array",
+				"minItems":    1,
+				"items":       object{"type": "string"},
+			},
+			"enabled":       defaults["enabled"],
+			"memoryRequest": defaults["memoryRequest"],
+			"memoryLimit":   defaults["memoryLimit"],
+		},
+	}
+
+	properties := object{"overrides": object{
+		"description": "Per-path environments, matched in list order; the first match wins.",
+		"type":        "array",
+		"items":       override,
+	}}
+	maps.Copy(properties, defaults)
+
+	return block("The pods the configs run in, for the rules that cannot judge a config "+
+		"without knowing what it runs in.", properties)
+}
+
+// rulesSchema is the "rules" block: which rules run, at what level, and with
+// what settings of their own.
+func rulesSchema() object {
+	return block("Which rules run and at what level.", object{
+		"default": object{
+			"description": "The set to start from: every rule, or only what enable names.",
+			"type":        "string",
+			"enum":        []any{defaultAll, defaultNone},
+		},
+		"enable": object{
+			"description": "Rules to turn on, on top of the set named by default.",
+			"type":        "array",
+			"items":       ref("#/$defs/rule", ""),
+		},
+		"disable": object{
+			"description": "Rules to turn off. Naming a rule here and under enable is an error.",
+			"type":        "array",
+			"items":       ref("#/$defs/rule", ""),
+		},
+		"severity": object{
+			"description": "The level a rule reports at. Writing \"off\" disables it, exactly as " +
+				"listing it under disable does.",
+			"type":                 "object",
+			"propertyNames":        ref("#/$defs/rule", ""),
+			"additionalProperties": ref("#/$defs/severity", ""),
+		},
+		"settings": object{
+			"description": "Each rule's own settings, keyed by rule name. No built-in rule reads a " +
+				"block yet, so writing one is currently reported as an error.",
+			"type":                 "object",
+			"propertyNames":        ref("#/$defs/rule", ""),
+			"additionalProperties": object{"type": "object"},
+		},
+	})
+}
+
+// issuesSchema is the "issues" block: which findings are reported and which of
+// them make a file fail.
+func issuesSchema() object {
+	return block("Which findings are reported, and which of them fail a file.", object{
+		"minSeverity": ref("#/$defs/severity", "The lowest severity worth printing."),
+		"failOn":      ref("#/$defs/severity", "The severity that makes a file invalid."),
+		"exitOnError": object{
+			"description": "Stop the run at the first file that fails.",
+			"type":        "boolean",
+		},
+	})
+}
+
+// outputSchema is the "output" block, which also accepts a bare format name:
+// that is the flat form the first release shipped, and it still means the same
+// thing.
+func outputSchema() object {
+	return object{
+		"description": "How the findings are printed. A bare format name is shorthand for the block.",
+		"oneOf": []any{
+			formatSchema(),
+			block("", object{
+				"format":  formatSchema(),
+				"summary": object{"description": "Append a count of the outcomes.", "type": "boolean"},
+				"verbose": object{
+					"description": "Also report the files that passed, and say which settings file was read.",
+					"type":        "boolean",
+				},
+				"color": object{
+					"description": "Print in colour when the destination is a terminal.",
+					"type":        "boolean",
+				},
+			}),
+		},
+	}
+}
+
+func formatSchema() object {
+	return object{
+		"description": "Output format.",
+		"type":        "string",
+		"enum":        []any{"text", "json", "junit", "tap", "github"},
+	}
+}
+
+// legacySchema describes the flat keys the first release shipped. They are
+// still read, so an editor must not underline a file that uses them -- but they
+// are marked deprecated, and each one says where it moved.
+func legacySchema() object {
+	run, rules := runSchema(), rulesSchema()
+	issues := issuesSchema()
+
+	moved := map[string]struct {
+		from object
+		to   string
+	}{
+		"collectorVersion":     {run, "run.collectorVersion"},
+		"distribution":         {run, "run.distribution"},
+		"schemaLocations":      {run, "run.schemaLocations"},
+		"strict":               {run, "run.strict"},
+		"ignoreMissingSchemas": {run, "run.ignoreMissingSchemas"},
+		"exclude":              {run, "run.exclude"},
+		"kubernetes":           {run, "run.kubernetes"},
+		"disable":              {rules, "rules.disable"},
+		"severity":             {rules, "rules.severity"},
+		"minSeverity":          {issues, "issues.minSeverity"},
+		"failOn":               {issues, "issues.failOn"},
+	}
+
+	out := object{
+		"summary": deprecate(object{
+			"description": "Append a count of the outcomes.", "type": "boolean",
+		}, "output.summary"),
+	}
+
+	for name, m := range moved {
+		//nolint:forcetypeassert // the blocks above are built here, one property deep
+		out[name] = deprecate(m.from["properties"].(object)[name].(object), m.to)
+	}
+
+	return out
+}
+
+// deprecate marks a property as replaced, keeping the type it had so a file
+// that still uses it is checked rather than merely tolerated.
+func deprecate(prop object, moved string) object {
+	out := object{"deprecated": true}
+	maps.Copy(out, prop)
+
+	out["description"] = fmt.Sprintf("Deprecated: moved to %s.", moved)
+
+	return out
+}
+
+// ruleSchema enumerates the rules the linter carries, which is what makes an
+// editor able to complete a name and underline a typo. It is why the committed
+// schema is generated rather than written: the list moves with the rule set.
+func ruleSchema() object {
+	names := make([]any, 0, len(ruleset.All()))
+	for _, r := range ruleset.All() {
+		names = append(names, r.Name())
+	}
+
+	return object{
+		"description": "A rule the linter carries.",
+		"type":        "string",
+		"enum":        names,
+	}
+}
+
+func severitySchema() object {
+	return object{
+		"description": "A severity level.",
+		"type":        "string",
+		"enum":        []any{string(diag.Error), string(diag.Warning), string(diag.Info), string(diag.Off)},
+	}
+}
+
+func quantitySchema() object {
+	return object{
+		"description": "A Kubernetes quantity such as 512Mi, 1Gi or 2G, or a bare byte count.",
+		"type":        "string",
+		"pattern":     `^[0-9]+(\.[0-9]+)?(([KMGTPE]i)|[kMGTPE])?$`,
+	}
+}
+
+// block builds a closed object with the given properties.
+func block(description string, properties object) object {
+	out := object{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties":           properties,
+	}
+
+	if description != "" {
+		out["description"] = description
+	}
+
+	return out
+}
+
+// ref points at a definition, optionally saying what it means here: a $ref
+// alongside a description reads as the description in an editor's tooltip.
+func ref(target, description string) object {
+	out := object{"$ref": target}
+	if description != "" {
+		out["description"] = description
+	}
+
+	return out
+}

--- a/pkg/cmd/otelcol-config-lint/jsonschema_test.go
+++ b/pkg/cmd/otelcol-config-lint/jsonschema_test.go
@@ -1,0 +1,109 @@
+package otelcolconfiglint_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	otelcolconfiglint "github.com/minuk-dev/otelcol-config-lint/pkg/cmd/otelcol-config-lint"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/ruleset"
+)
+
+// committedSchema is the generated copy an editor is pointed at.
+const committedSchema = "../../../" + otelcolconfiglint.SettingsSchemaFile
+
+// settingsFixtures holds one settings file per case the schema has to get
+// right. The valid ones are what an editor must not underline; the invalid ones
+// are what it has to catch.
+const settingsFixtures = "../../../testdata/settings"
+
+// TestTheCommittedSchemaIsUpToDate is what keeps an editor honest: the rule
+// names the schema enumerates come from the rule set, so a rule added without
+// regenerating would leave every editor underlining a name that works.
+//
+// Regenerate with: make config-schema.
+func TestTheCommittedSchemaIsUpToDate(t *testing.T) {
+	t.Parallel()
+
+	want, err := otelcolconfiglint.SettingsSchema()
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(committedSchema)
+	require.NoError(t, err, "the schema an editor points at has to be committed")
+
+	assert.Equal(t, string(want), string(got), "%s is stale; run: make config-schema", committedSchema)
+}
+
+// TestTheSchemaCommandPrintsTheSchema pins that the command and the committed
+// file are the same document, since the command is how it is regenerated.
+func TestTheSchemaCommandPrintsTheSchema(t *testing.T) {
+	t.Parallel()
+
+	code, out, errOut := run(t, "", "config-schema")
+	require.Equal(t, 0, code, "%s", errOut)
+
+	want, err := os.ReadFile(committedSchema)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(want), out)
+}
+
+// TestTheSchemaNamesEveryRule guards the part of the document that moves. The
+// generator builds the list from rule.All, so this fails only if a rule name
+// stopped reaching the schema at all.
+func TestTheSchemaNamesEveryRule(t *testing.T) {
+	t.Parallel()
+
+	doc, err := otelcolconfiglint.SettingsSchema()
+	require.NoError(t, err)
+
+	var parsed struct {
+		Defs struct {
+			Rule struct {
+				Enum []string `json:"enum"`
+			} `json:"rule"`
+		} `json:"$defs"`
+	}
+
+	require.NoError(t, json.Unmarshal(doc, &parsed))
+
+	for _, r := range ruleset.All() {
+		assert.Contains(t, parsed.Defs.Rule.Enum, r.Name())
+	}
+
+	assert.Len(t, parsed.Defs.Rule.Enum, len(ruleset.All()), "the enum should hold the rule set and nothing else")
+}
+
+// TestTheSettingsFixturesAreWhatTheySayTheyAre holds the linter to the same
+// verdict CI holds the JSON Schema to. Both read the same fixtures, so a schema
+// that disagreed with the loader would show up as one of the two accepting a
+// file the other rejects.
+func TestTheSettingsFixturesAreWhatTheySayTheyAre(t *testing.T) {
+	t.Parallel()
+
+	for _, group := range []struct {
+		dir     string
+		usage   bool
+		explain string
+	}{
+		{dir: "valid", usage: false, explain: "should be accepted"},
+		{dir: "invalid", usage: true, explain: "should be a usage error"},
+	} {
+		files, err := filepath.Glob(filepath.Join(settingsFixtures, group.dir, "*.yaml"))
+		require.NoError(t, err)
+		require.NotEmpty(t, files, "%s holds no fixtures", group.dir)
+
+		for _, path := range files {
+			// No severity flags: a flag wins over the file, and would hide a
+			// fixture whose whole point is the value it writes.
+			code, _, errOut := lint(t, "", "--config", path, validConfig)
+
+			assert.Equalf(t, group.usage, code == otelcolconfiglint.ExitUsage,
+				"%s %s, got exit %d: %s", path, group.explain, code, errOut)
+		}
+	}
+}

--- a/pkg/cmd/otelcol-config-lint/list.go
+++ b/pkg/cmd/otelcol-config-lint/list.go
@@ -6,8 +6,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
-
-	"github.com/minuk-dev/otelcol-config-lint/pkg/ruleset"
 )
 
 // newListCommand builds "list" and its subcommands. Each one carries only the
@@ -32,8 +30,9 @@ func (o *Options) newListRulesCommand() *cobra.Command {
 		Use:   "rules",
 		Short: "Print the rules and their default severities",
 		Long: "Print the rules and their default severities.\n\n" +
-			"A severity changed by --disable, --severity or the settings file is\n" +
-			"marked as overridden.",
+			"A severity changed by --default, --enable, --disable, --severity or\n" +
+			"the settings file is marked as overridden; a rule that will not run\n" +
+			"is listed at severity \"off\".",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			err := o.Prepare(cmd)
@@ -45,7 +44,7 @@ func (o *Options) newListRulesCommand() *cobra.Command {
 		},
 	}
 
-	o.registerSettingsFlag(cmd)
+	o.registerSettingsFlags(cmd)
 	o.registerRuleFlags(cmd)
 
 	return cmd
@@ -68,7 +67,7 @@ func (o *Options) newListVersionsCommand() *cobra.Command {
 		},
 	}
 
-	o.registerSettingsFlag(cmd)
+	o.registerSettingsFlags(cmd)
 	o.registerSchemaLocationFlag(cmd)
 	o.registerDistributionFlag(cmd)
 
@@ -76,14 +75,19 @@ func (o *Options) newListVersionsCommand() *cobra.Command {
 }
 
 func (o *Options) runListRules(cmd *cobra.Command) error {
-	overrides, err := o.severityOverrides()
+	overrides, err := o.policy.resolve()
+	if err != nil {
+		return err
+	}
+
+	rules, err := o.policy.rules()
 	if err != nil {
 		return err
 	}
 
 	w := newColumns(cmd.OutOrStdout())
 
-	for _, r := range ruleset.All() {
+	for _, r := range rules {
 		sev := r.Severity()
 
 		note := ""

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -3,22 +3,17 @@
 package otelcolconfiglint
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"io/fs"
 	"runtime"
 	"strings"
 
 	"github.com/samber/mo"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/lint"
-	"github.com/minuk-dev/otelcol-config-lint/pkg/ruleset"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/scanner"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
@@ -26,12 +21,8 @@ import (
 	"github.com/minuk-dev/otelcol-config-lint/pkg/version"
 )
 
-// Errors reported for bad flag values.
+// Errors reported for bad input.
 var (
-	// ErrUnknownRule names a rule that does not exist.
-	ErrUnknownRule = errors.New("unknown rule")
-	// ErrBadSeverityPair reports a --severity argument that is not rule=level.
-	ErrBadSeverityPair = errors.New("not in rule=level form")
 	// ErrNoInput reports that no file, directory or "-" was given.
 	ErrNoInput = errors.New("no files or directories specified")
 	// ErrNoSchemas reports that no schema version could be found.
@@ -71,10 +62,6 @@ func ExitCode(err error) int {
 // by reading files, not by checking them.
 const maxDefaultWorkers = 8
 
-// DefaultSettingsFile is looked for in the working directory when no
-// --config flag is given.
-const DefaultSettingsFile = ".otelcol-config-lint.yaml"
-
 // Options holds everything the command was asked to do. The fields are filled
 // in by RegisterFlags and then by the settings file, in that order.
 type Options struct {
@@ -89,14 +76,17 @@ type Options struct {
 	schemaLocations  []string
 	output           string
 	settingsFile     string
-	disable          string
-	severity         string
-	exclude          string
+	ruleDefault      string
+	enable           []string
+	disable          []string
+	severity         []string
+	exclude          []string
 	minSeverity      string
 	failOn           string
 	memoryRequest    string
 	memoryLimit      string
-	workers          int
+	concurrency      int
+	noConfig         bool
 	kubernetes       bool
 	strict           bool
 	ignoreMissing    bool
@@ -107,6 +97,9 @@ type Options struct {
 
 	// internal state
 	store schema.Store
+	// policy is which rules run, at what level, and with what settings, once
+	// the flags and the file have both had their say.
+	policy rulePolicy
 	// kubernetesEnabled is what the flag or the settings file said about
 	// running in Kubernetes; nil when neither said anything, which leaves the
 	// answer to be read from the memory numbers.
@@ -155,11 +148,13 @@ func NewCommand(opts *Options) *cobra.Command {
 	return cmd
 }
 
-// RegisterFlags declares every flag the lint run takes.
+// RegisterFlags declares every flag the lint run takes. Each one mirrors a key
+// of the settings file: the file is what a repository commits, and the flag is
+// how a single run departs from it.
 func (o *Options) RegisterFlags(cmd *cobra.Command) {
 	// The groups below are shared with the list subcommands, which take only
 	// the flags that change what they print.
-	o.registerSettingsFlag(cmd)
+	o.registerSettingsFlags(cmd)
 	o.registerSchemaLocationFlag(cmd)
 	o.registerDistributionFlag(cmd)
 	o.registerRuleFlags(cmd)
@@ -169,11 +164,12 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 	flags.StringVar(&o.collectorVersion, "collector-version", schema.Latest,
 		"collector release to validate against, e.g. v0.157.0")
 	flags.StringVar(&o.output, "output", "text", "output format: text, json, junit, tap or github")
-	flags.StringVar(&o.exclude, "exclude", "", "comma-separated glob patterns to skip when walking directories")
+	flags.StringSliceVar(&o.exclude, "exclude", nil, "glob patterns to skip when walking directories")
 	flags.StringVar(&o.minSeverity, "min-severity", "info", "lowest severity to report: error, warning or info")
 	flags.StringVar(&o.failOn, "fail-on", "error", "severity that makes a file invalid: error, warning or info")
-	// Spelled -n before cobra; the shorthand keeps that working.
-	flags.IntVarP(&o.workers, "n", "n", defaultWorkers(), "number of files to check in parallel")
+	// Spelled -n before this took golangci-lint's name for it, so -n stays the
+	// shorthand: it is what the documentation and every existing workflow use.
+	flags.IntVarP(&o.concurrency, "concurrency", "n", defaultWorkers(), "number of files to check in parallel")
 	flags.BoolVar(&o.kubernetes, "kubernetes", false, "the config runs in a Kubernetes pod")
 	flags.StringVar(&o.memoryRequest, "memory-request", "", "container memory request, e.g. 256Mi")
 	flags.StringVar(&o.memoryLimit, "memory-limit", "", "container memory limit, e.g. 512Mi")
@@ -181,7 +177,7 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 	flags.BoolVar(&o.ignoreMissing, "ignore-missing-schemas", false,
 		"do not fail on components missing from the schema")
 	flags.BoolVar(&o.summary, "summary", false, "print a summary of the results")
-	flags.BoolVar(&o.verbose, "verbose", false, "also report files that passed")
+	flags.BoolVar(&o.verbose, "verbose", false, "also report files that passed, and say which settings file was read")
 	flags.BoolVar(&o.noColor, "no-color", false, "disable coloured output")
 	flags.BoolVar(&o.exitOnError, "exit-on-error", false, "stop at the first file that fails")
 }
@@ -189,18 +185,31 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 // Prepare folds the settings file into the parsed flags and builds the schema
 // store. Flags given on the command line win over the file.
 func (o *Options) Prepare(cmd *cobra.Command) error {
-	fileSettings, err := loadSettings(o.fs(), o.settingsFile)
+	fileSettings, path, err := o.loadSettings()
 	if err != nil {
 		return err
 	}
 
+	legacy := fileSettings.normalize()
+
 	o.applySettings(fileSettings, cmd.Flags().Changed)
+
+	o.policy = o.rulePolicy(fileSettings)
 
 	o.store = schema.Store{Locations: o.schemaLocations, Distribution: o.distribution, Fs: o.Fs}
 
 	o.envPolicy, err = o.environmentPolicy()
 	if err != nil {
 		return err
+	}
+
+	if o.verbose && path != "" {
+		cmd.PrintErrf("otelcol-config-lint: settings read from %s\n", path)
+	}
+
+	if len(legacy) > 0 {
+		cmd.PrintErrf("otelcol-config-lint: %s: deprecated top-level keys: %s;"+
+			" move them under run, rules, issues or output\n", path, strings.Join(legacy, ", "))
 	}
 
 	return nil
@@ -232,11 +241,15 @@ func (o *Options) fs() afero.Fs {
 	return o.Fs
 }
 
-// registerSettingsFlag declares --config. Every command honours it: the
-// settings file states rule and schema policy, not only lint options.
-func (o *Options) registerSettingsFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.settingsFile, "config", "",
-		"settings file (default "+DefaultSettingsFile+" if present)")
+// registerSettingsFlags declares --config and --no-config. Every command
+// honours them: the settings file states rule and schema policy, not only lint
+// options.
+func (o *Options) registerSettingsFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	flags.StringVarP(&o.settingsFile, "config", "c", "",
+		"settings file (default: "+DefaultSettingsFile+", searched for here and in each parent)")
+	flags.BoolVar(&o.noConfig, "no-config", false, "ignore any settings file and use the flags alone")
 }
 
 // registerDistributionFlag declares --distribution, shared with
@@ -254,18 +267,21 @@ func (o *Options) registerSchemaLocationFlag(cmd *cobra.Command) {
 			"repeat to search several in order (default: the published registry)")
 }
 
-// registerRuleFlags declares the severity overrides, shared with "list rules".
+// registerRuleFlags declares the rule selection, shared with "list rules".
 func (o *Options) registerRuleFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
-	flags.StringVar(&o.disable, "disable", "", "comma-separated rules to turn off")
-	flags.StringVar(&o.severity, "severity", "",
-		"comma-separated rule=level overrides, e.g. missing-batch=warning")
+	flags.StringVar(&o.ruleDefault, "default", "",
+		"rule set to start from: "+defaultAll+" (the default) or "+defaultNone)
+	flags.StringSliceVarP(&o.enable, "enable", "E", nil, "rules to turn on, on top of --default")
+	flags.StringSliceVarP(&o.disable, "disable", "D", nil, "rules to turn off")
+	flags.StringSliceVar(&o.severity, "severity", nil,
+		"rule=level overrides, e.g. missing-batch=warning")
 }
 
 // runLint resolves what to check and how to report it, then does the work.
 func (o *Options) runLint(cmd *cobra.Command, paths []string) error {
-	sc := scanner.New(splitList(o.exclude))
+	sc := scanner.New(o.exclude)
 	sc.Fs = o.Fs
 
 	files, err := sc.Scan(paths)
@@ -318,7 +334,7 @@ func (o *Options) lintAll(
 	}
 
 	onDisk := sets.List(files.Difference(sets.New(scanner.StdinMarker)))
-	for r := range linter.LintAll(onDisk, o.workers) {
+	for r := range linter.LintAll(onDisk, o.concurrency) {
 		results[r.Path] = r
 	}
 
@@ -363,7 +379,12 @@ func (o *Options) newLinter(cmd *cobra.Command) (*lint.Linter, error) {
 		return nil, err
 	}
 
-	severities, err := o.severityOverrides()
+	severities, err := o.policy.resolve()
+	if err != nil {
+		return nil, err
+	}
+
+	rules, err := o.policy.rules()
 	if err != nil {
 		return nil, err
 	}
@@ -383,6 +404,7 @@ func (o *Options) newLinter(cmd *cobra.Command) (*lint.Linter, error) {
 		Fs:                   o.Fs,
 		Availability:         lint.NewVersionIndex(o.store),
 		Distributions:        lint.NewDistributionIndex(o.store, cat.CollectorVersion),
+		Rules:                rules,
 		Severities:           severities,
 		Environment:          o.envPolicy.Resolve,
 		Strict:               o.strict,
@@ -420,93 +442,10 @@ func (o *Options) loadSchema(cmd *cobra.Command) (*schema.Schema, error) {
 	return cat, nil
 }
 
-// severityOverrides builds the rule severity map from --disable and --severity.
-func (o *Options) severityOverrides() (map[string]diag.Severity, error) {
-	out := map[string]diag.Severity{}
-
-	for _, name := range splitList(o.disable) {
-		if _, ok := ruleset.Lookup(name); !ok {
-			return nil, fmt.Errorf("--disable: %w %q", ErrUnknownRule, name)
-		}
-
-		out[name] = diag.Off
-	}
-
-	for _, pair := range splitList(o.severity) {
-		name, level, found := strings.Cut(pair, "=")
-		if !found {
-			return nil, fmt.Errorf("--severity: %q is %w", pair, ErrBadSeverityPair)
-		}
-
-		if _, ok := ruleset.Lookup(name); !ok {
-			return nil, fmt.Errorf("--severity: %w %q", ErrUnknownRule, name)
-		}
-
-		sev, err := diag.ParseSeverity(level)
-		if err != nil {
-			return nil, fmt.Errorf("--severity %s: %w", name, err)
-		}
-
-		out[name] = sev
-	}
-
-	return out, nil
-}
-
-// settings is the file form of the command line options, so a repository can
-// commit its linting policy instead of repeating flags in CI.
-type settings struct {
-	CollectorVersion string `yaml:"collectorVersion"`
-	// Distribution names the collector binary the config will run on.
-	Distribution string `yaml:"distribution"`
-	// SchemaLocations are searched in order before the published registry.
-	SchemaLocations      []string          `yaml:"schemaLocations"`
-	Output               string            `yaml:"output"`
-	Strict               *bool             `yaml:"strict"`
-	IgnoreMissingSchemas *bool             `yaml:"ignoreMissingSchemas"`
-	Summary              *bool             `yaml:"summary"`
-	MinSeverity          string            `yaml:"minSeverity"`
-	FailOn               string            `yaml:"failOn"`
-	Disable              []string          `yaml:"disable"`
-	Severity             map[string]string `yaml:"severity"`
-	Exclude              []string          `yaml:"exclude"`
-	// Kubernetes describes the pods the configs run in, per path, for the
-	// rules that cannot judge a config without knowing what it runs in.
-	Kubernetes kubernetesSettings `yaml:"kubernetes"`
-}
-
-// loadSettings reads a settings file. When path is empty the default file is
-// used if it exists, and a missing default is not an error.
-func loadSettings(fsys afero.Fs, path string) (*settings, error) {
-	required := path != ""
-	if path == "" {
-		path = DefaultSettingsFile
-	}
-
-	src, err := afero.ReadFile(fsys, path)
-	if err != nil {
-		if !required && errors.Is(err, fs.ErrNotExist) {
-			return &settings{}, nil //nolint:exhaustruct // an absent file means every option keeps its default
-		}
-
-		return nil, fmt.Errorf("read settings: %w", err)
-	}
-
-	var s settings
-
-	dec := yaml.NewDecoder(bytes.NewReader(src))
-	dec.KnownFields(true)
-
-	err = dec.Decode(&s)
-	if err != nil && !errors.Is(err, io.EOF) {
-		return nil, fmt.Errorf("%s: %w", path, err)
-	}
-
-	return &s, nil
-}
-
 // applySettings folds a settings file into the options. changed reports whether
-// a flag was given on the command line; those always win over the file.
+// a flag was given on the command line; those always win over the file. The
+// rule lists are not here: they merge rather than replace, which rulePolicy
+// does.
 func (o *Options) applySettings(s *settings, changed func(name string) bool) {
 	str := func(name string, dst *string, v string) {
 		if !changed(name) {
@@ -519,72 +458,46 @@ func (o *Options) applySettings(s *settings, changed func(name string) bool) {
 		}
 	}
 
-	str("collector-version", &o.collectorVersion, s.CollectorVersion)
-	str("memory-request", &o.memoryRequest, s.Kubernetes.MemoryRequest)
-	str("memory-limit", &o.memoryLimit, s.Kubernetes.MemoryLimit)
-	str("distribution", &o.distribution, s.Distribution)
-	str("output", &o.output, s.Output)
-	str("min-severity", &o.minSeverity, s.MinSeverity)
-	str("fail-on", &o.failOn, s.FailOn)
-	boolean("strict", &o.strict, s.Strict)
-	boolean("ignore-missing-schemas", &o.ignoreMissing, s.IgnoreMissingSchemas)
-	boolean("summary", &o.summary, s.Summary)
+	str("collector-version", &o.collectorVersion, s.Run.CollectorVersion)
+	str("distribution", &o.distribution, s.Run.Distribution)
+	str("memory-request", &o.memoryRequest, s.Run.Kubernetes.MemoryRequest)
+	str("memory-limit", &o.memoryLimit, s.Run.Kubernetes.MemoryLimit)
+	str("output", &o.output, s.Output.Format)
+	str("min-severity", &o.minSeverity, s.Issues.MinSeverity)
+	str("fail-on", &o.failOn, s.Issues.FailOn)
+	boolean("strict", &o.strict, s.Run.Strict)
+	boolean("ignore-missing-schemas", &o.ignoreMissing, s.Run.IgnoreMissingSchemas)
+	boolean("summary", &o.summary, s.Output.Summary)
+	boolean("verbose", &o.verbose, s.Output.Verbose)
+	boolean("exit-on-error", &o.exitOnError, s.Issues.ExitOnError)
+
+	// The file says whether to colour, the flag says whether to stop; one is
+	// the negation of the other.
+	if !changed("no-color") && s.Output.Color != nil {
+		o.noColor = !*s.Output.Color
+	}
+
+	if !changed("concurrency") && s.Run.Concurrency != nil {
+		o.concurrency = *s.Run.Concurrency
+	}
 
 	// The deployment environment is a tri-state: the flag wins, then the file,
 	// and with neither the memory numbers speak for themselves.
 	switch {
 	case changed("kubernetes"):
 		o.kubernetesEnabled = &o.kubernetes
-	case s.Kubernetes.Enabled != nil:
-		o.kubernetesEnabled = s.Kubernetes.Enabled
+	case s.Run.Kubernetes.Enabled != nil:
+		o.kubernetesEnabled = s.Run.Kubernetes.Enabled
 	}
 
-	o.kubernetesOverrides = s.Kubernetes.Overrides
+	o.kubernetesOverrides = s.Run.Kubernetes.Overrides
 
-	if !changed("schema-location") && len(s.SchemaLocations) > 0 {
-		o.schemaLocations = append(o.schemaLocations, s.SchemaLocations...)
+	if !changed("schema-location") && len(s.Run.SchemaLocations) > 0 {
+		o.schemaLocations = append(o.schemaLocations, s.Run.SchemaLocations...)
 	}
 
-	if !changed("exclude") && len(s.Exclude) > 0 {
-		o.exclude = joinList(o.exclude, strings.Join(s.Exclude, ","))
-	}
-
-	// Rule lists merge instead of replacing: the file states the project
-	// policy and the flags add to it for a single run.
-	if len(s.Disable) > 0 {
-		o.disable = joinList(o.disable, strings.Join(s.Disable, ","))
-	}
-
-	if len(s.Severity) > 0 {
-		pairs := make([]string, 0, len(s.Severity))
-		for _, name := range sets.List(sets.KeySet(s.Severity)) {
-			pairs = append(pairs, name+"="+s.Severity[name])
-		}
-		// Later pairs win, so file overrides are listed first.
-		o.severity = joinList(strings.Join(pairs, ","), o.severity)
-	}
-}
-
-func splitList(s string) []string {
-	var out []string
-
-	for part := range strings.SplitSeq(s, ",") {
-		if part = strings.TrimSpace(part); part != "" {
-			out = append(out, part)
-		}
-	}
-
-	return out
-}
-
-func joinList(a, b string) string {
-	switch {
-	case a == "":
-		return b
-	case b == "":
-		return a
-	default:
-		return a + "," + b
+	if !changed("exclude") && len(s.Run.Exclude) > 0 {
+		o.exclude = append(o.exclude, s.Run.Exclude...)
 	}
 }
 

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -137,7 +137,7 @@ func NewCommand(opts *Options) *cobra.Command {
 	// this keeps it printing what the "version" subcommand prints.
 	cmd.SetVersionTemplate(versionTemplate)
 
-	cmd.AddCommand(newRunCommand(opts), newListCommand(opts), newVersionCommand())
+	cmd.AddCommand(newRunCommand(opts), newListCommand(opts), newConfigSchemaCommand(), newVersionCommand())
 
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		cmd.PrintErr(cmd.UsageString())

--- a/pkg/cmd/otelcol-config-lint/rules.go
+++ b/pkg/cmd/otelcol-config-lint/rules.go
@@ -1,0 +1,171 @@
+package otelcolconfiglint
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/ruleset"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/sets"
+)
+
+// Errors reported for a rule selection that cannot be resolved.
+var (
+	// ErrUnknownRule names a rule that does not exist.
+	ErrUnknownRule = errors.New("unknown rule")
+	// ErrBadSeverityPair reports a --severity argument that is not rule=level.
+	ErrBadSeverityPair = errors.New("not in rule=level form")
+	// ErrUnknownDefault reports a rules.default outside the sets on offer.
+	ErrUnknownDefault = errors.New("unknown rule set")
+	// ErrEnabledAndDisabled reports a rule named on both sides at once.
+	ErrEnabledAndDisabled = errors.New("is both enabled and disabled")
+)
+
+// The sets rules.default can name. They mirror golangci-lint's, minus the
+// curated middle: every rule here is one a collector config should pass, so
+// there is no subset to start from that is not simply all of them.
+const (
+	// defaultAll runs every registered rule, which is what a run that says
+	// nothing does.
+	defaultAll = "all"
+	// defaultNone runs only what enable names.
+	defaultNone = "none"
+)
+
+// rulePolicy is which rules run and at what level. It is resolved in the order
+// the fields are written: the default set, then enable, then disable, then the
+// explicit levels -- so a rule given a severity runs at it whatever came
+// before, which is the only reading under which writing one is never a no-op.
+type rulePolicy struct {
+	// set is the set to start from: defaultAll, defaultNone, or "" for the
+	// former.
+	set string
+	// enable and disable name rules. A rule in both is an error rather than a
+	// silent win for one of them.
+	enable  []string
+	disable []string
+	// severity holds rule=level pairs, later ones winning.
+	severity []string
+	// settings holds each rule's own block, keyed by rule name.
+	settings map[string]yaml.Node
+}
+
+// resolve turns the policy into the severity map the linter takes, where a
+// level of diag.Off is a rule that does not run.
+func (p rulePolicy) resolve() (map[string]diag.Severity, error) {
+	out := map[string]diag.Severity{}
+
+	switch p.set {
+	case "", defaultAll:
+	case defaultNone:
+		for _, r := range ruleset.All() {
+			out[r.Name()] = diag.Off
+		}
+	default:
+		return nil, fmt.Errorf("rules.default: %w %q (want %s or %s)",
+			ErrUnknownDefault, p.set, defaultAll, defaultNone)
+	}
+
+	both := sets.New(p.enable...).Intersection(sets.New(p.disable...))
+	if both.Len() > 0 {
+		return nil, fmt.Errorf("%q %w", sets.List(both)[0], ErrEnabledAndDisabled)
+	}
+
+	for _, name := range p.enable {
+		r, ok := ruleset.Lookup(name)
+		if !ok {
+			return nil, fmt.Errorf("enable: %w %q", ErrUnknownRule, name)
+		}
+
+		out[name] = r.Severity()
+	}
+
+	for _, name := range p.disable {
+		if _, ok := ruleset.Lookup(name); !ok {
+			return nil, fmt.Errorf("disable: %w %q", ErrUnknownRule, name)
+		}
+
+		out[name] = diag.Off
+	}
+
+	for _, pair := range p.severity {
+		name, level, found := strings.Cut(pair, "=")
+		if !found {
+			return nil, fmt.Errorf("severity: %q is %w", pair, ErrBadSeverityPair)
+		}
+
+		if _, ok := ruleset.Lookup(name); !ok {
+			return nil, fmt.Errorf("severity: %w %q", ErrUnknownRule, name)
+		}
+
+		sev, err := diag.ParseSeverity(level)
+		if err != nil {
+			return nil, fmt.Errorf("severity %s: %w", name, err)
+		}
+
+		out[name] = sev
+	}
+
+	return out, nil
+}
+
+// rules returns the rule set with each rule's own settings block applied. A
+// block written for a rule that does not exist is reported here, because
+// rule.Configure cannot tell a missing rule from a misspelled one.
+func (p rulePolicy) rules() ([]rule.Rule, error) {
+	for _, name := range sets.List(sets.KeySet(p.settings)) {
+		if _, ok := ruleset.Lookup(name); !ok {
+			return nil, fmt.Errorf("rules.settings: %w %q", ErrUnknownRule, name)
+		}
+	}
+
+	configured, err := rule.Configure(ruleset.All(), p.settings)
+	if err != nil {
+		return nil, fmt.Errorf("rules.settings: %w", err)
+	}
+
+	return configured, nil
+}
+
+// rulePolicy builds the policy from the flags and the settings file. The rule
+// lists merge rather than replace: the file states the project policy and a
+// flag adds to it for a single run, which is how -E and -D read next to a
+// committed config.
+func (o *Options) rulePolicy(s *settings) rulePolicy {
+	// File pairs are listed first so a flag that names the same rule wins.
+	severity := make([]string, 0, len(s.Rules.Severity)+len(o.severity))
+	for _, name := range sets.List(sets.KeySet(s.Rules.Severity)) {
+		severity = append(severity, name+"="+s.Rules.Severity[name])
+	}
+
+	set := o.ruleDefault
+	if set == "" {
+		set = s.Rules.Default
+	}
+
+	return rulePolicy{
+		set:      set,
+		enable:   append(trimAll(s.Rules.Enable), trimAll(o.enable)...),
+		disable:  append(trimAll(s.Rules.Disable), trimAll(o.disable)...),
+		severity: append(severity, trimAll(o.severity)...),
+		settings: s.Rules.Settings,
+	}
+}
+
+// trimAll drops the blank entries a comma-separated flag or a hand-written list
+// can carry, so "a,,b" and an empty flag both mean what they look like.
+func trimAll(in []string) []string {
+	var out []string
+
+	for _, s := range in {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}

--- a/pkg/cmd/otelcol-config-lint/run.go
+++ b/pkg/cmd/otelcol-config-lint/run.go
@@ -15,7 +15,12 @@ func newRunCommand(opts *Options) *cobra.Command {
 		Example: `  otelcol-config-lint run config.yaml
   otelcol-config-lint run --collector-version v0.157.0 --summary ./configs
   cat config.yaml | otelcol-config-lint run -
-  otelcol-config-lint run --output json --strict ./configs > report.json`,
+  otelcol-config-lint run --output json --strict ./configs > report.json
+  otelcol-config-lint run --default none -E invalid-value ./configs
+  otelcol-config-lint run -c ci.yaml ./configs
+
+The policy itself belongs in ` + DefaultSettingsFile + `, which is read from
+this directory or any parent above it; every flag here mirrors one of its keys.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := opts.Prepare(cmd)

--- a/pkg/cmd/otelcol-config-lint/settings.go
+++ b/pkg/cmd/otelcol-config-lint/settings.go
@@ -1,0 +1,375 @@
+package otelcolconfiglint
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+// ErrUnknownSettingsVersion reports a settings file written against a schema
+// this release does not know.
+var ErrUnknownSettingsVersion = errors.New("unknown settings version")
+
+// SettingsVersion is the schema the settings file is read as. A file may state
+// it to be explicit; a file that does not is read as this version. It exists so
+// a later schema can be told apart from this one rather than guessed at.
+const SettingsVersion = "1"
+
+// DefaultSettingsFile is the file looked for when no --config is given. It is
+// searched for in the working directory and then in each parent.
+const DefaultSettingsFile = ".otelcol-config-lint.yaml"
+
+// settingsNames are the spellings of the default file, tried in order. Both
+// YAML extensions are accepted because a repository should not have to rename
+// a file it already has.
+func settingsNames() []string {
+	return []string{DefaultSettingsFile, ".otelcol-config-lint.yml"}
+}
+
+// settings is the file form of the command line options, so a repository can
+// commit its linting policy instead of repeating flags in CI.
+//
+// The layout follows golangci-lint: what to check under "run", which rules
+// under "rules", what counts as a failure under "issues", and how it is printed
+// under "output". Every flag has a key here; the flags are the single-run
+// override, and the file is what the repository commits.
+//
+// The flat keys the first release shipped are still read -- see normalize --
+// because a settings file that quietly stops taking effect is a worse outcome
+// than one that is out of style.
+type settings struct {
+	// Version names the schema this file is written against.
+	Version string `yaml:"version"`
+
+	// Run is what to check, and against which collector.
+	Run runSettings `yaml:"run"`
+	// Rules is which rules run and at what level.
+	Rules rulesSettings `yaml:"rules"`
+	// Issues is which findings make a file fail.
+	Issues issuesSettings `yaml:"issues"`
+	// Output is how the findings are printed.
+	Output outputSettings `yaml:"output"`
+
+	// The flat form of the first release. Anything written here is folded into
+	// the blocks above, which win where both are written.
+	CollectorVersion     string              `yaml:"collectorVersion"`
+	Distribution         string              `yaml:"distribution"`
+	SchemaLocations      []string            `yaml:"schemaLocations"`
+	Strict               *bool               `yaml:"strict"`
+	IgnoreMissingSchemas *bool               `yaml:"ignoreMissingSchemas"`
+	Summary              *bool               `yaml:"summary"`
+	MinSeverity          string              `yaml:"minSeverity"`
+	FailOn               string              `yaml:"failOn"`
+	Disable              []string            `yaml:"disable"`
+	Severity             map[string]string   `yaml:"severity"`
+	Exclude              []string            `yaml:"exclude"`
+	Kubernetes           *kubernetesSettings `yaml:"kubernetes"`
+}
+
+// runSettings is the "run" block: which collector the configs target and which
+// files are checked against it.
+type runSettings struct {
+	// CollectorVersion is the release to validate against, e.g. v0.157.0.
+	CollectorVersion string `yaml:"collectorVersion"`
+	// Distribution names the collector binary the config will run on.
+	Distribution string `yaml:"distribution"`
+	// SchemaLocations are searched in order before the published registry.
+	SchemaLocations []string `yaml:"schemaLocations"`
+	// Strict reports unknown component settings as errors.
+	Strict *bool `yaml:"strict"`
+	// IgnoreMissingSchemas keeps components absent from the schema from
+	// failing the run, for a custom distribution.
+	IgnoreMissingSchemas *bool `yaml:"ignoreMissingSchemas"`
+	// Concurrency is how many files are checked in parallel.
+	Concurrency *int `yaml:"concurrency"`
+	// Exclude are glob patterns skipped when walking a directory.
+	Exclude []string `yaml:"exclude"`
+	// Kubernetes describes the pods the configs run in, per path, for the
+	// rules that cannot judge a config without knowing what it runs in.
+	Kubernetes kubernetesSettings `yaml:"kubernetes"`
+}
+
+// rulesSettings is the "rules" block: which rules run, at what level, and with
+// what settings of their own.
+type rulesSettings struct {
+	// Default is the set to start from: "all", every registered rule, or
+	// "none", which runs only what enable names.
+	Default string `yaml:"default"`
+	// Enable turns rules on, and is how anything runs under "none".
+	Enable []string `yaml:"enable"`
+	// Disable turns rules off.
+	Disable []string `yaml:"disable"`
+	// Severity re-levels a rule, e.g. missing-batch: warning. Writing "off"
+	// disables it, exactly as listing it under disable does.
+	Severity map[string]string `yaml:"severity"`
+	// Settings holds each rule's own block, keyed by rule name, the way
+	// golangci-lint's linters take settings under their name. A rule that
+	// reads no settings reports a block written for it rather than ignoring
+	// it -- see rule.Configurable.
+	Settings map[string]yaml.Node `yaml:"settings"`
+}
+
+// issuesSettings is the "issues" block: which findings are reported and which
+// of them make a file fail.
+type issuesSettings struct {
+	// MinSeverity is the lowest severity worth printing.
+	MinSeverity string `yaml:"minSeverity"`
+	// FailOn is the severity that makes a file invalid.
+	FailOn string `yaml:"failOn"`
+	// ExitOnError stops the run at the first file that fails.
+	ExitOnError *bool `yaml:"exitOnError"`
+}
+
+// outputSettings is the "output" block: how results are printed, as opposed to
+// what counts as a result.
+type outputSettings struct {
+	// Format is text, json, junit, tap or github.
+	Format string `yaml:"format"`
+	// Summary appends a count of the outcomes.
+	Summary *bool `yaml:"summary"`
+	// Verbose also reports the files that passed.
+	Verbose *bool `yaml:"verbose"`
+	// Color prints in colour when the destination is a terminal. Setting it
+	// false is what --no-color does.
+	Color *bool `yaml:"color"`
+}
+
+// UnmarshalYAML also accepts the block written as a bare format name, which is
+// the flat form the first release shipped: "output: json" and
+// "output: {format: json}" mean the same thing.
+func (o *outputSettings) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		err := node.Decode(&o.Format)
+		if err != nil {
+			return fmt.Errorf("output: %w", err)
+		}
+
+		return nil
+	}
+
+	// The block is decoded through a type without this method, both to avoid
+	// recursing and to get the strictness the top-level decoder was given:
+	// Node.Decode does not carry KnownFields over.
+	type output outputSettings
+
+	var block output
+
+	err := decodeStrict(node, &block)
+	if err != nil {
+		return fmt.Errorf("output: %w", err)
+	}
+
+	*o = outputSettings(block)
+
+	return nil
+}
+
+// normalize folds the flat first-release keys into the blocks and returns the
+// ones that were written, so the caller can say they are on their way out. A
+// key written in both forms keeps the block's value: the new spelling is the
+// one the file means.
+func (s *settings) normalize() []string {
+	return append(s.foldScalars(), s.foldLists()...)
+}
+
+// foldScalars folds the flat keys holding a single value.
+func (s *settings) foldScalars() []string {
+	var used []string
+
+	str := func(name string, dst *string, v string) {
+		if v == "" {
+			return
+		}
+
+		used = append(used, name)
+
+		if *dst == "" {
+			*dst = v
+		}
+	}
+	boolean := func(name string, dst **bool, v *bool) {
+		if v == nil {
+			return
+		}
+
+		used = append(used, name)
+
+		if *dst == nil {
+			*dst = v
+		}
+	}
+
+	str("collectorVersion", &s.Run.CollectorVersion, s.CollectorVersion)
+	str("distribution", &s.Run.Distribution, s.Distribution)
+	str("minSeverity", &s.Issues.MinSeverity, s.MinSeverity)
+	str("failOn", &s.Issues.FailOn, s.FailOn)
+	boolean("strict", &s.Run.Strict, s.Strict)
+	boolean("ignoreMissingSchemas", &s.Run.IgnoreMissingSchemas, s.IgnoreMissingSchemas)
+	boolean("summary", &s.Output.Summary, s.Summary)
+
+	return used
+}
+
+// foldLists folds the flat keys holding a collection, which cannot share the
+// emptiness test the scalars use.
+func (s *settings) foldLists() []string {
+	var used []string
+
+	list := func(name string, dst *[]string, v []string) {
+		if len(v) == 0 {
+			return
+		}
+
+		used = append(used, name)
+
+		if len(*dst) == 0 {
+			*dst = v
+		}
+	}
+
+	list("schemaLocations", &s.Run.SchemaLocations, s.SchemaLocations)
+	list("exclude", &s.Run.Exclude, s.Exclude)
+	list("disable", &s.Rules.Disable, s.Disable)
+
+	if len(s.Severity) > 0 {
+		used = append(used, "severity")
+
+		if len(s.Rules.Severity) == 0 {
+			s.Rules.Severity = s.Severity
+		}
+	}
+
+	if s.Kubernetes != nil {
+		used = append(used, "kubernetes")
+
+		if !s.Run.Kubernetes.written() {
+			s.Run.Kubernetes = *s.Kubernetes
+		}
+	}
+
+	return used
+}
+
+// loadSettings reads the settings file and reports where it was read from. When
+// no path was given the default file is looked for, and not finding one is not
+// an error; an explicitly named file that is missing is.
+func (o *Options) loadSettings() (*settings, string, error) {
+	//nolint:exhaustruct // an absent file means every option keeps its default
+	empty := &settings{}
+
+	path := o.settingsFile
+
+	switch {
+	case o.noConfig:
+		return empty, "", nil
+	case path == "":
+		path = findSettings(o.fs(), workingDir())
+		if path == "" {
+			return empty, "", nil
+		}
+	}
+
+	src, err := afero.ReadFile(o.fs(), path)
+	if err != nil {
+		// A discovered file that vanished between the two calls is treated as
+		// no file at all, which is what it was a moment ago.
+		if o.settingsFile == "" && errors.Is(err, fs.ErrNotExist) {
+			return empty, "", nil
+		}
+
+		return nil, "", fmt.Errorf("read settings: %w", err)
+	}
+
+	s, err := parseSettings(src)
+	if err != nil {
+		return nil, "", fmt.Errorf("%s: %w", path, err)
+	}
+
+	return s, path, nil
+}
+
+// parseSettings decodes a settings file, rejecting keys it does not know: a
+// misspelled key is policy that silently did not apply.
+func parseSettings(src []byte) (*settings, error) {
+	var s settings
+
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	dec.KnownFields(true)
+
+	err := dec.Decode(&s)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err //nolint:wrapcheck // the caller names the file
+	}
+
+	if s.Version != "" && s.Version != SettingsVersion {
+		return nil, fmt.Errorf("%w %q (this release reads version %s)",
+			ErrUnknownSettingsVersion, s.Version, SettingsVersion)
+	}
+
+	return &s, nil
+}
+
+// findSettings looks for the default file in dir and then in each parent, so a
+// policy committed at the repository root governs a run started from a
+// subdirectory. The search stops at the directory holding .git: past the
+// repository is somebody else's policy, not this project's.
+func findSettings(fsys afero.Fs, dir string) string {
+	for {
+		for _, name := range settingsNames() {
+			path := filepath.Join(dir, name)
+			if ok, _ := afero.Exists(fsys, path); ok {
+				return path
+			}
+		}
+
+		if ok, _ := afero.Exists(fsys, filepath.Join(dir, ".git")); ok {
+			return ""
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+
+		dir = parent
+	}
+}
+
+// workingDir is where the search for a settings file starts. A working
+// directory that cannot be read leaves the search relative, which finds a file
+// sitting right here and nothing above it.
+func workingDir() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+
+	return dir
+}
+
+// decodeStrict decodes a node into target, rejecting keys the target does not
+// have. It goes back through the text because that is the only decoder yaml.v3
+// lets KnownFields be set on -- Node.Decode is always lenient.
+func decodeStrict(node *yaml.Node, target any) error {
+	src, err := yaml.Marshal(node)
+	if err != nil {
+		return fmt.Errorf("re-encode: %w", err)
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	dec.KnownFields(true)
+
+	err = dec.Decode(target)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err //nolint:wrapcheck // the caller names the block
+	}
+
+	return nil
+}

--- a/pkg/cmd/otelcol-config-lint/settings_test.go
+++ b/pkg/cmd/otelcol-config-lint/settings_test.go
@@ -1,0 +1,375 @@
+package otelcolconfiglint_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	otelcolconfiglint "github.com/minuk-dev/otelcol-config-lint/pkg/cmd/otelcol-config-lint"
+)
+
+// absSchemas resolves the schema fixture before the caller changes directory:
+// the discovery tests run from a temporary tree, where a path relative to this
+// package points nowhere.
+func absSchemas(t *testing.T) string {
+	t.Helper()
+
+	abs, err := filepath.Abs(repoSchemas)
+	require.NoError(t, err)
+
+	return abs
+}
+
+// firedRules returns every rule a JSON report flagged, across all its files.
+func firedRules(t *testing.T, out string) []string {
+	t.Helper()
+
+	return lo.Uniq(lo.Flatten(lo.Values(rulesFired(t, out))))
+}
+
+// v0110Config uses the logging exporter, which v0.110.0 ships and v0.157.0 does
+// not, so which release a run actually targeted is visible in its result.
+const v0110Config = "receivers:\n  otlp:\n    protocols:\n      grpc:\nexporters:\n  logging:\n" +
+	"service:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      exporters: [logging]\n"
+
+// writeSettings writes a settings file into a fresh directory and returns its
+// path, for the tests that name it with --config rather than have it found.
+func writeSettings(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "settings.yaml")
+	writeFile(t, path, content)
+
+	return path
+}
+
+// TestTheBlocksAreWhereTheOptionsLive walks one setting out of each block, so a
+// block that stopped being read shows up here rather than in a run that quietly
+// ignored the policy it was given.
+func TestTheBlocksAreWhereTheOptionsLive(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, `version: "1"
+run:
+  collectorVersion: v0.110.0
+rules:
+  disable:
+    - missing-batch
+issues:
+  minSeverity: error
+output:
+  format: json
+  summary: true
+`)
+
+	code, out, errOut := lint(t, v0110Config, "--config", path, "-")
+	require.Equal(t, 0, code, "run.collectorVersion should select v0.110.0: %s%s", out, errOut)
+
+	assert.Contains(t, out, `"summary"`, "output.summary should append the counts")
+	assert.NotContains(t, out, "missing-batch", "rules.disable should turn the rule off")
+	assert.NotContains(t, out, `"severity":"warning"`, "issues.minSeverity should drop warnings")
+}
+
+func TestFlagsWinOverTheBlocks(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "run:\n  collectorVersion: v0.110.0\nissues:\n  minSeverity: error\n")
+
+	code, out, _ := lint(t, v0110Config, "--config", path, "--collector-version", "v0.157.0", "-")
+
+	assert.Equal(t, 1, code)
+	assert.Contains(t, out, "unknown-component", "--collector-version should beat run.collectorVersion")
+}
+
+// TestTheFlatFormIsStillRead pins the compatibility promise: a settings file
+// written against the first release keeps working, and says what to rename.
+func TestTheFlatFormIsStillRead(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "collectorVersion: v0.110.0\nminSeverity: error\ndisable:\n  - missing-batch\n")
+
+	code, out, errOut := lint(t, v0110Config, "--config", path, "-")
+	require.Equal(t, 0, code, "the flat keys should still take effect: %s%s", out, errOut)
+
+	assert.Contains(t, errOut, "deprecated top-level keys")
+	assert.Contains(t, errOut, "collectorVersion")
+	assert.Contains(t, errOut, "minSeverity")
+	assert.Contains(t, errOut, "disable")
+}
+
+// TestABlockBeatsTheFlatKeyItReplaced settles the one ambiguity of reading both
+// forms: a file that writes a setting twice means the newer spelling.
+func TestABlockBeatsTheFlatKeyItReplaced(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "collectorVersion: v0.157.0\nminSeverity: error\nrun:\n  collectorVersion: v0.110.0\n")
+
+	code, out, errOut := lint(t, v0110Config, "--config", path, "-")
+
+	assert.Equal(t, 0, code, "run.collectorVersion should win over the flat key: %s%s", out, errOut)
+}
+
+// TestOutputAcceptsABareFormat keeps the flat "output: json" spelling working
+// now that the key names a block.
+func TestOutputAcceptsABareFormat(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "output: json\n")
+
+	_, out, _ := lint(t, "", "--config", path, "--min-severity", "error", badConfig)
+
+	assert.Contains(t, out, `"filename"`, "a bare format should still select json")
+}
+
+//nolint:paralleltest // t.Chdir cannot be called from a parallel test
+func TestASettingsFileIsFoundInAParentDirectory(t *testing.T) {
+	schemas, dir := absSchemas(t), t.TempDir()
+	writeFile(t, filepath.Join(dir, ".otelcol-config-lint.yaml"),
+		"run:\n  collectorVersion: v0.110.0\nissues:\n  minSeverity: error\n")
+	writeFile(t, filepath.Join(dir, "a", "b", "keep.txt"), "")
+
+	t.Chdir(filepath.Join(dir, "a", "b"))
+
+	code, out, errOut := lint(t, v0110Config, "--schema-location", schemas, "--verbose", "-")
+	require.Equal(t, 0, code, "the settings file above should apply: %s%s", out, errOut)
+
+	assert.Contains(t, errOut, "settings read from", "--verbose should say which file was read")
+}
+
+// TestTheSearchStopsAtTheRepositoryRoot keeps a run from picking up whatever
+// happens to sit above the project it is linting.
+//
+//nolint:paralleltest // t.Chdir cannot be called from a parallel test
+func TestTheSearchStopsAtTheRepositoryRoot(t *testing.T) {
+	schemas, dir := absSchemas(t), t.TempDir()
+	writeFile(t, filepath.Join(dir, ".otelcol-config-lint.yaml"), "run:\n  collectorVersion: v0.110.0\n")
+	writeFile(t, filepath.Join(dir, "repo", ".git"), "gitdir: elsewhere\n")
+	writeFile(t, filepath.Join(dir, "repo", "sub", "keep.txt"), "")
+
+	t.Chdir(filepath.Join(dir, "repo", "sub"))
+
+	// v0.110.0 would accept the logging exporter; the default latest does not.
+	code, out, _ := lint(t, v0110Config, "--schema-location", schemas, "--min-severity", "error", "-")
+
+	assert.Equal(t, 1, code, "a file above the repository must not apply:\n%s", out)
+}
+
+//nolint:paralleltest // t.Chdir cannot be called from a parallel test
+func TestTheYmlSpellingIsFoundToo(t *testing.T) {
+	schemas, dir := absSchemas(t), t.TempDir()
+	writeFile(t, filepath.Join(dir, ".otelcol-config-lint.yml"),
+		"run:\n  collectorVersion: v0.110.0\nissues:\n  minSeverity: error\n")
+
+	t.Chdir(dir)
+
+	code, out, errOut := lint(t, v0110Config, "--schema-location", schemas, "-")
+
+	assert.Equal(t, 0, code, "the .yml spelling should be read: %s%s", out, errOut)
+}
+
+//nolint:paralleltest // t.Chdir cannot be called from a parallel test
+func TestNoConfigIgnoresTheFileThatWouldBeFound(t *testing.T) {
+	schemas, dir := absSchemas(t), t.TempDir()
+	writeFile(t, filepath.Join(dir, ".otelcol-config-lint.yaml"),
+		"run:\n  collectorVersion: v0.110.0\nissues:\n  minSeverity: error\n")
+
+	t.Chdir(dir)
+
+	code, out, _ := lint(t, v0110Config,
+		"--schema-location", schemas, "--no-config", "--min-severity", "error", "-")
+
+	assert.Equal(t, 1, code, "--no-config should leave the run on the defaults:\n%s", out)
+}
+
+// TestDefaultNoneRunsOnlyWhatIsEnabled is golangci-lint's opt-in mode: a
+// project that wants a short list states it rather than disabling the rest.
+func TestDefaultNoneRunsOnlyWhatIsEnabled(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "rules:\n  default: none\n  enable:\n    - invalid-value\n")
+
+	code, out, _ := lint(t, "", "--config", path, "--output", "json", badConfig)
+	require.Equal(t, 1, code, "the enabled rule should still fail the file:\n%s", out)
+
+	fired := firedRules(t, out)
+	assert.Contains(t, fired, "invalid-value", "the enabled rule should run")
+	assert.NotContains(t, fired, "unknown-component", "nothing else should")
+}
+
+func TestEnableAndDisableAreAlsoFlags(t *testing.T) {
+	t.Parallel()
+
+	code, out, _ := lint(t, "", "--default", "none", "-E", "invalid-value", "--output", "json", badConfig)
+	require.Equal(t, 1, code)
+
+	fired := firedRules(t, out)
+	assert.Contains(t, fired, "invalid-value")
+	assert.NotContains(t, fired, "unknown-component")
+
+	_, out, _ = lint(t, "", "-D", "invalid-value,unknown-component", "--output", "json", badConfig)
+
+	fired = firedRules(t, out)
+	assert.NotContains(t, fired, "invalid-value", "-D should turn a rule off")
+	assert.NotContains(t, fired, "unknown-component", "-D should take a comma-separated list")
+}
+
+// TestAFlagAddsToTheFilesRuleLists pins that the lists merge: the file states
+// the project policy and a flag adds to it for one run.
+func TestAFlagAddsToTheFilesRuleLists(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "rules:\n  disable:\n    - invalid-value\n")
+
+	_, out, _ := lint(t, "", "--config", path, "-D", "unknown-component", "--output", "json", badConfig)
+
+	fired := firedRules(t, out)
+	assert.NotContains(t, fired, "invalid-value", "the file's disable should still hold")
+	assert.NotContains(t, fired, "unknown-component", "the flag's should hold as well")
+}
+
+func TestARuleCannotBeBothEnabledAndDisabled(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "rules:\n  enable: [missing-batch]\n  disable: [missing-batch]\n")
+
+	code, _, errOut := lint(t, "", "--config", path, badConfig)
+
+	assert.Equal(t, 2, code)
+	assert.Contains(t, errOut, "missing-batch")
+}
+
+func TestAnUnknownRuleSetIsAUsageError(t *testing.T) {
+	t.Parallel()
+
+	code, _, errOut := lint(t, "", "--default", "most", badConfig)
+
+	assert.Equal(t, 2, code)
+	assert.Contains(t, errOut, "most")
+}
+
+// TestSettingsForARuleThatTakesNoneIsAUsageError is the schema doing its job:
+// the block is reserved for the rules that will read one, and writing a block
+// nothing reads is reported rather than ignored.
+func TestSettingsForARuleThatTakesNoneIsAUsageError(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "rules:\n  settings:\n    missing-batch:\n      timeout: 5s\n")
+
+	code, _, errOut := lint(t, "", "--config", path, badConfig)
+
+	assert.Equal(t, 2, code)
+	assert.Contains(t, errOut, "missing-batch")
+	assert.Contains(t, errOut, "takes no settings")
+}
+
+func TestSettingsForAnUnknownRuleIsAUsageError(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "rules:\n  settings:\n    no-such-rule:\n      x: 1\n")
+
+	code, _, errOut := lint(t, "", "--config", path, badConfig)
+
+	assert.Equal(t, 2, code)
+	assert.Contains(t, errOut, "no-such-rule")
+}
+
+// TestAMisspelledKeyIsReported covers both levels: policy that silently did not
+// apply is the failure mode a settings file is most prone to.
+func TestAMisspelledKeyIsReported(t *testing.T) {
+	t.Parallel()
+
+	for _, content := range []string{"runn:\n  strict: true\n", "output:\n  formt: json\n"} {
+		path := writeSettings(t, content)
+
+		code, _, errOut := lint(t, "", "--config", path, badConfig)
+
+		assert.Equal(t, 2, code, "%q should not be accepted", content)
+		assert.Contains(t, errOut, "not found")
+	}
+}
+
+func TestASettingsFileFromAnotherVersionIsReported(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "version: \"2\"\nrun:\n  strict: true\n")
+
+	code, _, errOut := lint(t, "", "--config", path, badConfig)
+
+	assert.Equal(t, 2, code)
+	assert.Contains(t, errOut, otelcolconfiglint.SettingsVersion)
+}
+
+// TestConcurrencyKeepsItsOldShorthand guards the rename: -n was the whole flag
+// before it took golangci-lint's name for it, and workflows still spell it that
+// way.
+func TestConcurrencyKeepsItsOldShorthand(t *testing.T) {
+	t.Parallel()
+
+	for _, arg := range [][]string{{"-n", "2"}, {"--concurrency", "2"}} {
+		args := append(append([]string{}, arg...), "--min-severity", "error", validConfig)
+
+		code, _, errOut := lint(t, "", args...)
+
+		assert.Equal(t, 0, code, "%v should be accepted: %s", arg, errOut)
+	}
+}
+
+// TestTheRunBlockCarriesTheRestOfTheFlags covers the settings that had no file
+// form until the blocks arrived.
+func TestTheRunBlockCarriesTheRestOfTheFlags(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, `run:
+  concurrency: 2
+  exclude:
+    - "typos.yaml"
+issues:
+  minSeverity: error
+  exitOnError: true
+output:
+  verbose: true
+`)
+
+	code, out, errOut := lint(t, "", "--config", path, invalidConfig)
+	require.Equal(t, 1, code, "%s%s", out, errOut)
+
+	assert.NotContains(t, out, "typos.yaml", "run.exclude should skip the file")
+	assert.Contains(t, out, "valid", "output.verbose should report the files that passed")
+}
+
+// TestOutputColorIsTheNegationOfNoColor pins the one key whose sense is
+// inverted against the flag it mirrors.
+func TestOutputColorIsTheNegationOfNoColor(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "output:\n  color: false\nissues:\n  minSeverity: error\n")
+
+	code, out, errOut := lint(t, "", "--config", path, badConfig)
+	require.Equal(t, 1, code, "%s%s", out, errOut)
+
+	assert.NotContains(t, out, "\x1b[", "colour should stay off")
+}
+
+func TestListRulesHonoursTheRuleBlock(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "rules:\n  default: none\n  enable:\n    - missing-batch\n")
+
+	code, out, errOut := run(t, "", "list", "rules", "--config", path)
+	require.Equal(t, 0, code, "%s", errOut)
+
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		name, rest, _ := strings.Cut(line, " ")
+		if name == "missing-batch" {
+			assert.NotContains(t, rest, "off", "an enabled rule should not be listed as off")
+
+			continue
+		}
+
+		assert.Contains(t, rest, "off", "%q should be listed as off under default: none", name)
+	}
+}

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -58,6 +58,10 @@ type Options struct {
 	Availability rule.Availability
 	// Distributions lets diagnostics mention other distributions. May be nil.
 	Distributions rule.Distributions
+	// Rules is the set to run. A nil Rules means every registered rule, which
+	// is what a caller with no per-rule settings to apply wants; a caller that
+	// has some passes what rule.Configure returned.
+	Rules []rule.Rule
 	// Severities overrides the level individual rules report at. A value of
 	// diag.Off disables the rule.
 	Severities map[string]diag.Severity
@@ -108,7 +112,11 @@ func New(opts Options) *Linter {
 		}
 	}
 
-	return &Linter{opts: opts, rules: ruleset.All()}
+	if opts.Rules == nil {
+		opts.Rules = ruleset.All()
+	}
+
+	return &Linter{opts: opts, rules: opts.Rules}
 }
 
 // Rules returns the rules the linter will run, in name order.

--- a/pkg/rule/configure.go
+++ b/pkg/rule/configure.go
@@ -1,0 +1,62 @@
+package rule
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ErrNoSettings reports a settings block written for a rule that reads none.
+var ErrNoSettings = errors.New("rule takes no settings")
+
+// Configurable is implemented by rules that read a block of their own from the
+// settings file, the way golangci-lint's linters take a settings block under
+// their name. A rule that does not implement it takes no settings, and writing
+// a block for it is reported rather than quietly ignored: a knob that does
+// nothing is worse than a knob that is missing.
+type Configurable interface {
+	Rule
+
+	// WithSettings returns the rule the given block describes. It must not
+	// modify the receiver: All builds the set fresh on every call, and a rule
+	// that configured itself in place would leak one run's policy into the
+	// next. The node is the mapping written under the rule's name.
+	WithSettings(node *yaml.Node) (Rule, error)
+}
+
+// Configure applies the per-rule settings blocks to a rule set and returns the
+// configured set, leaving the one it was given untouched.
+//
+// Blocks are keyed by rule name. A name the set does not hold is skipped:
+// whether it is a rule that was disabled or a rule that was misspelled is a
+// question the caller can answer and this package cannot.
+func Configure(rules []Rule, settings map[string]yaml.Node) ([]Rule, error) {
+	if len(settings) == 0 {
+		return rules, nil
+	}
+
+	out := slices.Clone(rules)
+
+	for i, r := range out {
+		node, ok := settings[r.Name()]
+		if !ok {
+			continue
+		}
+
+		conf, ok := r.(Configurable)
+		if !ok {
+			return nil, fmt.Errorf("%s: %w", r.Name(), ErrNoSettings)
+		}
+
+		configured, err := conf.WithSettings(&node)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", r.Name(), err)
+		}
+
+		out[i] = configured
+	}
+
+	return out, nil
+}

--- a/pkg/rule/configure_test.go
+++ b/pkg/rule/configure_test.go
@@ -1,0 +1,123 @@
+package rule_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/rule"
+)
+
+// configurableRule stands in for a rule that takes settings. No built-in rule
+// does yet -- the schema is there so one can, without every caller having to
+// change -- so the mechanism is exercised against a rule written here.
+type configurableRule struct {
+	limit int
+}
+
+func (configurableRule) Name() string            { return "configurable" }
+func (configurableRule) Description() string     { return "a rule that reads settings" }
+func (configurableRule) Severity() diag.Severity { return diag.Warning }
+func (configurableRule) Check(_ *rule.Context)   {}
+
+func (r configurableRule) WithSettings(node *yaml.Node) (rule.Rule, error) {
+	var block struct {
+		Limit int `yaml:"limit"`
+	}
+
+	err := node.Decode(&block)
+	if err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+
+	return configurableRule{limit: block.Limit}, nil
+}
+
+// plainRule takes no settings, which is every built-in rule today.
+type plainRule struct{}
+
+func (plainRule) Name() string            { return "plain" }
+func (plainRule) Description() string     { return "a rule that reads no settings" }
+func (plainRule) Severity() diag.Severity { return diag.Warning }
+func (plainRule) Check(_ *rule.Context)   {}
+
+// block parses one settings block, as the settings file's decoder hands it over.
+func block(t *testing.T, src string) yaml.Node {
+	t.Helper()
+
+	var doc yaml.Node
+
+	require.NoError(t, yaml.Unmarshal([]byte(src), &doc))
+
+	return *doc.Content[0]
+}
+
+func TestConfigureAppliesARulesOwnBlock(t *testing.T) {
+	t.Parallel()
+
+	rules := []rule.Rule{configurableRule{limit: 0}, plainRule{}}
+
+	out, err := rule.Configure(rules, map[string]yaml.Node{"configurable": block(t, "limit: 7")})
+	require.NoError(t, err)
+
+	configured, ok := out[0].(configurableRule)
+	require.True(t, ok, "the configured rule should keep its type")
+	assert.Equal(t, 7, configured.limit)
+}
+
+// TestConfigureLeavesTheRuleSetItWasGiven pins that a rule set stays reusable
+// after being configured: a rule that configured itself in place would carry
+// one run's settings into the next.
+func TestConfigureLeavesTheRuleSetItWasGiven(t *testing.T) {
+	t.Parallel()
+
+	rules := []rule.Rule{configurableRule{limit: 1}}
+
+	_, err := rule.Configure(rules, map[string]yaml.Node{"configurable": block(t, "limit: 9")})
+	require.NoError(t, err)
+
+	first, ok := rules[0].(configurableRule)
+	require.True(t, ok)
+	assert.Equal(t, 1, first.limit, "the set handed in must not change")
+}
+
+// TestSettingsForARuleThatTakesNoneAreReported guards the whole point of the
+// interface: a block nobody reads is a policy its author believes is in force.
+func TestSettingsForARuleThatTakesNoneAreReported(t *testing.T) {
+	t.Parallel()
+
+	_, err := rule.Configure([]rule.Rule{plainRule{}}, map[string]yaml.Node{"plain": block(t, "limit: 7")})
+
+	require.ErrorIs(t, err, rule.ErrNoSettings)
+	assert.Contains(t, err.Error(), "plain")
+}
+
+func TestConfigureReportsABlockARuleCannotRead(t *testing.T) {
+	t.Parallel()
+
+	_, err := rule.Configure(
+		[]rule.Rule{configurableRule{limit: 0}},
+		map[string]yaml.Node{"configurable": block(t, "limit: not-a-number")},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "configurable")
+}
+
+// TestConfigureIgnoresARuleTheSetDoesNotHold pins the division of labour: this
+// package cannot tell a rule that was turned off from one that was misspelled,
+// so the caller that knows the difference is the one that reports it.
+func TestConfigureIgnoresARuleTheSetDoesNotHold(t *testing.T) {
+	t.Parallel()
+
+	rules := []rule.Rule{plainRule{}}
+
+	out, err := rule.Configure(rules, map[string]yaml.Node{"absent": block(t, "limit: 7")})
+
+	require.NoError(t, err)
+	assert.Equal(t, rules, out)
+}

--- a/pkg/ruleset/ruleset.go
+++ b/pkg/ruleset/ruleset.go
@@ -6,9 +6,11 @@
 // only place that knows about all of them.
 //
 // Adding a rule is therefore two edits: a new package under pkg/rule, and one
-// line in the list below. A third is enforced by the tests: an invalid config
+// line in the list below. Two more are enforced by the tests: an invalid config
 // the rule reports on, under testdata/rules, which is where a rule is shown
-// working through the command line rather than against a stand-in schema.
+// working through the command line rather than against a stand-in schema; and
+// "make config-schema", because the JSON Schema an editor checks a settings
+// file against lists every name in this set.
 package ruleset
 
 import (

--- a/pkg/ruleset/ruleset_test.go
+++ b/pkg/ruleset/ruleset_test.go
@@ -816,3 +816,16 @@ func TestFindingsCiteUpstream(t *testing.T) {
 		}
 	}
 }
+
+// TestNoBuiltInRuleTakesSettingsYet records where rules.settings stands: the
+// schema is there for the rules that will want it, and no rule in the set reads
+// a block. When the first one does, this test is the reminder to document it.
+func TestNoBuiltInRuleTakesSettingsYet(t *testing.T) {
+	t.Parallel()
+
+	for _, r := range ruleset.All() {
+		if _, ok := r.(rule.Configurable); ok {
+			t.Errorf("%s now takes settings -- document its block under rules.settings", r.Name())
+		}
+	}
+}

--- a/testdata/settings/invalid/bad-default.yaml
+++ b/testdata/settings/invalid/bad-default.yaml
@@ -1,0 +1,2 @@
+rules:
+  default: most

--- a/testdata/settings/invalid/bad-severity.yaml
+++ b/testdata/settings/invalid/bad-severity.yaml
@@ -1,0 +1,2 @@
+issues:
+  minSeverity: critical

--- a/testdata/settings/invalid/unknown-block.yaml
+++ b/testdata/settings/invalid/unknown-block.yaml
@@ -1,0 +1,3 @@
+linters:
+  disable:
+    - missing-batch

--- a/testdata/settings/invalid/unknown-key.yaml
+++ b/testdata/settings/invalid/unknown-key.yaml
@@ -1,0 +1,3 @@
+run:
+  collectorVersion: v0.157.0
+  collector_version: v0.157.0

--- a/testdata/settings/invalid/unknown-rule.yaml
+++ b/testdata/settings/invalid/unknown-rule.yaml
@@ -1,0 +1,3 @@
+rules:
+  disable:
+    - no-such-rule

--- a/testdata/settings/valid/bare-output.yaml
+++ b/testdata/settings/valid/bare-output.yaml
@@ -1,0 +1,2 @@
+# A bare format name is the shorthand for the output block.
+output: json

--- a/testdata/settings/valid/flat.yaml
+++ b/testdata/settings/valid/flat.yaml
@@ -1,0 +1,20 @@
+# The flat form the first release shipped. Still read, still checked, and every
+# key here reports where it moved to.
+collectorVersion: v0.157.0
+distribution: contrib
+schemaLocations:
+  - default
+strict: true
+ignoreMissingSchemas: false
+summary: true
+minSeverity: warning
+failOn: error
+disable:
+  - missing-batch
+severity:
+  missing-memory-limiter: warning
+exclude:
+  - "*.tmpl.yaml"
+kubernetes:
+  enabled: true
+  memoryLimit: 512Mi

--- a/testdata/settings/valid/full.yaml
+++ b/testdata/settings/valid/full.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=../../../otelcol-config-lint.schema.json
+#
+# Every key the settings file takes, so the JSON Schema and the loader are held
+# to the same document.
+version: "1"
+
+run:
+  collectorVersion: v0.157.0
+  distribution: contrib
+  schemaLocations:
+    - ./schemas
+    - default
+  strict: true
+  ignoreMissingSchemas: false
+  concurrency: 4
+  exclude:
+    - "*.tmpl.yaml"
+  kubernetes:
+    enabled: true
+    memoryRequest: 512Mi
+    memoryLimit: 512Mi
+    overrides:
+      - paths: ["configs/agent-*.yaml"]
+        memoryRequest: 256Mi
+        memoryLimit: 256Mi
+      - paths: ["configs/legacy/*.yaml"]
+        enabled: false
+
+rules:
+  default: all
+  enable:
+    - no-persistent-queue
+  disable:
+    - missing-batch
+  severity:
+    missing-memory-limiter: warning
+    hardcoded-secret: error
+  settings: {}
+
+issues:
+  minSeverity: info
+  failOn: error
+  exitOnError: false
+
+output:
+  format: text
+  summary: true
+  verbose: false
+  color: true

--- a/testdata/settings/valid/minimal.yaml
+++ b/testdata/settings/valid/minimal.yaml
@@ -1,0 +1,4 @@
+# The common case: a release to target and one rule the project does not want.
+rules:
+  disable:
+    - missing-batch


### PR DESCRIPTION
The settings file was a flat list of keys, and the rules could only be turned off one at a time. Both are now shaped like golangci-lint's, which is the linter every Go project in reach of this one already has a config file for — and the shape is published as a JSON Schema, so an editor checks a settings file as it is written.

## The file

Four blocks — what to check under `run`, which rules under `rules`, what counts as a failure under `issues`, how it is printed under `output`:

```yaml
version: "1"
run:
  collectorVersion: v0.157.0
  strict: true
  concurrency: 8
  exclude: ["*.tmpl.yaml"]
  kubernetes: { ... }
rules:
  default: all          # or "none" -- run only what enable names
  enable: []
  disable: [missing-batch]
  severity: { missing-memory-limiter: warning }
  settings: {}          # each rule's own block, keyed by rule name
issues:
  minSeverity: warning
  failOn: error
  exitOnError: false
output:
  format: text
  summary: true
  verbose: false
  color: true
```

Every flag mirrors one of these keys, and the README table names the pairing for each: the flags are what a single run departs from, the file is what the repository commits.

`.otelcol-config-lint.yaml` (or `.yml`) is looked for in the working directory and then in each parent, stopping at the directory holding `.git`, so one file at the repository root governs a run started anywhere below it. `-c`/`--config` names another, `--no-config` uses none, `--verbose` says which one was read.

## Choosing the rules

`rules.default` names the set to start from — `all` or `none` — and `enable`, `disable` and `severity` move rules in and out of it. A rule named on both sides is an error rather than a silent win for one of them. `list rules` prints what the policy resolves to, so a rule that will not run is listed at severity `off`.

New flags mirror it: `--default`, `-E`/`--enable`, `-D`/`--disable`. The lists **merge** with the file rather than replacing it, so `-D` adds to the committed policy for one run.

## Per-rule settings

`rules.settings` is where a rule's own knobs will go, keyed by rule name. No built-in rule reads a block yet — the schema is here so one can be added without every settings file having to change shape — and until a rule declares that it takes settings, writing a block for it is reported rather than ignored: a knob nobody reads is worse than a knob that is missing.

`rule.Configurable` returns a new rule rather than mutating, since `rule.All` builds the set fresh per run and a rule that changed itself in place would carry one run's policy into the next.

## Checking the file in an editor

`otelcol-config-lint.schema.json` is a JSON Schema for the settings file. Point an editor at it and a misspelled key, a severity that is not a level, and a rule name that does not exist are underlined where they are written:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/minuk-dev/otelcol-config-lint/main/otelcol-config-lint.schema.json
```

It is **generated**, because the part that matters most is the part that moves: it enumerates every rule the linter carries, so a rule added without regenerating would leave editors underlining a name that works — and nothing else would notice, since the linter would go on accepting it. `otelcol-config-lint config-schema` prints the same document, which is how a project that would rather vendor the file gets the rule list the binary it pins actually runs. `make config-schema` rewrites the committed copy.

The flat keys are described too, marked `deprecated` and each saying where it moved, so an existing file is guided rather than underlined. Every block is closed (`additionalProperties: false`), matching the loader.

## Compatibility

- The flat top-level keys the first release shipped are still read and folded into the blocks; a run that finds one says which keys to move.
- `output: json` is not among them — a bare format name stays the shorthand for `output: {format: json}`.
- Keys stay camelCase rather than switching to golangci-lint's kebab-case: that would break every existing file for cosmetics.
- `-n` became `--concurrency`, keeping `-n` as its shorthand.
- `--disable`, `--severity` and `--exclude` became string slices: commas still work, and they are now repeatable too.
- `version: "1"` is a hook for a later schema — a file claiming another version is rejected with a clear message rather than misread.
- The action gained `default`, `enable` and `no-config` inputs.

## Testing

`go test ./...` and `golangci-lint run` are clean.

`testdata/settings` holds one file per case, valid and invalid, and **both sides are held to it**: Go runs the loader over them (`TestTheSettingsFixturesAreWhatTheySayTheyAre`) and the new `config-schema` workflow runs the JSON Schema over them, so a schema that drifted from the loader shows up as the two disagreeing about a file. That workflow also fails on a committed copy that does not match the generator, and checks the schema against the metaschema — an invalid schema is worse than none, since an editor drops it silently and a file with no checking reads exactly like a file with no mistakes.

Other new coverage: `pkg/rule/configure_test.go` for the per-rule settings mechanism, `pkg/cmd/otelcol-config-lint/settings_test.go` for the blocks, discovery, rule selection and the flat-form fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)