### PR TITLE
test(rule): give every rule an invalid config in testdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,7 @@ pkg/lint/                     the engine and the output formatters
 pkg/diag/                     diagnostics, severities and positions
 pkg/quantity/                 Kubernetes memory quantities, parsed and printed back
 pkg/version/                  the linter's own version, stamped at build time
+testdata/rules/               one invalid config per rule, with the run that shows it
 action.yml                    the GitHub Action; Dockerfile wraps the released image it runs
 build/docker/Dockerfile       the distroless linter image releases publish
 ```
@@ -765,6 +766,24 @@ found, err := ruletest.Run(mynewrule.New(), src)
 A test that is about two rules meeting -- one reporting where the other stays
 quiet -- belongs in `pkg/ruleset` instead, which is where the whole set is run
 at once.
+
+Last, the rule needs a config in `testdata/rules`: `my-new-rule.yaml`, which
+breaks it, with a comment naming the rule on the line that breaks it, and
+`my-new-rule.settings.yaml`, which says which rules the run has on in the shape
+golangci-lint uses:
+
+```yaml
+rules:
+  enable: [my-new-rule]  # must report on my-new-rule.yaml
+  disable: []            # switched off for this run, and must stay quiet
+  settings: {}           # per-rule options, keyed by rule name
+```
+
+The tests refuse a rule with no fixture, so this is where a rule is shown
+working through the real command line, the published schemas and the severity
+gate rather than against the stand-in schema. `testdata/rules/README.md` has the
+rest of the schema, including how a fixture selects its own collector release or
+states the container it runs in.
 
 ## Development
 

--- a/pkg/cmd/otelcol-config-lint/rules_test.go
+++ b/pkg/cmd/otelcol-config-lint/rules_test.go
@@ -1,0 +1,266 @@
+package otelcolconfiglint_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/ruleset"
+)
+
+// rulesDir holds one invalid config per rule, each next to the settings file
+// that says which rules the run has on. The point of a fixture per rule is that
+// a rule cannot be added without a config that shows what it reports, and a
+// rule cannot stop reporting without a test saying so.
+const rulesDir = "../../../testdata/rules"
+
+// settingsSuffix is what tells a fixture's settings file from a fixture. Both
+// are YAML in the same directory, so the suffix is what a walk sorts on.
+const settingsSuffix = ".settings.yaml"
+
+// fixture is the declaration next to a fixture, in the shape golangci-lint
+// uses: the rules switched on, the ones switched off, and per-rule options.
+// Everything under "run" describes the run itself and has a default.
+type fixture struct {
+	Rules struct {
+		// Enable names the rules that must report on the fixture.
+		Enable []string `yaml:"enable"`
+		// Disable names the rules the run turns off, which must then stay
+		// silent. It is how a fixture stays about one mistake when the config
+		// that shows it cannot help making another.
+		Disable []string `yaml:"disable"`
+		// Settings holds per-rule options, keyed by rule name. No rule takes
+		// one yet; the key is here so that adding one is a fixture edit rather
+		// than a change to how fixtures are written.
+		Settings map[string]map[string]any `yaml:"settings"`
+	} `yaml:"rules"`
+
+	Run struct {
+		CollectorVersion string `yaml:"collectorVersion"`
+		Distribution     string `yaml:"distribution"`
+		// SchemaLocations are relative to the fixture directory, and searched
+		// before the repository's schemas.
+		SchemaLocations []string `yaml:"schemaLocations"`
+		Strict          bool     `yaml:"strict"`
+		// MinSeverity defaults to info, so a fixture for an info-level rule
+		// needs to say nothing.
+		MinSeverity string `yaml:"minSeverity"`
+		Kubernetes  struct {
+			MemoryRequest string `yaml:"memoryRequest"`
+			MemoryLimit   string `yaml:"memoryLimit"`
+		} `yaml:"kubernetes"`
+	} `yaml:"run"`
+}
+
+// args renders the fixture's run as the command line that produces it, so what
+// a test checks is a run anyone can repeat by hand.
+func (f fixture) args(path string) []string {
+	args := []string{"--output", "json", "--min-severity", lo.CoalesceOrEmpty(f.Run.MinSeverity, "info")}
+
+	for _, loc := range f.Run.SchemaLocations {
+		args = append(args, "--schema-location", filepath.Join(rulesDir, loc))
+	}
+
+	for flag, value := range map[string]string{
+		"--collector-version": f.Run.CollectorVersion,
+		"--distribution":      f.Run.Distribution,
+		"--memory-request":    f.Run.Kubernetes.MemoryRequest,
+		"--memory-limit":      f.Run.Kubernetes.MemoryLimit,
+	} {
+		if value != "" {
+			args = append(args, flag, value)
+		}
+	}
+
+	if f.Run.Strict {
+		args = append(args, "--strict")
+	}
+
+	if len(f.Rules.Disable) > 0 {
+		args = append(args, "--disable", strings.Join(f.Rules.Disable, ","))
+	}
+
+	return append(args, path)
+}
+
+// ruleFixtures reads every fixture in rulesDir, keyed by rule name.
+func ruleFixtures(t *testing.T) map[string]fixture {
+	t.Helper()
+
+	paths, err := filepath.Glob(filepath.Join(rulesDir, "*.yaml"))
+	require.NoError(t, err)
+
+	out := map[string]fixture{}
+
+	for _, path := range paths {
+		if strings.HasSuffix(path, settingsSuffix) {
+			continue
+		}
+
+		name := strings.TrimSuffix(filepath.Base(path), ".yaml")
+		out[name] = readFixture(t, strings.TrimSuffix(path, ".yaml")+settingsSuffix)
+	}
+
+	require.NotEmpty(t, out, "no fixtures found in %s", rulesDir)
+
+	return out
+}
+
+func readFixture(t *testing.T, path string) fixture {
+	t.Helper()
+
+	src, err := os.ReadFile(path)
+	require.NoError(t, err, "every fixture needs a settings file saying which rules it is about")
+
+	var f fixture
+
+	dec := yaml.NewDecoder(strings.NewReader(string(src)))
+	dec.KnownFields(true)
+
+	require.NoError(t, dec.Decode(&f), "%s", path)
+
+	return f
+}
+
+// TestEveryRuleHasAFixture is the coverage gate: a new rule is not finished
+// until testdata carries a config it reports on, and the settings file next to
+// it says so.
+func TestEveryRuleHasAFixture(t *testing.T) {
+	t.Parallel()
+
+	fixtures := ruleFixtures(t)
+
+	for _, r := range ruleset.All() {
+		f, ok := fixtures[r.Name()]
+		if !ok {
+			t.Errorf("rule %q has no fixture; add %s/%s.yaml", r.Name(), rulesDir, r.Name())
+
+			continue
+		}
+
+		assert.Contains(t, f.Rules.Enable, r.Name(),
+			"%s.settings.yaml should enable the rule it is named after", r.Name())
+	}
+
+	for name, f := range fixtures {
+		_, known := ruleset.Lookup(name)
+		assert.Truef(t, known, "fixture %q names no registered rule", name)
+
+		for _, r := range slices.Concat(f.Rules.Enable, f.Rules.Disable, lo.Keys(f.Rules.Settings)) {
+			_, known := ruleset.Lookup(r)
+			assert.Truef(t, known, "%s.settings.yaml names the unknown rule %q", name, r)
+		}
+	}
+}
+
+// TestRuleFixturesReportTheirRule runs each fixture through the command line
+// the settings file describes: the rules it enables have to report, and the
+// ones it disables have to stay quiet.
+func TestRuleFixturesReportTheirRule(t *testing.T) {
+	t.Parallel()
+
+	for name, f := range ruleFixtures(t) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(rulesDir, name+".yaml")
+
+			_, out, errOut := lint(t, "", f.args(path)...)
+			fired := rulesFired(t, out)[name+".yaml"]
+
+			for _, want := range f.Rules.Enable {
+				assert.Containsf(t, fired, want,
+					"%s.yaml should report %s; it reported %v\n%s", name, want, fired, errOut)
+			}
+
+			for _, off := range f.Rules.Disable {
+				assert.NotContainsf(t, fired, off, "%s is disabled for %s.yaml", off, name)
+			}
+		})
+	}
+}
+
+// TestRuleFixturesCommentTheirMistake keeps the fixtures readable as
+// documentation: whoever opens one should read what is wrong on the line that
+// is wrong, not have to run the linter to find out. A comment naming the rule
+// has to sit on, or just above, a line the rule reports.
+func TestRuleFixturesCommentTheirMistake(t *testing.T) {
+	t.Parallel()
+
+	for name, f := range ruleFixtures(t) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(rulesDir, name+".yaml")
+
+			src, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			_, out, _ := lint(t, "", f.args(path)...)
+
+			marked := commentedLines(string(src), name)
+			require.NotEmptyf(t, marked, "%s.yaml should say in a comment what breaks %s", name, name)
+
+			reported := reportedLines(t, out, name)
+			require.NotEmpty(t, reported, "the fixture reported nothing to comment on")
+
+			assert.Truef(t, lo.SomeBy(reported, func(line int) bool {
+				return marked[line] || marked[line-1]
+			}), "%s.yaml comments %s on lines %v, but reports it on lines %v",
+				name, name, lo.Keys(marked), reported)
+		})
+	}
+}
+
+// commentedLines returns the lines carrying a comment that names the rule, as a
+// set of 1-based line numbers.
+func commentedLines(src, rule string) map[int]bool {
+	out := map[int]bool{}
+
+	for i, line := range strings.Split(src, "\n") {
+		_, comment, found := strings.Cut(line, "#")
+		if found && strings.Contains(comment, rule) {
+			out[i+1] = true
+		}
+	}
+
+	return out
+}
+
+// reportedLines returns the lines one rule reported on.
+func reportedLines(t *testing.T, out, rule string) []int {
+	t.Helper()
+
+	var report struct {
+		Files []struct {
+			Diagnostics []struct {
+				Rule     string `json:"rule"`
+				Position struct {
+					Line int `json:"line"`
+				} `json:"position"`
+			} `json:"diagnostics"`
+		} `json:"files"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(out), &report), "output is not valid JSON:\n%s", out)
+
+	var lines []int
+
+	for _, f := range report.Files {
+		for _, d := range f.Diagnostics {
+			if d.Rule == rule {
+				lines = append(lines, d.Position.Line)
+			}
+		}
+	}
+
+	return lines
+}

--- a/pkg/ruleset/ruleset.go
+++ b/pkg/ruleset/ruleset.go
@@ -6,7 +6,9 @@
 // only place that knows about all of them.
 //
 // Adding a rule is therefore two edits: a new package under pkg/rule, and one
-// line in the list below.
+// line in the list below. A third is enforced by the tests: an invalid config
+// the rule reports on, under testdata/rules, which is where a rule is shown
+// working through the command line rather than against a stand-in schema.
 package ruleset
 
 import (

--- a/testdata/rules/README.md
+++ b/testdata/rules/README.md
@@ -1,0 +1,77 @@
+# One invalid config per rule
+
+Every rule in `pkg/ruleset` has a fixture here: a config that breaks it, and a
+settings file that says so. Together they answer two questions a unit test
+answers less directly — what does a config that trips this rule look like, and
+does the rule still fire on it when run through the real command line, the
+published schemas and the severity gate.
+
+```
+testdata/rules/
+  insecure-tls.yaml            the config, with the mistake commented where it is
+  insecure-tls.settings.yaml   the rules the run has on, and the run itself
+  schemas/v9.9.9.json          a small schema, for what no release describes yet
+```
+
+`pkg/cmd/otelcol-config-lint/rules_test.go` reads all of it:
+
+- **every rule has a fixture** that enables it, and no fixture names a rule that
+  is not registered. A new rule is not finished until it has one.
+- **the fixture reports its rule**, and stays silent about the rules its settings
+  file disables.
+- **the mistake is commented where it is made**: a comment naming the rule has to
+  sit on, or just above, a line the rule reports. Whoever opens a fixture reads
+  what is wrong without running anything.
+
+## The settings file
+
+The shape is golangci-lint's: what is switched on, what is switched off, and
+per-rule options. Everything under `run` describes the run and has a default, so
+most fixtures write nothing there.
+
+```yaml
+rules:
+  # Rules that must report on the fixture. Normally the one it is named after.
+  enable:
+    - insecure-tls
+  # Rules the run turns off, which must then stay silent. This is how a fixture
+  # stays about one mistake when the config that shows it cannot help making
+  # another -- say a config with no service block, where every component is
+  # also unused.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet; the key is
+  # here so that giving a rule its first option is a fixture edit rather than a
+  # change to how fixtures are written.
+  settings: {}
+
+run:
+  minSeverity: info               # default: every finding is visible
+  collectorVersion: v0.157.0      # default: the latest schema in testdata/schemas
+  distribution: contrib           # default
+  schemaLocations: [schemas]      # searched first, relative to this directory
+  strict: false                   # default
+  kubernetes:                     # for the rules that need to know the container
+    memoryRequest: 256Mi
+    memoryLimit: 256Mi
+```
+
+Each field is a flag the command line already has, so a fixture is a run anyone
+can repeat by hand:
+
+```sh
+otelcol-config-lint run --schema-location testdata/schemas --min-severity info \
+  --memory-limit 256Mi testdata/rules/memory-limiter-sizing.yaml
+```
+
+## Adding one
+
+1. Write `<rule>.yaml`: a config that is otherwise clean, with one deliberate
+   mistake and a comment naming the rule on the line that makes it.
+2. Write `<rule>.settings.yaml` enabling the rule. If the config cannot avoid
+   tripping a second rule, disable that one and say why in a comment.
+3. `go test ./pkg/cmd/otelcol-config-lint/`.
+
+One rule reports something no published schema carries yet: no release in
+`testdata/schemas` marks a setting as deprecated, so `deprecated-field` brings
+its own schema in `schemas/` and selects it with `run.collectorVersion` and
+`run.schemaLocations`. A rule in that position is the reason `run` exists.

--- a/testdata/rules/batch-size-bounds.settings.yaml
+++ b/testdata/rules/batch-size-bounds.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - batch-size-bounds
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/batch-size-bounds.yaml
+++ b/testdata/rules/batch-size-bounds.yaml
@@ -1,0 +1,25 @@
+# batch-size-bounds: a batch processor the collector will refuse to start.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+    send_batch_size: 10000
+    send_batch_max_size: 1000 # batch-size-bounds: the cap is below the size a batch is sent at
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/component-stability.settings.yaml
+++ b/testdata/rules/component-stability.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - component-stability
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/component-stability.yaml
+++ b/testdata/rules/component-stability.yaml
@@ -1,0 +1,27 @@
+# component-stability: a component below beta stability.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+extensions:
+  remotetap: # component-stability: in development, so its configuration can change without notice
+    endpoint: localhost:12001
+service:
+  extensions: [remotetap]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/connector-wiring.settings.yaml
+++ b/testdata/rules/connector-wiring.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - connector-wiring
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/connector-wiring.yaml
+++ b/testdata/rules/connector-wiring.yaml
@@ -1,0 +1,31 @@
+# connector-wiring: a connector that only ever receives.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+connectors:
+  span_metrics: # connector-wiring: read below -- nothing exports into it, so it produces nothing
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]
+    metrics:
+      # No traces pipeline lists span_metrics as an exporter, so this pipeline waits on a
+      # connector nothing feeds.
+      receivers: [span_metrics]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/debug-exporter-verbosity.settings.yaml
+++ b/testdata/rules/debug-exporter-verbosity.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - debug-exporter-verbosity
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/debug-exporter-verbosity.yaml
+++ b/testdata/rules/debug-exporter-verbosity.yaml
@@ -1,0 +1,22 @@
+# debug-exporter-verbosity: a debug exporter writing out everything it is given.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  debug:
+    verbosity: detailed # the verbosity that writes each record out in full
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      # debug-exporter-verbosity: everything this pipeline exports is written to the log
+      exporters: [debug]

--- a/testdata/rules/debug-extension-exposed.settings.yaml
+++ b/testdata/rules/debug-extension-exposed.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - debug-extension-exposed
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/debug-extension-exposed.yaml
+++ b/testdata/rules/debug-extension-exposed.yaml
@@ -1,0 +1,27 @@
+# debug-extension-exposed: a debugging endpoint reachable from off the host.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+extensions:
+  zpages:
+    endpoint: 0.0.0.0:55679 # debug-extension-exposed: served to every network, not just this host
+service:
+  extensions: [zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/deprecated-component.settings.yaml
+++ b/testdata/rules/deprecated-component.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - deprecated-component
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/deprecated-component.yaml
+++ b/testdata/rules/deprecated-component.yaml
@@ -1,0 +1,23 @@
+# deprecated-component: a component upstream has replaced.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp: # deprecated-component: renamed to "otlp_grpc" upstream; the old name still resolves for now
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp]

--- a/testdata/rules/deprecated-field.settings.yaml
+++ b/testdata/rules/deprecated-field.settings.yaml
@@ -1,0 +1,14 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - deprecated-field
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+run:
+  collectorVersion: v9.9.9
+  # Searched before the repository's schemas, relative to this file.
+  schemaLocations: [schemas]

--- a/testdata/rules/deprecated-field.yaml
+++ b/testdata/rules/deprecated-field.yaml
@@ -1,0 +1,27 @@
+# deprecated-field: a setting upstream has replaced.
+#
+# No released schema carries a deprecated setting yet, so this fixture is
+# checked against the small schema in ./schemas, which does.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    compression: gzip # deprecated-field: replaced by "compression_type" in this schema
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/duplicate-key.settings.yaml
+++ b/testdata/rules/duplicate-key.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - duplicate-key
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/duplicate-key.yaml
+++ b/testdata/rules/duplicate-key.yaml
@@ -1,0 +1,27 @@
+# duplicate-key: the same mapping key written twice.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+  otlp: # duplicate-key: the declaration above is silently discarded
+    protocols:
+      http:
+        endpoint: localhost:4318
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/duplicate-reference.settings.yaml
+++ b/testdata/rules/duplicate-reference.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - duplicate-reference
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/duplicate-reference.yaml
+++ b/testdata/rules/duplicate-reference.yaml
@@ -1,0 +1,23 @@
+# duplicate-reference: the same component listed twice in one slot.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp, otlp] # duplicate-reference: the second entry adds nothing
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/empty-pipeline.settings.yaml
+++ b/testdata/rules/empty-pipeline.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - empty-pipeline
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/empty-pipeline.yaml
+++ b/testdata/rules/empty-pipeline.yaml
@@ -1,0 +1,10 @@
+# empty-pipeline: a pipeline that receives telemetry and never sends it anywhere.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+service:
+  pipelines:
+    traces: # empty-pipeline: no exporters, so the telemetry this pipeline receives goes nowhere
+      receivers: [otlp]

--- a/testdata/rules/hardcoded-secret.settings.yaml
+++ b/testdata/rules/hardcoded-secret.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - hardcoded-secret
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/hardcoded-secret.yaml
+++ b/testdata/rules/hardcoded-secret.yaml
@@ -1,0 +1,26 @@
+# hardcoded-secret: a credential the config carries itself.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    headers:
+      # hardcoded-secret: the token is in the repository; it belongs in ${env:OTLP_TOKEN}
+      authorization: Bearer a3f1c99d4b7e2085f6c1
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/insecure-tls.settings.yaml
+++ b/testdata/rules/insecure-tls.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - insecure-tls
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/insecure-tls.yaml
+++ b/testdata/rules/insecure-tls.yaml
@@ -1,0 +1,25 @@
+# insecure-tls: TLS verification switched off on a network component.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    tls:
+      insecure: true # insecure-tls: the connection to the backend is neither encrypted nor verified
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/invalid-pipeline-key.settings.yaml
+++ b/testdata/rules/invalid-pipeline-key.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - invalid-pipeline-key
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/invalid-pipeline-key.yaml
+++ b/testdata/rules/invalid-pipeline-key.yaml
@@ -1,0 +1,23 @@
+# invalid-pipeline-key: a pipeline named after no signal.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    tracez: # invalid-pipeline-key: a pipeline key must be <signal> or <signal>/<name>
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/invalid-value.settings.yaml
+++ b/testdata/rules/invalid-value.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - invalid-value
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/invalid-value.yaml
+++ b/testdata/rules/invalid-value.yaml
@@ -1,0 +1,24 @@
+# invalid-value: a setting whose value has the wrong type.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    timeout: 5 # invalid-value: a duration needs a unit, so this is not 5 seconds
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/memory-limiter-config.settings.yaml
+++ b/testdata/rules/memory-limiter-config.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - memory-limiter-config
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/memory-limiter-config.yaml
+++ b/testdata/rules/memory-limiter-config.yaml
@@ -1,0 +1,23 @@
+# memory-limiter-config: a memory_limiter the collector will refuse to start.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 0s # memory-limiter-config: the interval must be greater than zero
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/memory-limiter-sizing.settings.yaml
+++ b/testdata/rules/memory-limiter-sizing.settings.yaml
@@ -1,0 +1,15 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - memory-limiter-sizing
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+run:
+  # The container the config runs in, for the rules that cannot judge one without it.
+  kubernetes:
+    memoryRequest: 256Mi
+    memoryLimit: 256Mi

--- a/testdata/rules/memory-limiter-sizing.yaml
+++ b/testdata/rules/memory-limiter-sizing.yaml
@@ -1,0 +1,26 @@
+# memory-limiter-sizing: a memory_limiter that does not fit its container.
+#
+# The container is stated in memory-limiter-sizing.settings.yaml, since a
+# config alone never says how much memory it is given.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512 # memory-limiter-sizing: 512Mi enforced in the 256Mi container below
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/missing-batch.settings.yaml
+++ b/testdata/rules/missing-batch.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - missing-batch
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/missing-batch.yaml
+++ b/testdata/rules/missing-batch.yaml
@@ -1,0 +1,22 @@
+# missing-batch: telemetry leaves the collector one record at a time.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter] # missing-batch: nothing batches, so a record is an export
+      exporters: [otlp_grpc]

--- a/testdata/rules/missing-memory-limiter.settings.yaml
+++ b/testdata/rules/missing-memory-limiter.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - missing-memory-limiter
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/missing-memory-limiter.yaml
+++ b/testdata/rules/missing-memory-limiter.yaml
@@ -1,0 +1,19 @@
+# missing-memory-limiter: nothing bounds what the collector holds.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch] # missing-memory-limiter: under load, the OOM killer is the limit
+      exporters: [otlp_grpc]

--- a/testdata/rules/no-persistent-queue.settings.yaml
+++ b/testdata/rules/no-persistent-queue.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - no-persistent-queue
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/no-persistent-queue.yaml
+++ b/testdata/rules/no-persistent-queue.yaml
@@ -1,0 +1,22 @@
+# no-persistent-queue: a sending queue a restart empties.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  # no-persistent-queue: the default sending_queue is in memory, with no storage behind it
+  otlp_grpc:
+    endpoint: backend:4317
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/processor-order.settings.yaml
+++ b/testdata/rules/processor-order.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - processor-order
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/processor-order.yaml
+++ b/testdata/rules/processor-order.yaml
@@ -1,0 +1,24 @@
+# processor-order: processors run in the order they are listed.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      # processor-order: memory_limiter must run first, before the batch it protects
+      processors: [batch, memory_limiter]
+      exporters: [otlp_grpc]

--- a/testdata/rules/receiver-binds-all-interfaces.settings.yaml
+++ b/testdata/rules/receiver-binds-all-interfaces.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - receiver-binds-all-interfaces
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/receiver-binds-all-interfaces.yaml
+++ b/testdata/rules/receiver-binds-all-interfaces.yaml
@@ -1,0 +1,23 @@
+# receiver-binds-all-interfaces: a listener on every interface the host has.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317 # receiver-binds-all-interfaces: every network the host is on
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/required-field.settings.yaml
+++ b/testdata/rules/required-field.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - required-field
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/required-field.yaml
+++ b/testdata/rules/required-field.yaml
@@ -1,0 +1,20 @@
+# required-field: a setting the component cannot start without.
+receivers:
+  otlp: # required-field: the otlp receiver needs "protocols"; with none it enables nothing
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/schemas/v9.9.9.json
+++ b/testdata/rules/schemas/v9.9.9.json
@@ -1,0 +1,87 @@
+{
+  "collectorVersion": "v9.9.9",
+  "distribution": "contrib",
+  "components": {
+    "receiver": {
+      "otlp": {
+        "type": "otlp",
+        "signals": ["traces"],
+        "stability": {"traces": "stable"},
+        "fields": {
+          "type": "map",
+          "required": ["protocols"],
+          "children": {
+            "protocols": {
+              "type": "map",
+              "children": {
+                "grpc": {
+                  "type": "map",
+                  "children": {"endpoint": {"type": "string"}}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "processor": {
+      "batch": {
+        "type": "batch",
+        "signals": ["traces"],
+        "stability": {"traces": "stable"},
+        "fields": {
+          "type": "map",
+          "children": {
+            "send_batch_max_size": {"type": "int"},
+            "send_batch_size": {"type": "int"},
+            "timeout": {"type": "duration"}
+          }
+        }
+      },
+      "memory_limiter": {
+        "type": "memory_limiter",
+        "signals": ["traces"],
+        "stability": {"traces": "stable"},
+        "fields": {
+          "type": "map",
+          "required": ["check_interval"],
+          "children": {
+            "check_interval": {"type": "duration"},
+            "limit_mib": {"type": "int"},
+            "limit_percentage": {"type": "int"},
+            "spike_limit_mib": {"type": "int"},
+            "spike_limit_percentage": {"type": "int"}
+          }
+        }
+      }
+    },
+    "exporter": {
+      "otlp_grpc": {
+        "type": "otlp_grpc",
+        "signals": ["traces"],
+        "stability": {"traces": "stable"},
+        "fields": {
+          "type": "map",
+          "children": {
+            "compression": {
+              "type": "string",
+              "enum": ["gzip", "snappy", "zstd", "none", ""],
+              "deprecated": "use \"compression_type\", which also names the compression level"
+            },
+            "compression_type": {"type": "string"},
+            "endpoint": {"type": "string"},
+            "sending_queue": {
+              "type": "map",
+              "children": {
+                "enabled": {"type": "bool"},
+                "queue_size": {"type": "int"},
+                "storage": {"type": "string"}
+              }
+            },
+            "timeout": {"type": "duration"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/rules/service-required.settings.yaml
+++ b/testdata/rules/service-required.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - service-required
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/service-required.yaml
+++ b/testdata/rules/service-required.yaml
@@ -1,0 +1,12 @@
+# service-required: components are declared, but nothing wires them up.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+# service-required: no service block, so the collector starts nothing at all

--- a/testdata/rules/signal-support.settings.yaml
+++ b/testdata/rules/signal-support.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - signal-support
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/signal-support.yaml
+++ b/testdata/rules/signal-support.yaml
@@ -1,0 +1,20 @@
+# signal-support: a receiver wired into a signal it does not carry.
+receivers:
+  jaeger:
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    metrics:
+      receivers: [jaeger] # signal-support: the jaeger receiver carries traces only
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/undefined-extension-reference.settings.yaml
+++ b/testdata/rules/undefined-extension-reference.settings.yaml
@@ -1,0 +1,16 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - undefined-extension-reference
+  # Rules switched off for this run, so the fixture stays about one mistake.
+  # The exporter is spelt "otlp" because that release types the newer name's
+  # storage setting as a mapping; the old name is deprecated, which is not
+  # what this fixture is about.
+  disable:
+    - deprecated-component
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/undefined-extension-reference.yaml
+++ b/testdata/rules/undefined-extension-reference.yaml
@@ -1,0 +1,23 @@
+# undefined-extension-reference: a queue names a storage extension that is not there.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage # undefined-extension-reference: nothing declares "file_storage"
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp]

--- a/testdata/rules/undefined-reference.settings.yaml
+++ b/testdata/rules/undefined-reference.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - undefined-reference
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/undefined-reference.yaml
+++ b/testdata/rules/undefined-reference.yaml
@@ -1,0 +1,23 @@
+# undefined-reference: a pipeline names a component nobody declares.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp, jaeger] # undefined-reference: nothing declares "jaeger" under receivers
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/unknown-component.settings.yaml
+++ b/testdata/rules/unknown-component.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - unknown-component
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/unknown-component.yaml
+++ b/testdata/rules/unknown-component.yaml
@@ -1,0 +1,20 @@
+# unknown-component: a component type this release does not ship.
+receivers:
+  nosuchreceiver: # unknown-component: no receiver of this type exists in the targeted release
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [nosuchreceiver]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/unknown-field.settings.yaml
+++ b/testdata/rules/unknown-field.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - unknown-field
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/unknown-field.yaml
+++ b/testdata/rules/unknown-field.yaml
@@ -1,0 +1,24 @@
+# unknown-field: a setting the component does not accept.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    compresion: gzip # unknown-field: "compression" misspelt; the collector rejects the setting
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/unknown-pipeline-key.settings.yaml
+++ b/testdata/rules/unknown-pipeline-key.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - unknown-pipeline-key
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/unknown-pipeline-key.yaml
+++ b/testdata/rules/unknown-pipeline-key.yaml
@@ -1,0 +1,24 @@
+# unknown-pipeline-key: a pipeline accepts three slots and this is a fourth.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]
+      connectors: [span_metrics] # unknown-pipeline-key: a connector joins as receiver or exporter

--- a/testdata/rules/unknown-service-key.settings.yaml
+++ b/testdata/rules/unknown-service-key.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - unknown-service-key
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/unknown-service-key.yaml
+++ b/testdata/rules/unknown-service-key.yaml
@@ -1,0 +1,26 @@
+# unknown-service-key: a key inside service that the collector does not read.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  telemetrey: # unknown-service-key: "telemetry" misspelt; the block is silently never read
+    logs:
+      level: debug
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/unknown-top-level-key.settings.yaml
+++ b/testdata/rules/unknown-top-level-key.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - unknown-top-level-key
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/unknown-top-level-key.yaml
+++ b/testdata/rules/unknown-top-level-key.yaml
@@ -1,0 +1,25 @@
+# unknown-top-level-key: a section the collector does not read.
+recievers: # unknown-top-level-key: "receivers" misspelt, so the collector rejects the file
+  otlp:
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/unused-component.settings.yaml
+++ b/testdata/rules/unused-component.settings.yaml
@@ -1,0 +1,12 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - unused-component
+  # Nothing to switch off: the fixture reports what it is named after.
+  disable: []
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/unused-component.yaml
+++ b/testdata/rules/unused-component.yaml
@@ -1,0 +1,27 @@
+# unused-component: a declared component no pipeline reaches.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+  otlp/second: # unused-component: declared, referenced by no pipeline, so never instantiated
+    protocols:
+      http:
+        endpoint: localhost:4318
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]

--- a/testdata/rules/wrong-node-type.settings.yaml
+++ b/testdata/rules/wrong-node-type.settings.yaml
@@ -1,0 +1,17 @@
+# What this fixture is for, in the shape golangci-lint uses: the rules that
+# are switched on, the ones switched off, and per-rule options.
+rules:
+  # Rules that must report on the fixture.
+  enable:
+    - wrong-node-type
+  # Rules switched off for this run, so the fixture stays about one mistake.
+  # A slot the linter cannot read reaches no component: otlp then looks
+  # declared and unused, and the pipeline it belongs to looks like it has no
+  # receivers.
+  disable:
+    - unused-component
+    - empty-pipeline
+  # Per-rule options, keyed by rule name. No rule takes one yet.
+  settings: {}
+# No "run:" block: the defaults are enough -- the latest schema of the
+# contrib distribution, with every severity visible.

--- a/testdata/rules/wrong-node-type.yaml
+++ b/testdata/rules/wrong-node-type.yaml
@@ -1,0 +1,24 @@
+# wrong-node-type: a pipeline slot written as a mapping.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  batch:
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    sending_queue:
+      enabled: false
+service:
+  pipelines:
+    traces:
+      receivers: # wrong-node-type: a pipeline slot is a list of component ids, not a mapping
+        otlp: {}
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]


### PR DESCRIPTION
A rule's own tests run it against a stand-in schema, in the package that defines it. Nothing showed a rule working end to end -- through the real command line, the published schemas and the severity gate -- and nothing said a rule had to be shown at all, so a rule could be added, or quietly stop reporting, with no config anywhere naming it.

`testdata/rules` now holds one invalid config per rule, all 33 of them. Each is otherwise clean, breaks the rule it is named after, and says in a comment **on the offending line** what is wrong, so the directory reads as documentation of what each rule reports:

```yaml
# insecure-tls: TLS verification switched off on a network component.
exporters:
  otlp_grpc:
    endpoint: backend:4317
    tls:
      insecure: true # insecure-tls: the connection to the backend is neither encrypted nor verified
```

## The settings file

Next to each config is `<rule>.settings.yaml`, in the shape golangci-lint uses:

```yaml
rules:
  enable: [insecure-tls]  # must report on the fixture
  disable: []             # switched off for this run, and must stay silent
  settings: {}            # per-rule options, keyed by rule name
run:                      # every field has a default; most fixtures write none
  minSeverity: info
  collectorVersion: v9.9.9
  schemaLocations: [schemas]
  kubernetes: {memoryRequest: 256Mi, memoryLimit: 256Mi}
```

The options key is empty because no rule takes one yet; it is in the schema so that giving a rule its first option is a fixture edit rather than a change to how fixtures are written. Everything under `run` is a flag the command line already has, so a fixture is a run anyone can repeat by hand:

```sh
otelcol-config-lint run --schema-location testdata/schemas --min-severity info \
  --memory-limit 256Mi testdata/rules/memory-limiter-sizing.yaml
```

## What the tests read

Three tests in `pkg/cmd/otelcol-config-lint/rules_test.go`:

- **every rule has a fixture** that enables it, and no fixture names an unregistered rule
- **each fixture reports what it enables** and stays silent about what it disables
- **the comment sits where the finding is**: a comment naming the rule has to be on, or just above, a line the rule reports, so the comments cannot drift as the fixtures are edited

`disable` is what keeps a fixture about one mistake where the config showing it cannot avoid another: a pipeline slot written as a mapping reaches no component, so the receiver looks unused and the pipeline looks empty -- the same mistake reported twice, and each `disable` says so in a comment.

`deprecated-field` brings its own schema in `testdata/rules/schemas`. No release the repository ships describes a deprecated setting (required ones it does), so that rule has nothing to fire on otherwise. That is what `run` exists for.

## Noticed while writing the fixtures, not fixed here

The generated schemas type component-id settings as mappings -- `sending_queue.storage`, `auth.authenticator` -- so a valid `sending_queue: {storage: file_storage}` is reported as `invalid-value: "sending_queue.storage" must be a mapping`. It looks like a `schemagen` bug rather than a rule one, and it is why the `undefined-extension-reference` fixture uses the older `otlp` exporter name, whose `storage` the schema still types as a string.

## Checks

`go test ./...` and `make lint` pass on this branch, rebased on `main` after #87. CI lints `testdata/valid` and `testdata/invalid`; `testdata/rules` is a separate directory, so those steps are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)