### PR TITLE
feat(schema): hold the remote schema fetch to what it is worth trusting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ whole reference: `files` (default `.`, whitespace-separated, globs allowed),
 several in order), `strict`, `ignore-missing-schemas`, `min-severity`,
 `fail-on`, `default`, `enable`, `disable`, `severity`, `exclude`, `output`
 (default `github`), `config`, `no-config`, `summary` (default `true`),
-`verbose` and `exit-on-error`. Only `--concurrency` and `--no-color` are left
-out: a runner gains nothing from either.
+`verbose` and `exit-on-error`. `--concurrency`, `--no-color` and
+`--insecure-schema-location` are left out: a runner gains nothing from the
+first two, and a workflow that reads its schemas over plain HTTP is one whose
+findings anyone on the path can choose.
 
 The counts come back as outputs — `exit-code`, `valid`, `invalid`, `errors`,
 `skipped`, `warnings` and `infos` — so a later step can decide what to do with
@@ -127,6 +129,7 @@ from it.
 | `--collector-version` | `run.collectorVersion` | release to validate against, e.g. `v0.157.0` (default `latest`) |
 | `--distribution` | `run.distribution` | collector binary to validate against: `core`, `contrib` (default), `k8s` or `otlp` |
 | `--schema-location` | `run.schemaLocations` | where to find schemas: a registry directory or URL, a `{{.Version}}`/`{{.Distribution}}` template, or `default`. Repeat to search several in order |
+| `--insecure-schema-location` | `run.insecureSchemaLocation` | allow a plain `http://` schema location, which is otherwise refused. For a registry served on localhost |
 | `--strict` | `run.strict` | unknown component settings become errors instead of warnings |
 | `--ignore-missing-schemas` | `run.ignoreMissingSchemas` | do not fail on components absent from the schema (custom distributions) |
 | `--exclude` | `run.exclude` | glob patterns to skip when walking directories |
@@ -711,7 +714,7 @@ components:
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
 ```
 
-They are read over HTTP by default, so nothing needs installing or cloning. To
+They are read over HTTPS by default, so nothing needs installing or cloning. To
 pin a copy, or to run without network access, point at a checkout:
 
 ```sh
@@ -724,6 +727,14 @@ template naming a single file, or `default` for the published registry. Repeat
 the flag to search several in order, so a private distribution's schema can take
 precedence over the public ones, or so a vendored copy answers before the
 network is tried.
+
+A remote location must be `https://`. The schema is what every rule reasons
+from — which components exist, which settings they take — so anyone able to
+rewrite one in flight decides what the linter reports; a plain `http://`
+location is refused unless `--insecure-schema-location` says otherwise, which
+is there for a registry served on localhost. One download is capped at 32 MiB,
+so a registry that is hostile or merely broken cannot stream the linter out of
+memory.
 
 ### Adding a release
 

--- a/cmd/otelcol-config-lint/main.go
+++ b/cmd/otelcol-config-lint/main.go
@@ -3,25 +3,41 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
+	"os/signal"
+	"syscall"
 
 	otelcolconfiglint "github.com/minuk-dev/otelcol-config-lint/pkg/cmd/otelcol-config-lint"
 )
 
 func main() {
+	// The exit code is decided in run so that the signal handler is torn down
+	// before the process ends; os.Exit runs no deferred call.
+	os.Exit(run())
+}
+
+// run executes the command and reports the code the process should end with.
+func run() int {
+	// The run is carried on a context that an interrupt cancels, so a schema
+	// fetch that is still in flight ends with the rest of the command instead
+	// of holding the terminal until the client times out.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	cmd := otelcolconfiglint.NewCommand(nil)
 	cmd.SetArgs(os.Args[1:])
 	cmd.SetIn(os.Stdin)
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil && !errors.Is(err, otelcolconfiglint.ErrFilesInvalid) {
 		// Findings have already been printed by the formatter, so only
 		// command-level failures are worth a message here.
 		cmd.PrintErrf("otelcol-config-lint: %v\n", err)
 	}
 
-	os.Exit(otelcolconfiglint.ExitCode(err))
+	return otelcolconfiglint.ExitCode(err)
 }

--- a/otelcol-config-lint.schema.json
+++ b/otelcol-config-lint.schema.json
@@ -316,6 +316,10 @@
           "description": "Do not fail on components the schema does not describe, for a custom distribution.",
           "type": "boolean"
         },
+        "insecureSchemaLocation": {
+          "description": "Allow a plain http:// schema location, which is otherwise refused. For a registry served on localhost; over a network anyone on the path decides what the rules report.",
+          "type": "boolean"
+        },
         "kubernetes": {
           "additionalProperties": false,
           "description": "The pods the configs run in, for the rules that cannot judge a config without knowing what it runs in.",

--- a/pkg/cmd/otelcol-config-lint/list/list.go
+++ b/pkg/cmd/otelcol-config-lint/list/list.go
@@ -147,8 +147,9 @@ type versionsOptions struct {
 	*cmdutil.GlobalOptions
 
 	// flags
-	distribution    string
-	schemaLocations []string
+	distribution           string
+	schemaLocations        []string
+	insecureSchemaLocation bool
 
 	// internal state
 	// store is where the schemas are read from.
@@ -191,6 +192,8 @@ func (o *versionsOptions) declareFlags(cmd *cobra.Command) {
 	flags.StringSliceVar(&o.schemaLocations, "schema-location", nil,
 		"where to find schemas: a directory, a {{.Version}} template, a URL, or \"default\";\n"+
 			"repeat to search several in order (default: the published registry)")
+	flags.BoolVar(&o.insecureSchemaLocation, "insecure-schema-location", false,
+		"allow a plain http:// schema location, for a registry served on localhost")
 }
 
 // prepare folds the schema keys of the settings file into the flags and builds
@@ -205,15 +208,27 @@ func (o *versionsOptions) prepare(cmd *cobra.Command) error {
 
 	fold.Str("distribution", &o.distribution, file.Run.Distribution)
 	fold.List("schema-location", &o.schemaLocations, file.Run.SchemaLocations)
+	fold.Bool("insecure-schema-location", &o.insecureSchemaLocation, file.Run.InsecureSchemaLocation)
 
-	o.store = schema.Store{Locations: o.schemaLocations, Distribution: o.distribution, Fs: o.FS()}
+	o.store = schema.Store{
+		Locations:     o.schemaLocations,
+		Distribution:  o.distribution,
+		AllowInsecure: o.insecureSchemaLocation,
+		Fs:            o.FS(),
+	}
+
+	err = o.store.Validate()
+	if err != nil {
+		return fmt.Errorf("--schema-location: %w; pass --insecure-schema-location"+
+			" to allow one served on localhost", err)
+	}
 
 	return nil
 }
 
 // run prints one row per schema version, newest first.
 func (o *versionsOptions) run(cmd *cobra.Command) error {
-	versions := o.store.Versions()
+	versions := o.store.Versions(cmd.Context())
 	if len(versions) == 0 {
 		return ErrNoSchemas
 	}
@@ -221,7 +236,7 @@ func (o *versionsOptions) run(cmd *cobra.Command) error {
 	w := newColumns(cmd.OutOrStdout())
 
 	for i, v := range versions {
-		cat, err := o.store.Load(v)
+		cat, err := o.store.Load(cmd.Context(), v)
 		if err != nil {
 			w.row(v, "unreadable: "+err.Error(), "")
 

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -602,20 +602,13 @@ func TestAPlainHTTPSchemaLocationIsRefused(t *testing.T) {
 	defer srv.Close()
 
 	code, _, errOut := run(t, "", "run", "--no-config", "--schema-location", srv.URL, validConfig)
-	if code != otelcolconfiglint.ExitUsage {
-		t.Fatalf("an http:// location should not run, got exit %d: %s", code, errOut)
-	}
-
-	if !strings.Contains(errOut, "http") {
-		t.Errorf("the message should say what was refused:\n%s", errOut)
-	}
+	require.Equal(t, otelcolconfiglint.ExitUsage, code, "an http:// location should not run: %s", errOut)
+	assert.Contains(t, errOut, "http", "the message should say what was refused")
 
 	// The escape hatch is what a registry served on localhost is read under.
 	code, _, errOut = run(t, "", "run", "--no-config", "--insecure-schema-location",
 		"--schema-location", srv.URL, validConfig)
-	if code != 0 {
-		t.Errorf("the opt-in should permit the location, got exit %d: %s", code, errOut)
-	}
+	assert.Equal(t, otelcolconfiglint.ExitOK, code, "the opt-in should permit the location: %s", errOut)
 }
 
 // TestListVersionsRefusesAPlainHTTPLocation pins that the listings hold to the
@@ -624,13 +617,8 @@ func TestListVersionsRefusesAPlainHTTPLocation(t *testing.T) {
 	t.Parallel()
 
 	code, _, errOut := run(t, "", "list", "versions", "--no-config", "--schema-location", "http://example.invalid")
-	if code != otelcolconfiglint.ExitUsage {
-		t.Fatalf("an http:// location should not be listed, got exit %d: %s", code, errOut)
-	}
-
-	if !strings.Contains(errOut, "http") {
-		t.Errorf("the message should say what was refused:\n%s", errOut)
-	}
+	require.Equal(t, otelcolconfiglint.ExitUsage, code, "an http:// location should not be listed: %s", errOut)
+	assert.Contains(t, errOut, "http", "the message should say what was refused")
 }
 
 // TestListSubcommandsRejectLintFlags pins the point of the split: the listings

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -587,6 +589,47 @@ func TestListVersionsHonoursTheSchemaLocation(t *testing.T) {
 
 	if !strings.Contains(out, "v9.9.9") {
 		t.Errorf("a project schema should be listed:\n%s", out)
+	}
+}
+
+// TestAPlainHTTPSchemaLocationIsRefused pins that the schema a run reasons
+// from may not arrive over a transport anyone on the path can rewrite, and
+// that the refusal is reported where a bad flag is.
+func TestAPlainHTTPSchemaLocationIsRefused(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.FileServer(http.Dir(repoSchemas)))
+	defer srv.Close()
+
+	code, _, errOut := run(t, "", "run", "--no-config", "--schema-location", srv.URL, validConfig)
+	if code != otelcolconfiglint.ExitUsage {
+		t.Fatalf("an http:// location should not run, got exit %d: %s", code, errOut)
+	}
+
+	if !strings.Contains(errOut, "http") {
+		t.Errorf("the message should say what was refused:\n%s", errOut)
+	}
+
+	// The escape hatch is what a registry served on localhost is read under.
+	code, _, errOut = run(t, "", "run", "--no-config", "--insecure-schema-location",
+		"--schema-location", srv.URL, validConfig)
+	if code != 0 {
+		t.Errorf("the opt-in should permit the location, got exit %d: %s", code, errOut)
+	}
+}
+
+// TestListVersionsRefusesAPlainHTTPLocation pins that the listings hold to the
+// same rule: they read the same registries a run does.
+func TestListVersionsRefusesAPlainHTTPLocation(t *testing.T) {
+	t.Parallel()
+
+	code, _, errOut := run(t, "", "list", "versions", "--no-config", "--schema-location", "http://example.invalid")
+	if code != otelcolconfiglint.ExitUsage {
+		t.Fatalf("an http:// location should not be listed, got exit %d: %s", code, errOut)
+	}
+
+	if !strings.Contains(errOut, "http") {
+		t.Errorf("the message should say what was refused:\n%s", errOut)
 	}
 }
 

--- a/pkg/cmd/otelcol-config-lint/run/run.go
+++ b/pkg/cmd/otelcol-config-lint/run/run.go
@@ -349,11 +349,11 @@ func (o *options) lintAll(
 	results := make(map[string]lint.Result, files.Len())
 
 	if files.Has(scanner.StdinMarker) {
-		results[scanner.StdinMarker] = linter.LintReader("stdin", cmd.InOrStdin())
+		results[scanner.StdinMarker] = linter.LintReader(cmd.Context(), "stdin", cmd.InOrStdin())
 	}
 
 	onDisk := sets.List(files.Difference(sets.New(scanner.StdinMarker)))
-	for r := range linter.LintAll(onDisk, o.concurrency) {
+	for r := range linter.LintAll(cmd.Context(), onDisk, o.concurrency) {
 		results[r.Path] = r
 	}
 
@@ -411,8 +411,8 @@ func (o *options) newLinter(cmd *cobra.Command) (*lint.Linter, error) {
 	return lint.New(lint.Options{
 		Schema:               cat,
 		Fs:                   o.FS(),
-		Availability:         lint.NewVersionIndex(cmd.Context(), o.store),
-		Distributions:        lint.NewDistributionIndex(cmd.Context(), o.store, cat.CollectorVersion),
+		Availability:         lint.NewVersionIndex(o.store),
+		Distributions:        lint.NewDistributionIndex(o.store, cat.CollectorVersion),
 		Rules:                o.resolved.Rules,
 		Severities:           o.resolved.Severities,
 		Environment:          o.envPolicy.Resolve,

--- a/pkg/cmd/otelcol-config-lint/run/run.go
+++ b/pkg/cmd/otelcol-config-lint/run/run.go
@@ -54,8 +54,9 @@ type options struct {
 
 	// flags
 	// Where the schemas come from, and which binary they describe.
-	distribution    string
-	schemaLocations []string
+	distribution           string
+	schemaLocations        []string
+	insecureSchemaLocation bool
 	// Which rules run, and at what level.
 	ruleDefault string
 	enable      []string
@@ -157,6 +158,8 @@ func (o *options) declareFlags(cmd *cobra.Command) {
 	flags.StringSliceVar(&o.schemaLocations, "schema-location", nil,
 		"where to find schemas: a directory, a {{.Version}} template, a URL, or \"default\";\n"+
 			"repeat to search several in order (default: the published registry)")
+	flags.BoolVar(&o.insecureSchemaLocation, "insecure-schema-location", false,
+		"allow a plain http:// schema location, for a registry served on localhost")
 	flags.StringVar(&o.ruleDefault, "default", "",
 		"rule set to start from: "+ruleset.DefaultAll+" (the default) or "+ruleset.DefaultNone)
 	flags.StringSliceVarP(&o.enable, "enable", "E", nil, "rules to turn on, on top of --default")
@@ -198,6 +201,7 @@ func (o *options) prepare(cmd *cobra.Command) error {
 	o.applySettings(file, fold)
 	fold.Str("distribution", &o.distribution, file.Run.Distribution)
 	fold.List("schema-location", &o.schemaLocations, file.Run.SchemaLocations)
+	fold.Bool("insecure-schema-location", &o.insecureSchemaLocation, file.Run.InsecureSchemaLocation)
 	fold.Str("memory-request", &o.memoryRequest, file.Run.Kubernetes.MemoryRequest)
 	fold.Str("memory-limit", &o.memoryLimit, file.Run.Kubernetes.MemoryLimit)
 
@@ -226,7 +230,20 @@ func (o *options) prepare(cmd *cobra.Command) error {
 		return err
 	}
 
-	o.store = schema.Store{Locations: o.schemaLocations, Distribution: o.distribution, Fs: o.FS()}
+	o.store = schema.Store{
+		Locations:     o.schemaLocations,
+		Distribution:  o.distribution,
+		AllowInsecure: o.insecureSchemaLocation,
+		Fs:            o.FS(),
+	}
+
+	// A location the store will refuse is a bad flag, so it is reported here
+	// with the rest of them rather than as a registry that served nothing.
+	err = o.store.Validate()
+	if err != nil {
+		return fmt.Errorf("--schema-location: %w; pass --insecure-schema-location"+
+			" to allow one served on localhost", err)
+	}
 
 	o.envPolicy, err = o.environmentPolicy()
 	if err != nil {
@@ -394,8 +411,8 @@ func (o *options) newLinter(cmd *cobra.Command) (*lint.Linter, error) {
 	return lint.New(lint.Options{
 		Schema:               cat,
 		Fs:                   o.FS(),
-		Availability:         lint.NewVersionIndex(o.store),
-		Distributions:        lint.NewDistributionIndex(o.store, cat.CollectorVersion),
+		Availability:         lint.NewVersionIndex(cmd.Context(), o.store),
+		Distributions:        lint.NewDistributionIndex(cmd.Context(), o.store, cat.CollectorVersion),
 		Rules:                o.resolved.Rules,
 		Severities:           o.resolved.Severities,
 		Environment:          o.envPolicy.Resolve,
@@ -409,7 +426,7 @@ func (o *options) newLinter(cmd *cobra.Command) (*lint.Linter, error) {
 // loadSchema resolves the targeted release, falling back to the newest
 // schema that is not newer than the request when there is no exact match.
 func (o *options) loadSchema(cmd *cobra.Command) (*schema.Schema, error) {
-	cat, err := o.store.Load(o.collectorVersion)
+	cat, err := o.store.Load(cmd.Context(), o.collectorVersion)
 	if err == nil {
 		return cat, nil
 	}
@@ -426,7 +443,7 @@ func (o *options) loadSchema(cmd *cobra.Command) (*schema.Schema, error) {
 
 	cmd.PrintErrf("otelcol-config-lint: no schema for %s, falling back to %s\n", unknown.Version, near)
 
-	cat, err = o.store.Load(near)
+	cat, err = o.store.Load(cmd.Context(), near)
 	if err != nil {
 		return nil, fmt.Errorf("load schema %s: %w", near, err)
 	}

--- a/pkg/lint/availability.go
+++ b/pkg/lint/availability.go
@@ -12,12 +12,6 @@ import (
 // consulting every schema a store can serve. It is built on first use, so runs
 // that never hit an unknown component pay nothing for it.
 type VersionIndex struct {
-	// ctx is the run's, so a build that reaches the network is cancelled with
-	// it. The index is built lazily, deep inside a rule that asked a question,
-	// so there is no call to carry it on instead.
-	//
-	//nolint:containedctx // the index is lazy; the context cannot arrive with the question
-	ctx   context.Context
 	store schema.Store
 
 	once  sync.Once
@@ -29,26 +23,30 @@ type versionKey struct {
 	typ  string
 }
 
-// NewVersionIndex returns an index over the schemas in store. It is built on
-// first use, under ctx, which is the run's.
-func NewVersionIndex(ctx context.Context, store schema.Store) *VersionIndex {
-	return &VersionIndex{ctx: ctx, store: store, once: sync.Once{}, byKey: nil}
+// NewVersionIndex returns an index over the schemas in store.
+func NewVersionIndex(store schema.Store) *VersionIndex {
+	return &VersionIndex{store: store, once: sync.Once{}, byKey: nil}
 }
 
 // Versions returns the schema versions containing the component, oldest first.
-func (v *VersionIndex) Versions(k config.Kind, typ string) []string {
-	v.once.Do(v.build)
+//
+// The context is the asking run's: the first question is what walks the store,
+// which for a remote registry means a fetch per release. It is built once, so
+// the first question's context is the one that build runs under; a later
+// question is answered from the map.
+func (v *VersionIndex) Versions(ctx context.Context, k config.Kind, typ string) []string {
+	v.once.Do(func() { v.build(ctx) })
 
 	return v.byKey[versionKey{k, typ}]
 }
 
-func (v *VersionIndex) build() {
+func (v *VersionIndex) build(ctx context.Context) {
 	v.byKey = map[versionKey][]string{}
-	versions := v.store.Versions(v.ctx)
+	versions := v.store.Versions(ctx)
 	// Store.Versions is newest first; walk backwards so results read oldest
 	// first, which is how a "added in ..." hint wants to be read.
 	for i := len(versions) - 1; i >= 0; i-- {
-		c, err := v.store.Load(v.ctx, versions[i])
+		c, err := v.store.Load(ctx, versions[i])
 		if err != nil {
 			continue
 		}

--- a/pkg/lint/availability.go
+++ b/pkg/lint/availability.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"context"
 	"sync"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
@@ -11,6 +12,12 @@ import (
 // consulting every schema a store can serve. It is built on first use, so runs
 // that never hit an unknown component pay nothing for it.
 type VersionIndex struct {
+	// ctx is the run's, so a build that reaches the network is cancelled with
+	// it. The index is built lazily, deep inside a rule that asked a question,
+	// so there is no call to carry it on instead.
+	//
+	//nolint:containedctx // the index is lazy; the context cannot arrive with the question
+	ctx   context.Context
 	store schema.Store
 
 	once  sync.Once
@@ -22,9 +29,10 @@ type versionKey struct {
 	typ  string
 }
 
-// NewVersionIndex returns an index over the schemas in store.
-func NewVersionIndex(store schema.Store) *VersionIndex {
-	return &VersionIndex{store: store, once: sync.Once{}, byKey: nil}
+// NewVersionIndex returns an index over the schemas in store. It is built on
+// first use, under ctx, which is the run's.
+func NewVersionIndex(ctx context.Context, store schema.Store) *VersionIndex {
+	return &VersionIndex{ctx: ctx, store: store, once: sync.Once{}, byKey: nil}
 }
 
 // Versions returns the schema versions containing the component, oldest first.
@@ -36,11 +44,11 @@ func (v *VersionIndex) Versions(k config.Kind, typ string) []string {
 
 func (v *VersionIndex) build() {
 	v.byKey = map[versionKey][]string{}
-	versions := v.store.Versions()
+	versions := v.store.Versions(v.ctx)
 	// Store.Versions is newest first; walk backwards so results read oldest
 	// first, which is how a "added in ..." hint wants to be read.
 	for i := len(versions) - 1; i >= 0; i-- {
-		c, err := v.store.Load(versions[i])
+		c, err := v.store.Load(v.ctx, versions[i])
 		if err != nil {
 			continue
 		}

--- a/pkg/lint/distributions.go
+++ b/pkg/lint/distributions.go
@@ -16,11 +16,6 @@ import (
 // Like VersionIndex it is built on first use, so a run that never meets an
 // unknown component pays nothing for it.
 type DistributionIndex struct {
-	// ctx is the run's, for the same reason VersionIndex holds one: the index
-	// is built inside the rule that asked, not at the call that made it.
-	//
-	//nolint:containedctx // the index is lazy; the context cannot arrive with the question
-	ctx     context.Context
 	store   schema.Store
 	version string
 
@@ -30,28 +25,31 @@ type DistributionIndex struct {
 
 // NewDistributionIndex returns an index over the sibling distributions store
 // can serve at the given collector release.
-func NewDistributionIndex(ctx context.Context, store schema.Store, version string) *DistributionIndex {
-	return &DistributionIndex{ctx: ctx, store: store, version: version, once: sync.Once{}, byKey: nil}
+func NewDistributionIndex(store schema.Store, version string) *DistributionIndex {
+	return &DistributionIndex{store: store, version: version, once: sync.Once{}, byKey: nil}
 }
 
 // Distributions returns the distributions shipping the component, sorted. The
 // one already being checked against is not among them: the caller knows it is
 // absent there, which is why it is asking.
-func (d *DistributionIndex) Distributions(k config.Kind, typ string) []string {
-	d.once.Do(d.build)
+//
+// The context is the asking run's, on the same terms as VersionIndex.Versions:
+// the first question is what reads the sibling distributions.
+func (d *DistributionIndex) Distributions(ctx context.Context, k config.Kind, typ string) []string {
+	d.once.Do(func() { d.build(ctx) })
 
 	return d.byKey[versionKey{k, typ}]
 }
 
-func (d *DistributionIndex) build() {
+func (d *DistributionIndex) build(ctx context.Context) {
 	d.byKey = map[versionKey][]string{}
 
-	for _, dist := range d.store.Distributions(d.ctx) {
+	for _, dist := range d.store.Distributions(ctx) {
 		if dist == d.store.Distribution {
 			continue
 		}
 
-		c, err := d.store.WithDistribution(dist).Load(d.ctx, d.version)
+		c, err := d.store.WithDistribution(dist).Load(ctx, d.version)
 		if err != nil {
 			continue
 		}

--- a/pkg/lint/distributions.go
+++ b/pkg/lint/distributions.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"context"
 	"sync"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
@@ -15,6 +16,11 @@ import (
 // Like VersionIndex it is built on first use, so a run that never meets an
 // unknown component pays nothing for it.
 type DistributionIndex struct {
+	// ctx is the run's, for the same reason VersionIndex holds one: the index
+	// is built inside the rule that asked, not at the call that made it.
+	//
+	//nolint:containedctx // the index is lazy; the context cannot arrive with the question
+	ctx     context.Context
 	store   schema.Store
 	version string
 
@@ -24,8 +30,8 @@ type DistributionIndex struct {
 
 // NewDistributionIndex returns an index over the sibling distributions store
 // can serve at the given collector release.
-func NewDistributionIndex(store schema.Store, version string) *DistributionIndex {
-	return &DistributionIndex{store: store, version: version, once: sync.Once{}, byKey: nil}
+func NewDistributionIndex(ctx context.Context, store schema.Store, version string) *DistributionIndex {
+	return &DistributionIndex{ctx: ctx, store: store, version: version, once: sync.Once{}, byKey: nil}
 }
 
 // Distributions returns the distributions shipping the component, sorted. The
@@ -40,12 +46,12 @@ func (d *DistributionIndex) Distributions(k config.Kind, typ string) []string {
 func (d *DistributionIndex) build() {
 	d.byKey = map[versionKey][]string{}
 
-	for _, dist := range d.store.Distributions() {
+	for _, dist := range d.store.Distributions(d.ctx) {
 		if dist == d.store.Distribution {
 			continue
 		}
 
-		c, err := d.store.WithDistribution(dist).Load(d.version)
+		c, err := d.store.WithDistribution(dist).Load(d.ctx, d.version)
 		if err != nil {
 			continue
 		}

--- a/pkg/lint/environment_test.go
+++ b/pkg/lint/environment_test.go
@@ -140,11 +140,11 @@ service:
 
 	l := newLinter(t, lint.Options{Environment: policy.Resolve})
 
-	if r := l.Lint("agent-node.yaml", []byte(src)); !fires(r, "memory-limiter-sizing") {
+	if r := l.Lint(t.Context(), "agent-node.yaml", []byte(src)); !fires(r, "memory-limiter-sizing") {
 		t.Errorf("the agent's limiter does not fit its container: %+v", r.Diagnostics)
 	}
 
-	if r := l.Lint("gateway.yaml", []byte(src)); fires(r, "memory-limiter-sizing") {
+	if r := l.Lint(t.Context(), "gateway.yaml", []byte(src)); fires(r, "memory-limiter-sizing") {
 		t.Errorf("the gateway has room for the same limiter: %+v", r.Diagnostics)
 	}
 }
@@ -153,7 +153,7 @@ func TestLinterWithoutAResolverKnowsNoEnvironment(t *testing.T) {
 	t.Parallel()
 
 	src := strings.Replace(good, "limit_mib: 512", "limit_mib: 4096", 1)
-	if r := newLinter(t, lint.Options{}).Lint("x.yaml", []byte(src)); fires(r, "memory-limiter-sizing") {
+	if r := newLinter(t, lint.Options{}).Lint(t.Context(), "x.yaml", []byte(src)); fires(r, "memory-limiter-sizing") {
 		t.Errorf("sizing needs an environment nobody gave: %+v", r.Diagnostics)
 	}
 }

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -2,6 +2,7 @@
 package lint
 
 import (
+	"context"
 	"errors"
 	"io"
 	"sync"
@@ -55,9 +56,9 @@ type Options struct {
 	// Fs is the filesystem LintFile reads from. A nil Fs means the real one.
 	Fs afero.Fs
 	// Availability lets diagnostics mention other releases. May be nil.
-	Availability rule.Availability
+	Availability Availability
 	// Distributions lets diagnostics mention other distributions. May be nil.
-	Distributions rule.Distributions
+	Distributions Distributions
 	// Rules is the set to run. A nil Rules means every registered rule, which
 	// is what a caller with no per-rule settings to apply wants; a caller that
 	// has some passes what rule.Configure returned.
@@ -80,6 +81,21 @@ type Options struct {
 	MinSeverity diag.Severity
 	// FailOn is the severity at which a file counts as invalid.
 	FailOn diag.Severity
+}
+
+// Availability reports which releases ship a component type. It is what
+// rule.Availability is bound from, and it takes a context because answering
+// can mean walking a remote registry: that fetch belongs to the run asking the
+// question, not to whoever built the index. VersionIndex implements it.
+type Availability interface {
+	Versions(ctx context.Context, k config.Kind, typ string) []string
+}
+
+// Distributions reports which distributions of the targeted release ship a
+// component type, on the same terms as Availability. DistributionIndex
+// implements it.
+type Distributions interface {
+	Distributions(ctx context.Context, k config.Kind, typ string) []string
 }
 
 // Linter checks config files against a rule set.
@@ -132,27 +148,29 @@ func (l *Linter) SeverityFor(r rule.Rule) diag.Severity {
 }
 
 // LintFile reads and checks a single config file.
-func (l *Linter) LintFile(path string) Result {
+func (l *Linter) LintFile(ctx context.Context, path string) Result {
 	src, err := afero.ReadFile(l.fs(), path)
 	if err != nil {
 		return Result{Path: path, Status: Error, Err: err}
 	}
 
-	return l.Lint(path, src)
+	return l.Lint(ctx, path, src)
 }
 
 // LintReader checks config read from r, reporting it under name.
-func (l *Linter) LintReader(name string, r io.Reader) Result {
+func (l *Linter) LintReader(ctx context.Context, name string, r io.Reader) Result {
 	src, err := io.ReadAll(r)
 	if err != nil {
 		return Result{Path: name, Status: Error, Err: err}
 	}
 
-	return l.Lint(name, src)
+	return l.Lint(ctx, name, src)
 }
 
-// Lint checks config source that was read from path.
-func (l *Linter) Lint(path string, src []byte) Result {
+// Lint checks config source that was read from path. The context is what the
+// schema lookups a rule may make run under, so a run that is cancelled does
+// not leave one waiting on a registry.
+func (l *Linter) Lint(ctx context.Context, path string, src []byte) Result {
 	f, err := config.Parse(path, src)
 	if err != nil {
 		var syn *config.SyntaxError
@@ -167,20 +185,35 @@ func (l *Linter) Lint(path string, src []byte) Result {
 		return Result{Path: path, Status: Error, Err: err}
 	}
 
-	ctx := rule.Context{
+	ruleCtx := rule.Context{
 		File:   f,
 		Schema: l.opts.Schema,
 		Index:  rule.NewIndex(f),
-		Avail:  l.opts.Availability,
-		Dists:  l.opts.Distributions,
+		Avail:  nil,
+		Dists:  nil,
 		Strict: l.opts.Strict,
 		Env:    l.environment(path),
+	}
+
+	// The context is bound here rather than held by whatever answers. An index
+	// is a cache with no run of its own, so the run a lookup belongs to is the
+	// one asking, and the rule asks without knowing a context was involved.
+	if l.opts.Availability != nil {
+		ruleCtx.Avail = rule.AvailabilityFunc(func(k config.Kind, typ string) []string {
+			return l.opts.Availability.Versions(ctx, k, typ)
+		})
+	}
+
+	if l.opts.Distributions != nil {
+		ruleCtx.Dists = rule.DistributionsFunc(func(k config.Kind, typ string) []string {
+			return l.opts.Distributions.Distributions(ctx, k, typ)
+		})
 	}
 
 	var found diag.Diagnostics
 
 	for _, r := range l.rules {
-		for _, d := range rule.Run(r, ctx, l.SeverityFor(r)) {
+		for _, d := range rule.Run(r, ruleCtx, l.SeverityFor(r)) {
 			if d.Severity.AtLeast(l.opts.MinSeverity) {
 				found = append(found, d)
 			}
@@ -203,7 +236,7 @@ func (l *Linter) Lint(path string, src []byte) Result {
 
 // LintAll checks paths concurrently with up to n workers, sending results in
 // completion order. It closes the returned channel when every path is done.
-func (l *Linter) LintAll(paths []string, n int) <-chan Result {
+func (l *Linter) LintAll(ctx context.Context, paths []string, n int) <-chan Result {
 	if n < 1 {
 		n = 1
 	}
@@ -216,7 +249,7 @@ func (l *Linter) LintAll(paths []string, n int) <-chan Result {
 	for range n {
 		workers.Go(func() {
 			for p := range in {
-				out <- l.LintFile(p)
+				out <- l.LintFile(ctx, p)
 			}
 		})
 	}

--- a/pkg/lint/linter_test.go
+++ b/pkg/lint/linter_test.go
@@ -2,6 +2,7 @@ package lint_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/spf13/afero"
 
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/lint"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
@@ -72,15 +74,15 @@ func TestStatuses(t *testing.T) {
 
 	l := newLinter(t, lint.Options{MinSeverity: diag.Error})
 
-	if r := l.Lint("good.yaml", []byte(good)); r.Status != lint.Valid {
+	if r := l.Lint(t.Context(), "good.yaml", []byte(good)); r.Status != lint.Valid {
 		t.Errorf("want valid, got %s: %+v", r.Status, r.Diagnostics)
 	}
 
-	if r := l.Lint("bad.yaml", []byte(bad)); r.Status != lint.Invalid {
+	if r := l.Lint(t.Context(), "bad.yaml", []byte(bad)); r.Status != lint.Invalid {
 		t.Errorf("want invalid, got %s", r.Status)
 	}
 
-	if r := l.LintFile(filepath.Join(t.TempDir(), "nope.yaml")); r.Status != lint.Error {
+	if r := l.LintFile(t.Context(), filepath.Join(t.TempDir(), "nope.yaml")); r.Status != lint.Error {
 		t.Errorf("a missing file should be an error, got %s", r.Status)
 	}
 }
@@ -90,7 +92,7 @@ func TestSyntaxErrorIsADiagnosticNotAFailure(t *testing.T) {
 
 	l := newLinter(t, lint.Options{})
 
-	r := l.Lint("broken.yaml", []byte("receivers:\n  otlp: [1, 2\n"))
+	r := l.Lint(t.Context(), "broken.yaml", []byte("receivers:\n  otlp: [1, 2\n"))
 	if r.Status != lint.Invalid {
 		t.Fatalf("want invalid, got %s", r.Status)
 	}
@@ -103,9 +105,9 @@ func TestSyntaxErrorIsADiagnosticNotAFailure(t *testing.T) {
 func TestMinSeverityFilters(t *testing.T) {
 	t.Parallel()
 
-	all := newLinter(t, lint.Options{MinSeverity: diag.Info}).Lint("x.yaml", []byte(bad))
+	all := newLinter(t, lint.Options{MinSeverity: diag.Info}).Lint(t.Context(), "x.yaml", []byte(bad))
 
-	errsOnly := newLinter(t, lint.Options{MinSeverity: diag.Error}).Lint("x.yaml", []byte(bad))
+	errsOnly := newLinter(t, lint.Options{MinSeverity: diag.Error}).Lint(t.Context(), "x.yaml", []byte(bad))
 	if len(errsOnly.Diagnostics) >= len(all.Diagnostics) {
 		t.Errorf("filtering did nothing: %d vs %d", len(errsOnly.Diagnostics), len(all.Diagnostics))
 	}
@@ -122,11 +124,12 @@ func TestFailOnRaisesTheGate(t *testing.T) {
 
 	// A config whose only problem is an unused component: warnings only.
 	src := good + "extensions:\n  zpages:\n"
-	if r := newLinter(t, lint.Options{}).Lint("x.yaml", []byte(src)); r.Status != lint.Valid {
+	if r := newLinter(t, lint.Options{}).Lint(t.Context(), "x.yaml", []byte(src)); r.Status != lint.Valid {
 		t.Errorf("warnings should not fail by default: %+v", r.Diagnostics)
 	}
 
-	if r := newLinter(t, lint.Options{FailOn: diag.Warning}).Lint("x.yaml", []byte(src)); r.Status != lint.Invalid {
+	strictly := newLinter(t, lint.Options{FailOn: diag.Warning})
+	if r := strictly.Lint(t.Context(), "x.yaml", []byte(src)); r.Status != lint.Invalid {
 		t.Error("-fail-on warning should fail")
 	}
 }
@@ -135,7 +138,7 @@ func TestDisabledRule(t *testing.T) {
 	t.Parallel()
 
 	l := newLinter(t, lint.Options{Severities: map[string]diag.Severity{"empty-pipeline": diag.Off}})
-	for _, d := range l.Lint("x.yaml", []byte(bad)).Diagnostics {
+	for _, d := range l.Lint(t.Context(), "x.yaml", []byte(bad)).Diagnostics {
 		if d.Rule == "empty-pipeline" {
 			t.Fatal("a disabled rule reported anyway")
 		}
@@ -148,11 +151,11 @@ func TestIgnoreMissingSchemasSilencesUnknownComponents(t *testing.T) {
 	src := strings.Replace(good, "  otlp:\n    protocols:\n      grpc:", "  mycorp_custom:", 1)
 	src = strings.Replace(src, "receivers: [otlp]", "receivers: [mycorp_custom]", 1)
 
-	if r := newLinter(t, lint.Options{}).Lint("x.yaml", []byte(src)); r.Status != lint.Invalid {
+	if r := newLinter(t, lint.Options{}).Lint(t.Context(), "x.yaml", []byte(src)); r.Status != lint.Invalid {
 		t.Error("an unknown component should fail by default")
 	}
 
-	r := newLinter(t, lint.Options{IgnoreMissingSchemas: true}).Lint("x.yaml", []byte(src))
+	r := newLinter(t, lint.Options{IgnoreMissingSchemas: true}).Lint(t.Context(), "x.yaml", []byte(src))
 	if r.Status != lint.Valid {
 		t.Errorf("want valid, got %s: %+v", r.Status, r.Diagnostics)
 	}
@@ -178,7 +181,7 @@ func TestLintAllVisitsEveryFile(t *testing.T) {
 	}
 
 	seen := map[string]bool{}
-	for r := range newLinter(t, lint.Options{}).LintAll(paths, 3) {
+	for r := range newLinter(t, lint.Options{}).LintAll(t.Context(), paths, 3) {
 		seen[r.Path] = true
 	}
 
@@ -201,11 +204,11 @@ func TestLintFileReadsTheGivenFs(t *testing.T) {
 
 	l := newLinter(t, lint.Options{Fs: fsys, MinSeverity: diag.Error})
 
-	if r := l.LintFile("/configs/agent.yaml"); r.Status != lint.Valid {
+	if r := l.LintFile(t.Context(), "/configs/agent.yaml"); r.Status != lint.Valid {
 		t.Errorf("want valid, got %s: %v %+v", r.Status, r.Err, r.Diagnostics)
 	}
 
-	if r := l.LintFile("/configs/absent.yaml"); r.Status != lint.Error {
+	if r := l.LintFile(t.Context(), "/configs/absent.yaml"); r.Status != lint.Error {
 		t.Errorf("a missing file should be an error, got %s", r.Status)
 	}
 }
@@ -216,8 +219,8 @@ func TestSummary(t *testing.T) {
 	l := newLinter(t, lint.Options{})
 
 	var s lint.Summary
-	s.Add(l.Lint("good.yaml", []byte(good)))
-	s.Add(l.Lint("bad.yaml", []byte(bad)))
+	s.Add(l.Lint(t.Context(), "good.yaml", []byte(good)))
+	s.Add(l.Lint(t.Context(), "bad.yaml", []byte(bad)))
 
 	if s.Valid != 1 || s.Invalid != 1 {
 		t.Errorf("unexpected summary: %+v", s)
@@ -232,7 +235,7 @@ func TestFormatters(t *testing.T) {
 	t.Parallel()
 
 	l := newLinter(t, lint.Options{})
-	result := l.Lint("bad.yaml", []byte(bad))
+	result := l.Lint(t.Context(), "bad.yaml", []byte(bad))
 
 	for _, name := range []string{"text", "json", "junit", "tap", "github"} {
 		var buf bytes.Buffer
@@ -296,12 +299,54 @@ func TestTextFormatterQuietOnSuccess(t *testing.T) {
 	}
 }
 
+// runKey marks a context as belonging to one run, which is what the recorder
+// below reads back out of the question it is asked.
+type runKey struct{}
+
+// askedWith records which run's context a rule's schema question arrived on.
+type askedWith struct {
+	asked bool
+	run   string
+}
+
+func (a *askedWith) Versions(ctx context.Context, _ config.Kind, _ string) []string {
+	a.asked = true
+	a.run, _ = ctx.Value(runKey{}).(string)
+
+	return nil
+}
+
+// TestTheRunsContextReachesARulesSchemaQuestion pins where the context lives.
+// The index behind Availability is a cache with no run of its own, so the
+// context comes from the call being served, not from the index: linting under
+// one is what decides which run a lookup belongs to, and cancelling that run is
+// what ends a fetch it started.
+func TestTheRunsContextReachesARulesSchemaQuestion(t *testing.T) {
+	t.Parallel()
+
+	src := strings.Replace(good, "  otlp:\n    protocols:\n      grpc:", "  mycorp_custom:", 1)
+	src = strings.Replace(src, "receivers: [otlp]", "receivers: [mycorp_custom]", 1)
+
+	avail := &askedWith{asked: false, run: ""}
+	ctx := context.WithValue(t.Context(), runKey{}, "this run")
+
+	newLinter(t, lint.Options{Availability: avail}).Lint(ctx, "x.yaml", []byte(src))
+
+	if !avail.asked {
+		t.Fatal("an unknown component should have asked which releases ship it")
+	}
+
+	if avail.run != "this run" {
+		t.Errorf("the question should arrive on the linting call's context, got %q", avail.run)
+	}
+}
+
 func TestVersionIndexFindsRemovedComponents(t *testing.T) {
 	t.Parallel()
 
-	idx := lint.NewVersionIndex(t.Context(), repoStore())
+	idx := lint.NewVersionIndex(repoStore())
 
-	versions := idx.Versions("exporter", "logging")
+	versions := idx.Versions(t.Context(), "exporter", "logging")
 	if len(versions) == 0 {
 		t.Fatal("the logging exporter should exist in some published release")
 	}
@@ -312,7 +357,7 @@ func TestVersionIndexFindsRemovedComponents(t *testing.T) {
 		}
 	}
 
-	if len(idx.Versions("exporter", "definitely_not_a_component")) != 0 {
+	if len(idx.Versions(t.Context(), "exporter", "definitely_not_a_component")) != 0 {
 		t.Error("an unknown component should have no versions")
 	}
 }
@@ -327,7 +372,7 @@ func TestAMissingCheckIntervalIsReportedOnce(t *testing.T) {
 
 	var about []string
 
-	for _, d := range newLinter(t, lint.Options{}).Lint("x.yaml", []byte(src)).Diagnostics {
+	for _, d := range newLinter(t, lint.Options{}).Lint(t.Context(), "x.yaml", []byte(src)).Diagnostics {
 		if strings.Contains(d.Message, "check_interval") {
 			about = append(about, d.Rule)
 		}
@@ -346,7 +391,7 @@ func TestFormattersCarryTheDocumentationLink(t *testing.T) {
 	// A memory_limiter that is present and empty: the collector refuses to
 	// start, and upstream's README is what says so.
 	src := strings.Replace(good, "    check_interval: 1s\n    limit_mib: 512\n    spike_limit_mib: 128\n", "", 1)
-	result := newLinter(t, lint.Options{}).Lint("x.yaml", []byte(src))
+	result := newLinter(t, lint.Options{}).Lint(t.Context(), "x.yaml", []byte(src))
 
 	const docs = "processor/memorylimiterprocessor/README.md"
 

--- a/pkg/lint/linter_test.go
+++ b/pkg/lint/linter_test.go
@@ -56,7 +56,7 @@ func newLinter(t *testing.T, opts lint.Options) *lint.Linter {
 	t.Helper()
 
 	if opts.Schema == nil {
-		cat, err := repoStore().Load(schema.Latest)
+		cat, err := repoStore().Load(t.Context(), schema.Latest)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -299,7 +299,7 @@ func TestTextFormatterQuietOnSuccess(t *testing.T) {
 func TestVersionIndexFindsRemovedComponents(t *testing.T) {
 	t.Parallel()
 
-	idx := lint.NewVersionIndex(repoStore())
+	idx := lint.NewVersionIndex(t.Context(), repoStore())
 
 	versions := idx.Versions("exporter", "logging")
 	if len(versions) == 0 {

--- a/pkg/lint/linter_test.go
+++ b/pkg/lint/linter_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
@@ -332,13 +334,8 @@ func TestTheRunsContextReachesARulesSchemaQuestion(t *testing.T) {
 
 	newLinter(t, lint.Options{Availability: avail}).Lint(ctx, "x.yaml", []byte(src))
 
-	if !avail.asked {
-		t.Fatal("an unknown component should have asked which releases ship it")
-	}
-
-	if avail.run != "this run" {
-		t.Errorf("the question should arrive on the linting call's context, got %q", avail.run)
-	}
+	require.True(t, avail.asked, "an unknown component should have asked which releases ship it")
+	assert.Equal(t, "this run", avail.run, "the question should arrive on the linting call's context")
 }
 
 func TestVersionIndexFindsRemovedComponents(t *testing.T) {

--- a/pkg/rule/schema.go
+++ b/pkg/rule/schema.go
@@ -13,6 +13,14 @@ type Availability interface {
 	Versions(k config.Kind, typ string) []string
 }
 
+// AvailabilityFunc adapts a function to Availability. It is how a caller binds
+// what the interface deliberately does not carry -- the context of the run
+// asking, say -- without a rule having to know that anything was bound.
+type AvailabilityFunc func(k config.Kind, typ string) []string
+
+// Versions returns the schema versions containing the component, oldest first.
+func (f AvailabilityFunc) Versions(k config.Kind, typ string) []string { return f(k, typ) }
+
 // Distributions reports which distributions of the targeted release ship a
 // component type. A schema describes one distribution, so this is what lets a
 // rule say where a component the running binary lacks does ship.
@@ -21,6 +29,13 @@ type Distributions interface {
 	// sorted, excluding the one being checked against.
 	Distributions(k config.Kind, typ string) []string
 }
+
+// DistributionsFunc adapts a function to Distributions, as AvailabilityFunc
+// does to Availability.
+type DistributionsFunc func(k config.Kind, typ string) []string
+
+// Distributions returns the distributions containing the component, sorted.
+func (f DistributionsFunc) Distributions(k config.Kind, typ string) []string { return f(k, typ) }
 
 // SchemaReady reports whether a schema with components was resolved. Rules
 // that consult the schema stay silent otherwise rather than reporting every

--- a/pkg/schema/store.go
+++ b/pkg/schema/store.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/afero"
@@ -56,15 +58,35 @@ const DistributionPlaceholder = "{{.Distribution}}"
 // supplied its own client.
 const defaultFetchTimeout = 30 * time.Second
 
+// maxRemoteBytes bounds what one remote schema or index may deliver, and
+// maxRemoteMiB is the same number as the error reports it. A location is
+// whatever the caller named, and a decoder materialises everything it is
+// handed, so the ceiling is the linter's rather than the endpoint's. The
+// largest published schema is a few megabytes; this leaves room for a registry
+// an order of magnitude richer and still bounds what a hostile or merely
+// broken one can claim.
+const (
+	maxRemoteMiB   = 32
+	maxRemoteBytes = maxRemoteMiB << 20
+)
+
+// insecureScheme is the transport a schema location may not use unless the
+// caller opted in.
+const insecureScheme = "http://"
+
+// secureScheme is the transport a remote schema location is expected to use.
+const secureScheme = "https://"
+
 // Store resolves collector versions to schemas. The zero value reads the
-// official registry over HTTP.
+// official registry over HTTPS.
 //
 // A location is one of:
 //
 //   - "default", the official registry;
 //   - a directory, searched for "<version>.json";
 //   - a template containing {{.Version}}, resolved as a local path or, when it
-//     starts with http:// or https://, fetched over HTTP.
+//     starts with https://, fetched over the network. A plain http:// location
+//     is refused unless AllowInsecure says otherwise.
 //
 // Locations are consulted in order, so a project can keep its own schema
 // directory ahead of the built-ins. When no location is given, only the
@@ -74,9 +96,14 @@ type Store struct {
 	// Distribution selects which collector binary to describe. An empty value
 	// means DefaultDistribution.
 	Distribution string
-	// HTTPClient fetches remote locations. A nil client uses a default with a
-	// 30 second timeout.
+	// HTTPClient fetches remote locations. A nil client uses a shared default
+	// with a 30 second timeout.
 	HTTPClient *http.Client
+	// AllowInsecure permits a plain http:// location. It is off by default: a
+	// schema decides which components exist and which settings are valid, so
+	// anyone able to rewrite one in flight decides what the rules report. Turn
+	// it on for a registry served over loopback, where there is no flight.
+	AllowInsecure bool
 	// Fs is the filesystem local locations are read from. A nil Fs means the
 	// real one. Remote locations go over HTTPClient and ignore it.
 	Fs afero.Fs
@@ -85,13 +112,13 @@ type Store struct {
 // Versions lists every schema the store can serve, newest first. Templated and
 // remote locations cannot be enumerated, so they never appear here even though
 // Load can still resolve them.
-func (s Store) Versions() []string {
+func (s Store) Versions(ctx context.Context) []string {
 	seen := map[string]bool{}
 
 	var out []string
 
 	for _, loc := range s.locations() {
-		for _, v := range s.versionsAt(loc) {
+		for _, v := range s.versionsAt(ctx, loc) {
 			if v != "" && !seen[v] {
 				seen[v] = true
 				out = append(out, v)
@@ -106,9 +133,9 @@ func (s Store) Versions() []string {
 
 // Distributions lists the distributions the store can serve, sorted. Only a
 // registry says what it carries, so other location kinds report none.
-func (s Store) Distributions() []string {
+func (s Store) Distributions(ctx context.Context) []string {
 	for _, loc := range s.locations() {
-		idx := s.indexAt(loc)
+		idx := s.indexAt(ctx, loc)
 		if idx != nil {
 			return idx.Names()
 		}
@@ -126,9 +153,14 @@ func (s Store) WithDistribution(distribution string) Store {
 
 // Load returns the schema for a collector version. The special value "latest"
 // (or an empty string) selects the newest schema the store can enumerate.
-func (s Store) Load(version string) (*Schema, error) {
+func (s Store) Load(ctx context.Context, version string) (*Schema, error) {
+	err := s.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	if version == "" || version == Latest {
-		versions := s.Versions()
+		versions := s.Versions(ctx)
 		if len(versions) == 0 {
 			return nil, fmt.Errorf("%w in %s", errNoSchemas, strings.Join(s.locations(), ", "))
 		}
@@ -141,7 +173,7 @@ func (s Store) Load(version string) (*Schema, error) {
 	var tried []string
 
 	for _, loc := range s.locations() {
-		c, err := s.loadFrom(loc, version)
+		c, err := s.loadFrom(ctx, loc, version)
 		switch {
 		case err == nil:
 			return c, nil
@@ -152,7 +184,25 @@ func (s Store) Load(version string) (*Schema, error) {
 		}
 	}
 
-	return nil, &UnknownVersionError{Version: version, Available: s.Versions(), Tried: tried}
+	return nil, &UnknownVersionError{Version: version, Available: s.Versions(ctx), Tried: tried}
+}
+
+// Validate reports the first location the store will refuse, so a command can
+// say so while it is still reading its flags rather than at the first fetch.
+// A location that is merely unreachable is not one of them: whether a registry
+// answers is only known by asking it.
+func (s Store) Validate() error {
+	if s.AllowInsecure {
+		return nil
+	}
+
+	for _, loc := range s.locations() {
+		if isInsecure(loc) {
+			return fmt.Errorf("%w: %s", errInsecureLocation, loc)
+		}
+	}
+
+	return nil
 }
 
 // fs returns the filesystem to read local locations from, which is the real one
@@ -175,10 +225,10 @@ func (s Store) distribution() string {
 }
 
 // indexAt reads a location's index, or nil when it has none.
-func (s Store) indexAt(loc string) *Index {
+func (s Store) indexAt(ctx context.Context, loc string) *Index {
 	switch kindOf(loc) {
 	case locRemote:
-		idx, err := s.fetchIndex(loc)
+		idx, err := s.fetchIndex(ctx, loc)
 		if err != nil {
 			return nil
 		}
@@ -198,10 +248,10 @@ func (s Store) indexAt(loc string) *Index {
 
 // versionsAt lists the versions one location can serve. A template names a
 // single file and cannot be listed, so it contributes nothing.
-func (s Store) versionsAt(loc string) []string {
+func (s Store) versionsAt(ctx context.Context, loc string) []string {
 	switch kindOf(loc) {
 	case locRemote:
-		idx, err := s.fetchIndex(loc)
+		idx, err := s.fetchIndex(ctx, loc)
 		if err != nil {
 			return nil
 		}
@@ -281,14 +331,22 @@ var (
 	errNoSchemas = errors.New("no schemas available")
 	// errBadStatus signals a remote location answering with an unusable status.
 	errBadStatus = errors.New("unexpected status")
+	// errTooLarge signals a remote location serving more than maxRemoteBytes.
+	errTooLarge = fmt.Errorf("schema is larger than the %d MiB limit", maxRemoteMiB)
+	// errInsecureLocation signals a plain http:// location without the opt-in
+	// that permits one.
+	errInsecureLocation = errors.New("refusing to fetch a schema over plain http, " +
+		"which anyone on the path can rewrite")
 )
 
-func (s Store) loadFrom(loc, version string) (*Schema, error) {
+func (s Store) loadFrom(ctx context.Context, loc, version string) (*Schema, error) {
 	switch kindOf(loc) {
 	case locRemote:
-		return s.loadFromRegistry(loc, version, s.fetch)
+		return s.loadFromRegistry(loc, version, func(target string) (*Schema, error) {
+			return s.fetch(ctx, target)
+		})
 	case locTemplate, locFile:
-		return s.loadOne(s.resolve(loc, version))
+		return s.loadOne(ctx, s.resolve(loc, version))
 	default:
 		// A directory holding an index is a registry root, laid out by
 		// distribution. Without one it is the flat legacy layout.
@@ -301,9 +359,9 @@ func (s Store) loadFrom(loc, version string) (*Schema, error) {
 }
 
 // loadOne reads a location that names a single schema, local or remote.
-func (s Store) loadOne(target string) (*Schema, error) {
+func (s Store) loadOne(ctx context.Context, target string) (*Schema, error) {
 	if isRemote(target) {
-		return s.fetch(target)
+		return s.fetch(ctx, target)
 	}
 
 	return s.readLocal(target)
@@ -353,15 +411,13 @@ func (s Store) readLocal(path string) (*Schema, error) {
 }
 
 // fetchIndex reads a remote registry's index.
-func (s Store) fetchIndex(root string) (*Index, error) {
-	body, err := s.get(join(root, IndexFile))
+func (s Store) fetchIndex(ctx context.Context, root string) (*Index, error) {
+	body, err := s.get(ctx, join(root, IndexFile))
 	if err != nil {
 		return nil, err
 	}
 
-	defer func() { _ = body.Close() }()
-
-	return ReadIndex(body)
+	return ReadIndex(bytes.NewReader(body))
 }
 
 // join appends path segments to a registry root, which is a URL or a local
@@ -372,59 +428,91 @@ func join(root string, segments ...string) string {
 }
 
 func isRemote(loc string) bool {
-	return strings.HasPrefix(loc, "http://") || strings.HasPrefix(loc, "https://")
+	return strings.HasPrefix(loc, insecureScheme) || strings.HasPrefix(loc, secureScheme)
 }
 
-// fetch reads a schema over HTTP. Loading is synchronous and the client
-// already carries a timeout, so the request runs on a background context.
-func (s Store) fetch(url string) (*Schema, error) {
-	body, err := s.get(url)
+// isInsecure reports a location fetched over a transport that anyone on the
+// path can rewrite.
+func isInsecure(loc string) bool {
+	return strings.HasPrefix(loc, insecureScheme)
+}
+
+// fetch reads a schema over the network.
+func (s Store) fetch(ctx context.Context, url string) (*Schema, error) {
+	body, err := s.get(ctx, url)
 	if err != nil {
 		return nil, err
 	}
 
-	defer func() { _ = body.Close() }()
-
-	return Read(body)
+	return Read(bytes.NewReader(body))
 }
 
-// get performs the request behind fetch and fetchIndex. The caller closes the
-// body. Loading is synchronous and the client already carries a timeout, so the
-// request runs on a background context.
-func (s Store) get(url string) (io.ReadCloser, error) {
-	client := s.HTTPClient
-	if client == nil {
-		client = &http.Client{
-			Timeout:       defaultFetchTimeout,
-			Transport:     nil,
-			CheckRedirect: nil,
-			Jar:           nil,
-		}
+// get performs the request behind fetch and fetchIndex, and returns what the
+// endpoint served. The body is read here rather than handed to a decoder so
+// that maxRemoteBytes is enforced in one place, and so that a location serving
+// too much is reported as exactly that instead of as a parse failure part-way
+// through a truncated document.
+func (s Store) get(ctx context.Context, url string) ([]byte, error) {
+	if !s.AllowInsecure && isInsecure(url) {
+		return nil, fmt.Errorf("%w: %s", errInsecureLocation, url)
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("build request for %s: %w", url, err)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := s.client().Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", url, err)
 	}
 
+	defer func() { _ = resp.Body.Close() }()
+
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return resp.Body, nil
+		return readBody(url, resp.Body)
 	case http.StatusNotFound:
-		_ = resp.Body.Close()
-
 		return nil, errNotFound
 	default:
-		_ = resp.Body.Close()
-
 		return nil, fmt.Errorf("GET %s: %w %s", url, errBadStatus, resp.Status)
 	}
 }
+
+// readBody reads a response under maxRemoteBytes. One byte past the limit is
+// asked for, so a body sitting exactly on it is still served and anything
+// longer is refused rather than silently cut short.
+func readBody(url string, body io.Reader) ([]byte, error) {
+	buf, err := io.ReadAll(io.LimitReader(body, maxRemoteBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", url, err)
+	}
+
+	if len(buf) > maxRemoteBytes {
+		return nil, fmt.Errorf("read %s: %w", url, errTooLarge)
+	}
+
+	return buf, nil
+}
+
+// client is what the store fetches with.
+func (s Store) client() *http.Client {
+	if s.HTTPClient != nil {
+		return s.HTTPClient
+	}
+
+	return defaultClient()
+}
+
+// defaultClient is what a store with no client of its own fetches with. It is
+// built once and shared: a client owns a connection pool, so one per request
+// means a connection per request, and building the version index walks every
+// release a registry carries.
+//
+//nolint:gochecknoglobals // one client is the point: a package-level one is what makes the pool shared
+var defaultClient = sync.OnceValue(func() *http.Client {
+	return &http.Client{Timeout: defaultFetchTimeout}
+})
 
 type locKind int
 

--- a/pkg/schema/store_internal_test.go
+++ b/pkg/schema/store_internal_test.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestStoresShareOneDefaultClient pins that a store without a client of its own
@@ -15,16 +17,9 @@ func TestStoresShareOneDefaultClient(t *testing.T) {
 
 	first, second := Store{}, Store{Distribution: "core"}
 
-	if first.client() != second.client() {
-		t.Error("stores with no client of their own should share the default one")
-	}
-
-	if first.client().Timeout != defaultFetchTimeout {
-		t.Errorf("the default client should carry the fetch timeout, got %v", first.client().Timeout)
-	}
+	assert.Same(t, first.client(), second.client(), "stores with no client of their own should share one")
+	assert.Equal(t, defaultFetchTimeout, first.client().Timeout, "the shared client should carry the fetch timeout")
 
 	own := Store{HTTPClient: &http.Client{}}
-	if own.client() == defaultClient() {
-		t.Error("a store with a client of its own should fetch with it")
-	}
+	assert.NotSame(t, defaultClient(), own.client(), "a store with a client of its own should fetch with it")
 }

--- a/pkg/schema/store_internal_test.go
+++ b/pkg/schema/store_internal_test.go
@@ -1,0 +1,30 @@
+package schema
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestStoresShareOneDefaultClient pins that a store without a client of its own
+// does not build one per call. A client owns a connection pool, so a fresh one
+// per request is a fresh connection per request, and building the version index
+// fetches one schema per release a registry carries. It is written inside the
+// package because that client is unexported, which is what lets it be shared.
+func TestStoresShareOneDefaultClient(t *testing.T) {
+	t.Parallel()
+
+	first, second := Store{}, Store{Distribution: "core"}
+
+	if first.client() != second.client() {
+		t.Error("stores with no client of their own should share the default one")
+	}
+
+	if first.client().Timeout != defaultFetchTimeout {
+		t.Errorf("the default client should carry the fetch timeout, got %v", first.client().Timeout)
+	}
+
+	own := Store{HTTPClient: &http.Client{}}
+	if own.client() == defaultClient() {
+		t.Error("a store with a client of its own should fetch with it")
+	}
+}

--- a/pkg/schema/store_test.go
+++ b/pkg/schema/store_test.go
@@ -1,7 +1,9 @@
 package schema_test
 
 import (
+	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -69,7 +71,7 @@ func TestTheRepositoryRegistryLoads(t *testing.T) {
 
 	store := schema.Store{Locations: []string{repoSchemas}}
 
-	versions := store.Versions()
+	versions := store.Versions(t.Context())
 	if len(versions) == 0 {
 		t.Fatal("the registry lists no schemas")
 	}
@@ -80,7 +82,7 @@ func TestTheRepositoryRegistryLoads(t *testing.T) {
 		}
 	}
 
-	latest, err := store.Load(schema.Latest)
+	latest, err := store.Load(t.Context(), schema.Latest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +105,7 @@ func TestUnknownVersionSuggestsTheNearestOlder(t *testing.T) {
 
 	store := schema.Store{Locations: []string{repoSchemas}}
 
-	_, err := store.Load("v0.115.0")
+	_, err := store.Load(t.Context(), "v0.115.0")
 	if err == nil {
 		t.Fatal("want an error for a version with no schema")
 	}
@@ -132,7 +134,7 @@ func TestDirectoryLocationWinsOverEmbedded(t *testing.T) {
 
 	store := schema.Store{Locations: []string{dir, repoSchemas}}
 
-	cat, err := store.Load("v0.157.0")
+	cat, err := store.Load(t.Context(), "v0.157.0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +144,7 @@ func TestDirectoryLocationWinsOverEmbedded(t *testing.T) {
 	}
 
 	// Versions not present locally still fall through to the next location.
-	_, err = store.Load("v0.110.0")
+	_, err = store.Load(t.Context(), "v0.110.0")
 	if err != nil {
 		t.Errorf("fallthrough to the registry failed: %v", err)
 	}
@@ -157,7 +159,7 @@ func TestTemplateLocation(t *testing.T) {
 
 	store := schema.Store{Locations: []string{filepath.Join(dir, "otel-{{.Version}}.json")}}
 
-	cat, err := store.Load("v0.150.0")
+	cat, err := store.Load(t.Context(), "v0.150.0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,14 +183,14 @@ func TestRemoteLocation(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := schema.Store{Locations: []string{srv.URL + "/{{.Version}}.json"}}
+	store := schema.Store{Locations: []string{srv.URL + "/{{.Version}}.json"}, AllowInsecure: true}
 
-	_, err := store.Load("v0.140.0")
+	_, err := store.Load(t.Context(), "v0.140.0")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = store.Load("v0.130.0")
+	_, err = store.Load(t.Context(), "v0.130.0")
 	if err == nil {
 		t.Error("a 404 should not resolve")
 	}
@@ -247,7 +249,7 @@ func TestRegistryDirectorySelectsTheDistribution(t *testing.T) {
 	for dist, want := range map[string]int{"": 2, distCore: 1, distContrib: 2} {
 		store := schema.Store{Locations: []string{root}, Distribution: dist}
 
-		cat, err := store.Load("v0.157.0")
+		cat, err := store.Load(t.Context(), "v0.157.0")
 		if err != nil {
 			t.Fatalf("distribution %q: %v", dist, err)
 		}
@@ -272,7 +274,7 @@ func TestRegistryDirectoryEnumeratesFromTheIndex(t *testing.T) {
 	registry(t, root)
 
 	store := schema.Store{Locations: []string{root}}
-	if got := store.Versions(); len(got) != 1 || got[0] != latestVersion {
+	if got := store.Versions(t.Context()); len(got) != 1 || got[0] != latestVersion {
 		t.Errorf("Versions() = %v, want [%s]", got, latestVersion)
 	}
 }
@@ -292,9 +294,9 @@ func TestRemoteRegistryRoot(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := schema.Store{Locations: []string{srv.URL}, Distribution: distCore}
+	store := schema.Store{Locations: []string{srv.URL}, Distribution: distCore, AllowInsecure: true}
 
-	cat, err := store.Load("v0.157.0")
+	cat, err := store.Load(t.Context(), "v0.157.0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +305,7 @@ func TestRemoteRegistryRoot(t *testing.T) {
 		t.Errorf("unexpected schema: %+v", cat)
 	}
 
-	if got := store.Versions(); len(got) != 1 || got[0] != "v0.157.0" {
+	if got := store.Versions(t.Context()); len(got) != 1 || got[0] != "v0.157.0" {
 		t.Errorf("Versions() = %v, want [v0.157.0] from the index", got)
 	}
 }
@@ -322,11 +324,11 @@ func TestIndexVersionsArePerDistribution(t *testing.T) {
 		`{"distributions":{"contrib":["v0.157.0","v0.150.0"],"core":["v0.157.0"]}}`)
 
 	store := schema.Store{Locations: []string{root}, Distribution: distCore}
-	if got := store.Versions(); len(got) != 1 || got[0] != latestVersion {
+	if got := store.Versions(t.Context()); len(got) != 1 || got[0] != latestVersion {
 		t.Errorf("Versions() = %v, want only the release core has", got)
 	}
 
-	if got := (schema.Store{Locations: []string{root}}).Versions(); len(got) != 2 {
+	if got := (schema.Store{Locations: []string{root}}).Versions(t.Context()); len(got) != 2 {
 		t.Errorf("the default distribution should see both releases, got %v", got)
 	}
 }
@@ -344,12 +346,12 @@ func TestARegistryRefusesADistributionItLacks(t *testing.T) {
 	write(t, filepath.Join(root, schema.IndexFile),
 		`{"distributions":{"contrib":["v0.157.0"]}}`)
 
-	_, err := (schema.Store{Locations: []string{root}, Distribution: "k8s"}).Load(latestVersion)
+	_, err := (schema.Store{Locations: []string{root}, Distribution: "k8s"}).Load(t.Context(), latestVersion)
 	if err == nil {
 		t.Fatal("k8s is not in this registry, so it must not resolve")
 	}
 
-	_, err = (schema.Store{Locations: []string{root}}).Load(latestVersion)
+	_, err = (schema.Store{Locations: []string{root}}).Load(t.Context(), latestVersion)
 	if err != nil {
 		t.Errorf("the default distribution should still resolve: %v", err)
 	}
@@ -367,7 +369,7 @@ func TestDefaultExpandsToTheOfficialRegistry(t *testing.T) {
 	// The local flat location answers first, so nothing reaches the network.
 	store := schema.Store{Locations: []string{dir, schema.Default}}
 
-	_, err := store.Load(latestVersion)
+	_, err := store.Load(t.Context(), latestVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -397,9 +399,9 @@ func TestRemoteFileLocation(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := schema.Store{Locations: []string{srv.URL + "/schemas/v0.157.0.yaml"}}
+	store := schema.Store{Locations: []string{srv.URL + "/schemas/v0.157.0.yaml"}, AllowInsecure: true}
 
-	_, err := store.Load("v0.157.0")
+	_, err := store.Load(t.Context(), "v0.157.0")
 	if err != nil {
 		t.Fatalf("%v (requested %v)", err, asked)
 	}
@@ -427,7 +429,7 @@ func TestDistributionPlaceholderInATemplate(t *testing.T) {
 		Distribution: distCore,
 	}
 
-	cat, err := store.Load("v0.150.0")
+	cat, err := store.Load(t.Context(), "v0.150.0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,11 +455,11 @@ func TestStoreFsReadsAnInMemoryRegistry(t *testing.T) {
 
 	store := schema.Store{Locations: []string{root}, Distribution: distCore, Fs: fsys}
 
-	if got := store.Versions(); !slices.Equal(got, []string{"v0.150.0"}) {
+	if got := store.Versions(t.Context()); !slices.Equal(got, []string{"v0.150.0"}) {
 		t.Errorf("Versions() = %v, want the in-memory index", got)
 	}
 
-	cat, err := store.Load(schema.Latest)
+	cat, err := store.Load(t.Context(), schema.Latest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -474,7 +476,7 @@ func TestStoreFsIsNotTheRealFilesystem(t *testing.T) {
 
 	store := schema.Store{Locations: []string{repoSchemas}, Fs: afero.NewMemMapFs()}
 
-	_, err := store.Load(schema.Latest)
+	_, err := store.Load(t.Context(), schema.Latest)
 	if err == nil {
 		t.Error("want an error: the committed schemas are not on the given Fs")
 	}
@@ -494,7 +496,7 @@ func TestAliasesAreMarkedDeprecated(t *testing.T) {
 
 	store := schema.Store{Locations: []string{repoSchemas}}
 
-	cat, err := store.Load(schema.Latest)
+	cat, err := store.Load(t.Context(), schema.Latest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -513,6 +515,113 @@ func TestAliasesAreMarkedDeprecated(t *testing.T) {
 				t.Errorf("%s %q points at missing canonical type %q", kind, typ, comp.AliasOf)
 			}
 		}
+	}
+}
+
+// TestAPlainHTTPLocationIsRefused pins the default: a schema decides which
+// components exist, so it may not arrive over a transport anyone on the path
+// can rewrite.
+func TestAPlainHTTPLocationIsRefused(t *testing.T) {
+	t.Parallel()
+
+	var asked int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		asked++
+
+		_, _ = w.Write([]byte(`{"collectorVersion":"v0.157.0","components":{}}`))
+	}))
+	defer srv.Close()
+
+	store := schema.Store{Locations: []string{srv.URL + "/{{.Version}}.json"}}
+
+	_, err := store.Load(t.Context(), "v0.157.0")
+	if err == nil {
+		t.Fatal("an http:// location should be refused")
+	}
+
+	if !strings.Contains(err.Error(), "http") {
+		t.Errorf("the error should say what it refused, got %v", err)
+	}
+
+	if asked != 0 {
+		t.Errorf("a refused location should not be fetched, got %d requests", asked)
+	}
+
+	if store.Validate() == nil {
+		t.Error("Validate should report the location a command is about to be refused for")
+	}
+
+	// The opt-in is what a registry on localhost is served under.
+	allowed := store
+	allowed.AllowInsecure = true
+
+	err = allowed.Validate()
+	if err != nil {
+		t.Fatalf("the opt-in should permit http, got %v", err)
+	}
+
+	_, err = allowed.Load(t.Context(), "v0.157.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestARemoteSchemaIsCappedInSize pins that a location cannot decide how much
+// memory the linter spends. The cap is reported as itself, not as a parse
+// failure part-way through a truncated document.
+func TestARemoteSchemaIsCappedInSize(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "collectorVersion: v0.157.0\ncomponents: {}\n# ")
+
+		// More than the store will accept, streamed rather than allocated.
+		_, _ = io.CopyN(w, filler{}, 64<<20)
+	}))
+	defer srv.Close()
+
+	store := schema.Store{Locations: []string{srv.URL + "/{{.Version}}.yaml"}, AllowInsecure: true}
+
+	_, err := store.Load(t.Context(), "v0.157.0")
+	if err == nil {
+		t.Fatal("a body over the limit should not be decoded")
+	}
+
+	if !strings.Contains(err.Error(), "larger than") {
+		t.Errorf("the error should name the limit, got %v", err)
+	}
+}
+
+// filler is an endless body, standing in for a registry that streams.
+type filler struct{}
+
+func (filler) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+
+	return len(p), nil
+}
+
+// TestFetchStopsWhenTheContextIsCancelled pins that an interrupt reaches a
+// request that is already in flight, rather than waiting out the timeout.
+func TestFetchStopsWhenTheContextIsCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		cancel()
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	store := schema.Store{Locations: []string{srv.URL + "/{{.Version}}.json"}, AllowInsecure: true}
+
+	_, err := store.Load(ctx, "v0.157.0")
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("a cancelled run should report it, got %v", err)
 	}
 }
 

--- a/pkg/schema/store_test.go
+++ b/pkg/schema/store_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
@@ -536,35 +538,19 @@ func TestAPlainHTTPLocationIsRefused(t *testing.T) {
 	store := schema.Store{Locations: []string{srv.URL + "/{{.Version}}.json"}}
 
 	_, err := store.Load(t.Context(), "v0.157.0")
-	if err == nil {
-		t.Fatal("an http:// location should be refused")
-	}
-
-	if !strings.Contains(err.Error(), "http") {
-		t.Errorf("the error should say what it refused, got %v", err)
-	}
-
-	if asked != 0 {
-		t.Errorf("a refused location should not be fetched, got %d requests", asked)
-	}
-
-	if store.Validate() == nil {
-		t.Error("Validate should report the location a command is about to be refused for")
-	}
+	require.Error(t, err, "an http:// location should be refused")
+	assert.Contains(t, err.Error(), "http", "the error should say what it refused")
+	assert.Zero(t, asked, "a refused location should not be fetched")
+	require.Error(t, store.Validate(), "Validate should refuse it while a command is still reading flags")
 
 	// The opt-in is what a registry on localhost is served under.
 	allowed := store
 	allowed.AllowInsecure = true
 
-	err = allowed.Validate()
-	if err != nil {
-		t.Fatalf("the opt-in should permit http, got %v", err)
-	}
+	require.NoError(t, allowed.Validate(), "the opt-in should permit http")
 
 	_, err = allowed.Load(t.Context(), "v0.157.0")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 // TestARemoteSchemaIsCappedInSize pins that a location cannot decide how much
@@ -584,13 +570,9 @@ func TestARemoteSchemaIsCappedInSize(t *testing.T) {
 	store := schema.Store{Locations: []string{srv.URL + "/{{.Version}}.yaml"}, AllowInsecure: true}
 
 	_, err := store.Load(t.Context(), "v0.157.0")
-	if err == nil {
-		t.Fatal("a body over the limit should not be decoded")
-	}
-
-	if !strings.Contains(err.Error(), "larger than") {
-		t.Errorf("the error should name the limit, got %v", err)
-	}
+	require.Error(t, err, "a body over the limit should not be decoded")
+	assert.Contains(t, err.Error(), "larger than",
+		"the error should name the limit rather than the parse it prevented")
 }
 
 // filler is an endless body, standing in for a registry that streams.
@@ -620,9 +602,7 @@ func TestFetchStopsWhenTheContextIsCancelled(t *testing.T) {
 	store := schema.Store{Locations: []string{srv.URL + "/{{.Version}}.json"}, AllowInsecure: true}
 
 	_, err := store.Load(ctx, "v0.157.0")
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("a cancelled run should report it, got %v", err)
-	}
+	require.ErrorIs(t, err, context.Canceled, "a cancelled run should end the fetch it started")
 }
 
 func write(t *testing.T, path, content string) {

--- a/pkg/settings/jsonschema.go
+++ b/pkg/settings/jsonschema.go
@@ -93,6 +93,12 @@ func runSchema() object {
 			"type":  "array",
 			"items": object{"type": "string"},
 		},
+		"insecureSchemaLocation": object{
+			"description": "Allow a plain http:// schema location, which is otherwise refused. " +
+				"For a registry served on localhost; over a network anyone on the path decides " +
+				"what the rules report.",
+			"type": "boolean",
+		},
 		"strict": object{
 			"description": "Report unknown component settings as errors instead of warnings.",
 			"type":        "boolean",

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -84,6 +84,10 @@ type RunBlock struct {
 	Distribution string `yaml:"distribution"`
 	// SchemaLocations are searched in order before the published registry.
 	SchemaLocations []string `yaml:"schemaLocations"`
+	// InsecureSchemaLocation permits a plain http:// schema location, which is
+	// otherwise refused: a schema states which components exist, so a transport
+	// anyone can rewrite decides what the rules report.
+	InsecureSchemaLocation *bool `yaml:"insecureSchemaLocation"`
 	// Strict reports unknown component settings as errors.
 	Strict *bool `yaml:"strict"`
 	// IgnoreMissingSchemas keeps components absent from the schema from


### PR DESCRIPTION
Closes #71.

`Store.get` is the one place every remote schema and index comes through, and it trusted the endpoint completely. Four things follow, in the order the issue puts them.

## The body is bounded

A remote body is read under a 32 MiB ceiling, in one place, before any decoder sees it. `--schema-location` takes an arbitrary URL and a decoder materialises whatever arrives, so a registry that is hostile or merely broken could stream the linter out of memory; the 30 second client timeout bounds the duration, not the size. Reading it in `get` rather than in each decoder is what lets a location serving too much be reported as exactly that:

```
read https://…/contrib/v0.157.0.yaml: schema is larger than the 32 MiB limit
```

## `http://` is refused

The schema is the evidence every rule reasons from, so anyone able to rewrite one in flight decides which components exist and which settings are valid. A plain `http://` location now fails where a bad flag fails, before anything is fetched:

```
otelcol-config-lint: --schema-location: refusing to fetch a schema over plain http,
which anyone on the path can rewrite: http://example.invalid;
pass --insecure-schema-location to allow one served on localhost
```

`--insecure-schema-location` (settings key `run.insecureSchemaLocation`) is the opt-in, for a registry served on loopback. It is deliberately **not** an input of the GitHub action: a workflow whose findings anyone on the path can choose is not worth offering. `Store.Validate` is what the commands call while they are still reading flags; `get` refuses one too, so a library caller cannot slip past it.

## One client, one connection pool

The default client is built once (`sync.OnceValue`) and shared. Before, a nil `HTTPClient` meant a fresh client — and therefore a fresh transport and pool — per request, so nothing was ever reused; that is invisible for one schema and paid on every release when `VersionIndex.build` walks a registry.

## Cancellation reaches the network

`Load`, `Versions` and `Distributions` take a `context.Context`. The commands pass the one cobra carries, and `main` derives it from `SIGINT`/`SIGTERM`, so Ctrl-C ends an in-flight fetch instead of holding the terminal until the client times out.

No struct holds a context. `Lint`/`LintFile`/`LintReader`/`LintAll` take one, the two lazy indexes take one on the question they answer (`Versions(ctx, …)`, `Distributions(ctx, …)`), and the linter binds it per file into `rule.Context.Avail`/`.Dists` through the new `rule.AvailabilityFunc`/`rule.DistributionsFunc` adapters. The rules are untouched: a rule still asks without a context, since it has no run of its own to speak for.

## Left out

The `sha256` per index entry the issue lists last. It closes a different gap — a compromised registry rather than a compromised link — needs a change to the schema registry's published `index.json`, and the issue itself marks it as separately worth designing.

## Tests

- an `http://` location is refused, is not fetched, and is permitted by the opt-in (store and command level)
- a body past the ceiling is refused as too large rather than decoded
- a cancelled context ends a fetch in flight
- stores with no client of their own share one, so the pool is shared
- a rule's schema question arrives on the context the linting call was made with

`go test ./...` passes and `golangci-lint` v2.11.3 — the version CI pins — reports 0 issues. `otelcol-config-lint.schema.json` is regenerated for the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z
