### PR TITLE
feat(schema): retry, ask once, and keep what the registry served

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ whole reference: `files` (default `.`, whitespace-separated, globs allowed),
 several in order), `strict`, `ignore-missing-schemas`, `min-severity`,
 `fail-on`, `default`, `enable`, `disable`, `severity`, `exclude`, `output`
 (default `github`), `config`, `no-config`, `summary` (default `true`),
-`verbose` and `exit-on-error`. `--concurrency`, `--no-color` and
+`verbose` and `exit-on-error`. `--concurrency`, `--no-color`, `--no-cache` and
 `--insecure-schema-location` are left out: a runner gains nothing from the
-first two, and a workflow that reads its schemas over plain HTTP is one whose
-findings anyone on the path can choose.
+first two, a fresh container has no cache to read, and a workflow that reads
+its schemas over plain HTTP is one whose findings anyone on the path can
+choose.
 
 The counts come back as outputs — `exit-code`, `valid`, `invalid`, `errors`,
 `skipped`, `warnings` and `infos` — so a later step can decide what to do with
@@ -130,6 +131,7 @@ from it.
 | `--distribution` | `run.distribution` | collector binary to validate against: `core`, `contrib` (default), `k8s` or `otlp` |
 | `--schema-location` | `run.schemaLocations` | where to find schemas: a registry directory or URL, a `{{.Version}}`/`{{.Distribution}}` template, or `default`. Repeat to search several in order |
 | `--insecure-schema-location` | `run.insecureSchemaLocation` | allow a plain `http://` schema location, which is otherwise refused. For a registry served on localhost |
+| `--no-cache` | `run.noCache` | fetch schemas again instead of reading the ones kept from earlier runs |
 | `--strict` | `run.strict` | unknown component settings become errors instead of warnings |
 | `--ignore-missing-schemas` | `run.ignoreMissingSchemas` | do not fail on components absent from the schema (custom distributions) |
 | `--exclude` | `run.exclude` | glob patterns to skip when walking directories |
@@ -748,6 +750,24 @@ is there for a registry served on localhost. One download is capped at 32 MiB,
 so a registry that is hostile or merely broken cannot stream the linter out of
 memory.
 
+### Caching
+
+A schema describes one release of one distribution, so what it says under a
+version does not change. Fetched schemas are therefore kept between runs, under
+`$XDG_CACHE_HOME/otelcol-config-lint` (the platform's own cache directory when
+the environment names none), and a second run reads them from there without
+asking the registry. The index, which grows a line per release, is offered back
+with its ETag instead, so an up-to-date run pays a `304` rather than the file.
+
+`--no-cache` reads nothing and keeps nothing. The registry tracks its own main,
+so a schema can be corrected under a version this machine has already read;
+that is when to reach for it. Deleting the directory has the same effect once.
+
+A throttled or briefly failing registry is asked again — three attempts, waiting
+as long as a `Retry-After` asks for and backing off from half a second
+otherwise — so one `429` does not fail a lint. A `404` is not retried: it means
+the registry does not carry that version, which waiting will not change.
+
 ### Adding a release
 
 A distribution is described by the same [OCB builder
@@ -775,7 +795,11 @@ go run ./cmd/schemagen generate --builder acme=./builder.yaml --registry ./schem
 
 `cmd/schemagen` downloads every module the manifest names, plus everything they
 require, and writes `<distribution>/<version>.yaml` and `.json` into the schema
-repository, along with the `index.json` listing them. The download goes through
+repository, along with the `index.json` listing them. The index also records
+the extension each distribution's schemas should be fetched with, so reading
+one over the network costs a single request instead of probing `.yaml`, `.yml`
+and `.json` in turn; a distribution whose releases do not agree on one form
+names none, and is probed as before. The download goes through
 the `go` command, so `GOPROXY`, `GOPRIVATE` and whatever credentials this
 machine builds with apply unchanged: a **private component resolves exactly as
 it does for the build that consumes it**, and a `replaces:` entry pointing at a

--- a/otelcol-config-lint.schema.json
+++ b/otelcol-config-lint.schema.json
@@ -375,6 +375,10 @@
           },
           "type": "object"
         },
+        "noCache": {
+          "description": "Fetch schemas again instead of reading the ones kept from earlier runs. A published schema does not change under its version, so it is kept between runs; this is what picks up a correction to one already read.",
+          "type": "boolean"
+        },
         "schemaLocations": {
           "description": "Where to find schemas, searched in order: a directory, a URL, a {{.Version}}/{{.Distribution}} template, or \"default\" for the published registry.",
           "items": {

--- a/pkg/cmd/otelcol-config-lint/list/list.go
+++ b/pkg/cmd/otelcol-config-lint/list/list.go
@@ -150,6 +150,7 @@ type versionsOptions struct {
 	distribution           string
 	schemaLocations        []string
 	insecureSchemaLocation bool
+	noCache                bool
 
 	// internal state
 	// store is where the schemas are read from.
@@ -194,6 +195,8 @@ func (o *versionsOptions) declareFlags(cmd *cobra.Command) {
 			"repeat to search several in order (default: the published registry)")
 	flags.BoolVar(&o.insecureSchemaLocation, "insecure-schema-location", false,
 		"allow a plain http:// schema location, for a registry served on localhost")
+	flags.BoolVar(&o.noCache, "no-cache", false,
+		"fetch schemas again instead of reading the ones kept from earlier runs")
 }
 
 // prepare folds the schema keys of the settings file into the flags and builds
@@ -209,11 +212,13 @@ func (o *versionsOptions) prepare(cmd *cobra.Command) error {
 	fold.Str("distribution", &o.distribution, file.Run.Distribution)
 	fold.List("schema-location", &o.schemaLocations, file.Run.SchemaLocations)
 	fold.Bool("insecure-schema-location", &o.insecureSchemaLocation, file.Run.InsecureSchemaLocation)
+	fold.Bool("no-cache", &o.noCache, file.Run.NoCache)
 
 	o.store = schema.Store{
 		Locations:     o.schemaLocations,
 		Distribution:  o.distribution,
 		AllowInsecure: o.insecureSchemaLocation,
+		NoCache:       o.noCache,
 		Fs:            o.FS(),
 	}
 

--- a/pkg/cmd/otelcol-config-lint/run/run.go
+++ b/pkg/cmd/otelcol-config-lint/run/run.go
@@ -57,6 +57,7 @@ type options struct {
 	distribution           string
 	schemaLocations        []string
 	insecureSchemaLocation bool
+	noCache                bool
 	// Which rules run, and at what level.
 	ruleDefault string
 	enable      []string
@@ -160,6 +161,8 @@ func (o *options) declareFlags(cmd *cobra.Command) {
 			"repeat to search several in order (default: the published registry)")
 	flags.BoolVar(&o.insecureSchemaLocation, "insecure-schema-location", false,
 		"allow a plain http:// schema location, for a registry served on localhost")
+	flags.BoolVar(&o.noCache, "no-cache", false,
+		"fetch schemas again instead of reading the ones kept from earlier runs")
 	flags.StringVar(&o.ruleDefault, "default", "",
 		"rule set to start from: "+ruleset.DefaultAll+" (the default) or "+ruleset.DefaultNone)
 	flags.StringSliceVarP(&o.enable, "enable", "E", nil, "rules to turn on, on top of --default")
@@ -202,6 +205,7 @@ func (o *options) prepare(cmd *cobra.Command) error {
 	fold.Str("distribution", &o.distribution, file.Run.Distribution)
 	fold.List("schema-location", &o.schemaLocations, file.Run.SchemaLocations)
 	fold.Bool("insecure-schema-location", &o.insecureSchemaLocation, file.Run.InsecureSchemaLocation)
+	fold.Bool("no-cache", &o.noCache, file.Run.NoCache)
 	fold.Str("memory-request", &o.memoryRequest, file.Run.Kubernetes.MemoryRequest)
 	fold.Str("memory-limit", &o.memoryLimit, file.Run.Kubernetes.MemoryLimit)
 
@@ -234,6 +238,7 @@ func (o *options) prepare(cmd *cobra.Command) error {
 		Locations:     o.schemaLocations,
 		Distribution:  o.distribution,
 		AllowInsecure: o.insecureSchemaLocation,
+		NoCache:       o.noCache,
 		Fs:            o.FS(),
 	}
 

--- a/pkg/cmd/schemagen/schemagen_test.go
+++ b/pkg/cmd/schemagen/schemagen_test.go
@@ -2,6 +2,7 @@ package schemagen_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/cmd/schemagen"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 )
 
 // run executes the command and returns its exit code and streams. The wiring
@@ -393,6 +395,50 @@ replaces:
 	index := readFile(t, filepath.Join(out, "index.json"))
 	assert.Contains(t, index, "custom")
 	assert.Contains(t, index, "v0.157.0")
+	// Both forms are written, so the readable one is what a fetch should ask
+	// for, and the index says so rather than leaving it to be probed.
+	assert.Contains(t, index, `"extensions"`)
+	assert.Contains(t, index, `".yaml"`)
+}
+
+// TestIndexNamesTheExtensionPublished covers the request the index saves: a
+// registry publishing one form says which, so reading a schema from it over
+// the network costs one request instead of a probe through three.
+func TestIndexNamesTheExtensionPublished(t *testing.T) {
+	t.Parallel()
+
+	modules, out := t.TempDir(), t.TempDir()
+	manifest := singleComponentManifest(t, modules)
+
+	code, _, stderr := run(t, "--builder", "custom="+manifest, "--registry", out,
+		"--formats", "json", "--cache", t.TempDir())
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+
+	var idx schema.Index
+
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, filepath.Join(out, "index.json"))), &idx))
+
+	ext, named := idx.Extension("custom")
+	assert.True(t, named, "the index named no extension for a distribution published as JSON alone")
+	assert.Equal(t, ".json", ext)
+
+	// A release published in another form leaves the distribution with no
+	// single answer, so the index names none and the probe stays the fallback.
+	writeFile(t, filepath.Join(out, "custom", "v0.150.0.yaml"),
+		"collectorVersion: v0.150.0\ndistribution: custom\ncomponents: {}\n")
+
+	code, _, stderr = run(t, "--builder", "custom="+manifest, "--registry", out,
+		"--formats", "json", "--cache", t.TempDir())
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+
+	// Decoded into a fresh index: an absent "extensions" key leaves whatever
+	// the previous decode put there, which is the value under test.
+	var regenerated schema.Index
+
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, filepath.Join(out, "index.json"))), &regenerated))
+
+	_, named = regenerated.Extension("custom")
+	assert.False(t, named, "releases that disagree on a form should name none")
 }
 
 // TestWritesOneFile covers the single-manifest form: the schema goes where

--- a/pkg/cmd/schemagen/write.go
+++ b/pkg/cmd/schemagen/write.go
@@ -82,20 +82,27 @@ func (o *Options) writeIndex() error {
 		return fmt.Errorf("read %s: %w", o.registryDir, err)
 	}
 
-	idx := &schema.Index{Distributions: map[string][]string{}}
+	idx := &schema.Index{Distributions: map[string][]string{}, Extensions: map[string]string{}}
 
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
 		}
 
-		versions := versionsIn(filepath.Join(o.registryDir, e.Name()))
+		dir := filepath.Join(o.registryDir, e.Name())
+
+		versions := versionsIn(dir)
 		if len(versions) == 0 {
 			// Not a distribution, just a directory that happens to sit here.
 			continue
 		}
 
 		idx.Distributions[e.Name()] = versions
+
+		ext := extensionIn(dir, versions)
+		if ext != "" {
+			idx.Extensions[e.Name()] = ext
+		}
 	}
 
 	dest := filepath.Join(o.registryDir, schema.IndexFile)
@@ -117,6 +124,41 @@ func (o *Options) writeIndex() error {
 	o.logf("wrote %s (%d distributions)\n", dest, len(idx.Distributions))
 
 	return nil
+}
+
+// extensionIn returns the file extension a distribution's schemas should be
+// fetched with: the form every release in the directory is served as, which is
+// the preferred one where a release carries several. It is recorded in the
+// index so that a remote fetch asks once instead of probing each extension in
+// turn.
+//
+// Releases that disagree -- older ones published only as JSON, say, and newer
+// ones as YAML -- have no single answer, and an index naming one of them would
+// send half the fetches at a file that is not there. Those record nothing, and
+// are probed as before.
+func extensionIn(dir string, versions []string) string {
+	answer := ""
+
+	for _, v := range versions {
+		found := ""
+
+		for _, ext := range schema.Extensions() {
+			_, err := os.Stat(filepath.Join(dir, v+ext))
+			if err == nil {
+				found = ext
+
+				break
+			}
+		}
+
+		if answer != "" && found != answer {
+			return ""
+		}
+
+		answer = found
+	}
+
+	return answer
 }
 
 // versionsIn lists the releases a distribution directory holds, in any of the

--- a/pkg/schema/cache.go
+++ b/pkg/schema/cache.go
@@ -1,0 +1,183 @@
+package schema
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+)
+
+// cacheDirName is what the cache is called inside the user's cache directory.
+const cacheDirName = "otelcol-config-lint"
+
+// cacheEnv is the environment variable naming where caches go, which is where
+// this one goes when it is set.
+const cacheEnv = "XDG_CACHE_HOME"
+
+// etagSuffix names the file holding an entry's validator, beside the body it
+// validates. Two files rather than one envelope: what is cached is exactly
+// what was served, so a cached schema can be read with any editor and diffed
+// against the registry.
+const etagSuffix = ".etag"
+
+// The modes the cache creates its directory and files with. Nothing here is
+// secret, but nothing else has a reason to write it either.
+const (
+	cacheDirPerm  = 0o700
+	cacheFilePerm = 0o600
+)
+
+// freshness says what a cached copy of a location is worth without asking the
+// registry about it.
+type freshness int
+
+const (
+	// immutable marks a location whose content will not change under the same
+	// URL: a schema is generated from one release of one distribution, so the
+	// only thing a second fetch can serve is the bytes already on disk. A
+	// correction to a published schema is the exception, which is what
+	// --no-cache is for.
+	immutable freshness = iota
+	// revalidated marks a location that changes in place -- the index, which
+	// grows a line per release. The cached copy is offered to the registry
+	// with If-None-Match, so a run that is up to date pays a 304 instead of
+	// the file.
+	revalidated
+)
+
+// diskCache keeps what a registry served, so that the next run does not ask
+// for it again. Entries are keyed by URL, and the body and its validator are
+// separate files.
+//
+// It is best-effort throughout: a cache that cannot be read or written is a
+// fetch that goes to the network, never an error. Nothing here is the answer
+// the caller asked for.
+type diskCache struct {
+	fs  afero.Fs
+	dir string
+}
+
+// cache is where this store keeps what it fetched, or nil when it was told not
+// to keep anything or there is nowhere to put it.
+func (s Store) cache() *diskCache {
+	if s.NoCache {
+		return nil
+	}
+
+	dir := s.CacheDir
+	if dir == "" {
+		root, err := cacheRoot()
+		if err != nil {
+			return nil
+		}
+
+		dir = root
+	}
+
+	return &diskCache{fs: s.fs(), dir: dir}
+}
+
+// cacheRoot is where fetched schemas are kept when the caller named nowhere:
+// under $XDG_CACHE_HOME when the environment names one, and under the
+// platform's own cache directory otherwise. The variable is honoured on every
+// platform, rather than only where os.UserCacheDir reads it, so that one
+// setting moves the cache wherever the run happens.
+func cacheRoot() (string, error) {
+	dir := os.Getenv(cacheEnv)
+	if dir == "" {
+		var err error
+
+		dir, err = os.UserCacheDir()
+		if err != nil {
+			return "", fmt.Errorf("locate the cache directory: %w", err)
+		}
+	}
+
+	return filepath.Join(dir, cacheDirName), nil
+}
+
+// path is where one URL's body is kept. The name is a digest of the URL: a
+// location is whatever the caller named, and its path is not one this package
+// should be laying out directories from.
+func (c *diskCache) path(url string) string {
+	sum := sha256.Sum256([]byte(url))
+
+	return filepath.Join(c.dir, hex.EncodeToString(sum[:]))
+}
+
+// load returns what was cached for a URL: the body, the validator to offer the
+// registry with it, and whether there was anything at all.
+func (c *diskCache) load(url string) ([]byte, string, bool) {
+	body, err := afero.ReadFile(c.fs, c.path(url))
+	if err != nil {
+		return nil, "", false
+	}
+
+	// A missing validator only means the entry cannot be revalidated; the body
+	// is still the body.
+	etag, err := afero.ReadFile(c.fs, c.path(url)+etagSuffix)
+	if err != nil {
+		return body, "", true
+	}
+
+	return body, string(etag), true
+}
+
+// save records what a registry served. A failure is ignored: the run has the
+// bytes it needed, and a cache that cannot be written is only a slower next
+// run.
+func (c *diskCache) save(url string, body []byte, etag string) {
+	err := c.fs.MkdirAll(c.dir, cacheDirPerm)
+	if err != nil {
+		return
+	}
+
+	err = c.write(c.path(url), body)
+	if err != nil {
+		return
+	}
+
+	if etag == "" {
+		// Leave no stale validator beside a fresh body: it would be offered
+		// for content it no longer describes.
+		_ = c.fs.Remove(c.path(url) + etagSuffix)
+
+		return
+	}
+
+	_ = c.write(c.path(url)+etagSuffix, []byte(etag))
+}
+
+// write puts a file in place in one step, so that a run reading the cache
+// while another writes it sees either the old entry or the new one, and a
+// write cut short leaves neither.
+func (c *diskCache) write(path string, content []byte) error {
+	tmp, err := afero.TempFile(c.fs, c.dir, filepath.Base(path)+"-")
+	if err != nil {
+		return fmt.Errorf("create a cache entry: %w", err)
+	}
+
+	_, err = tmp.Write(content)
+	if cerr := tmp.Close(); err == nil {
+		err = cerr
+	}
+
+	if err == nil {
+		err = c.fs.Chmod(tmp.Name(), cacheFilePerm)
+	}
+
+	if err == nil {
+		err = c.fs.Rename(tmp.Name(), path)
+	}
+
+	if err != nil {
+		_ = c.fs.Remove(tmp.Name())
+
+		return fmt.Errorf("write a cache entry: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/schema/cache_internal_test.go
+++ b/pkg/schema/cache_internal_test.go
@@ -1,0 +1,183 @@
+package schema
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCacheServesAnImmutableLocationWithoutAsking pins the request the cache
+// saves. A published schema describes one release of one distribution, so the
+// only thing a second fetch could serve is what is already on disk -- and
+// asking anyway, every run, against a registry that throttles, is the pattern
+// the cache exists to end.
+func TestCacheServesAnImmutableLocationWithoutAsking(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+
+		_, _ = w.Write([]byte("served"))
+	}))
+	defer srv.Close()
+
+	store := Store{AllowInsecure: true, CacheDir: t.TempDir()}
+
+	first, err := store.get(t.Context(), srv.URL, immutable)
+	require.NoError(t, err)
+
+	second, err := store.get(t.Context(), srv.URL, immutable)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+	assert.Equal(t, int32(1), requests.Load(), "the second read should have come from the cache")
+}
+
+// TestCacheRevalidatesAnIndex pins that what does change under its own URL is
+// asked about rather than assumed. The index grows a line per release, so it
+// is offered back with its validator: a run that is up to date pays a 304
+// instead of the file.
+func TestCacheRevalidatesAnIndex(t *testing.T) {
+	t.Parallel()
+
+	var offered atomic.Value
+
+	offered.Store("")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		offered.Store(r.Header.Get("If-None-Match"))
+
+		if r.Header.Get("If-None-Match") == `"v1"` {
+			w.WriteHeader(http.StatusNotModified)
+
+			return
+		}
+
+		w.Header().Set("ETag", `"v1"`)
+		_, _ = w.Write([]byte("the index"))
+	}))
+	defer srv.Close()
+
+	store := Store{AllowInsecure: true, CacheDir: t.TempDir()}
+
+	_, err := store.get(t.Context(), srv.URL, revalidated)
+	require.NoError(t, err)
+	assert.Empty(t, offered.Load(), "nothing was cached yet, so nothing should have been offered")
+
+	body, err := store.get(t.Context(), srv.URL, revalidated)
+	require.NoError(t, err)
+	assert.Equal(t, `"v1"`, offered.Load(), "the cached copy should have been offered for revalidation")
+	assert.Equal(t, "the index", string(body), "a 304 should serve what the cache holds")
+}
+
+// TestCacheServesTheNewBodyWhenTheValidatorIsStale pins the other half of
+// revalidation: an index that has moved on is served, stored, and offered
+// under its new validator.
+func TestCacheServesTheNewBodyWhenTheValidatorIsStale(t *testing.T) {
+	t.Parallel()
+
+	var current atomic.Value
+
+	current.Store(`"v1"`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tag, _ := current.Load().(string)
+		if r.Header.Get("If-None-Match") == tag {
+			w.WriteHeader(http.StatusNotModified)
+
+			return
+		}
+
+		w.Header().Set("ETag", tag)
+		_, _ = w.Write([]byte("index " + tag))
+	}))
+	defer srv.Close()
+
+	store := Store{AllowInsecure: true, CacheDir: t.TempDir()}
+
+	_, err := store.get(t.Context(), srv.URL, revalidated)
+	require.NoError(t, err)
+
+	current.Store(`"v2"`)
+
+	body, err := store.get(t.Context(), srv.URL, revalidated)
+	require.NoError(t, err)
+	assert.Equal(t, `index "v2"`, string(body), "a moved-on location should serve its new body")
+
+	body, err = store.get(t.Context(), srv.URL, revalidated)
+	require.NoError(t, err)
+	assert.Equal(t, `index "v2"`, string(body), "the new validator should have replaced the old one")
+}
+
+// TestNoCacheAsksEveryTime pins what --no-cache is for: a schema corrected
+// under a version already read once is only picked up by a run that does not
+// trust what it kept.
+func TestNoCacheAsksEveryTime(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+
+		_, _ = w.Write([]byte("served"))
+	}))
+	defer srv.Close()
+
+	store := Store{AllowInsecure: true, CacheDir: t.TempDir(), NoCache: true}
+
+	for range 2 {
+		_, err := store.get(t.Context(), srv.URL, immutable)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int32(2), requests.Load(), "--no-cache should keep nothing and read nothing")
+	assert.Nil(t, store.cache(), "--no-cache should leave no cache at all")
+
+	entries, err := os.ReadDir(store.CacheDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "--no-cache should have written nothing")
+}
+
+// TestAnUnwritableCacheIsStillAFetch pins that the cache never decides whether
+// a run works. It holds what was served; it is not the answer.
+func TestAnUnwritableCacheIsStillAFetch(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("served"))
+	}))
+	defer srv.Close()
+
+	store := Store{
+		AllowInsecure: true,
+		CacheDir:      t.TempDir(),
+		Fs:            afero.NewReadOnlyFs(afero.NewMemMapFs()),
+	}
+
+	body, err := store.get(t.Context(), srv.URL, immutable)
+	require.NoError(t, err)
+	assert.Equal(t, "served", string(body))
+}
+
+// TestCacheRootHonoursXDG pins where the cache goes when the caller names
+// nowhere. XDG_CACHE_HOME is read on every platform, rather than only where
+// os.UserCacheDir happens to read it, so one setting moves the cache wherever
+// the run happens.
+func TestCacheRootHonoursXDG(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(cacheEnv, dir)
+
+	root, err := cacheRoot()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, cacheDirName), root)
+}

--- a/pkg/schema/index.go
+++ b/pkg/schema/index.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 
 	"github.com/spf13/afero"
@@ -25,6 +26,31 @@ type Index struct {
 	// distribution before v0.120.0, so asking a flat list of versions what the
 	// otlp registry holds would name releases it cannot serve.
 	Distributions map[string][]string `json:"distributions"`
+	// Extensions names the file extension each distribution's schemas should
+	// be fetched with. Without it a fetch has to probe ".yaml", ".yml" and
+	// ".json" in turn, which against a remote registry is three requests and
+	// two wasted 404s for every schema read.
+	//
+	// It is optional, and a registry whose releases do not agree on one form
+	// leaves a distribution out rather than naming the wrong one; the probe is
+	// still there for those, and for an index written before this field was.
+	Extensions map[string]string `json:"extensions,omitempty"`
+}
+
+// Extension returns the file extension a distribution's schemas are published
+// with, and whether the index named a usable one.
+//
+// A value outside the set this package reads is refused. The index comes from
+// the registry and the answer goes into a URL, so a registry that names
+// something else -- a path of its own choosing, or simply a typo -- gets the
+// probe rather than a fetch aimed wherever it pointed.
+func (i *Index) Extension(distribution string) (string, bool) {
+	ext, ok := i.Extensions[distribution]
+	if !ok || !slices.Contains(Extensions(), ext) {
+		return "", false
+	}
+
+	return ext, true
 }
 
 // Names returns the distributions the index covers, sorted.

--- a/pkg/schema/retry.go
+++ b/pkg/schema/retry.go
@@ -1,0 +1,116 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// fetchAttempts is how many times a remote location is asked before the fetch
+// reports what it last got. The default registry is served from GitHub, which
+// throttles and which returns a transient 5xx often enough that a run notices;
+// one 429 should not fail a lint that a second request would have passed.
+const fetchAttempts = 3
+
+// retryBaseDelay is how long the wait after the first failed attempt is, with
+// each further one doubling it. Three attempts therefore span about a second
+// and a half, which is short enough to sit inside a lint run and long enough
+// for the burst that provoked the throttle to have passed.
+const retryBaseDelay = 500 * time.Millisecond
+
+// maxRetryDelay caps one wait, including a Retry-After the endpoint named. A
+// registry asking to be left alone for an hour is telling the run to fail with
+// its error rather than to hold a terminal open for an hour.
+const maxRetryDelay = 10 * time.Second
+
+// retryAfterHeader is where an endpoint says how long it wants to be left
+// alone, which is worth more than any backoff guessed from this side.
+const retryAfterHeader = "Retry-After"
+
+// statusError reports a status a remote location answered with that the store
+// cannot read a schema from. It carries what deciding on a retry needs: the
+// status itself, and how long the endpoint asked to be left alone.
+//
+// A transport failure is not one of these and is not retried. Whether a
+// connection that was reset would succeed on a second attempt is not knowable
+// from here, while a 429 says so outright.
+type statusError struct {
+	url    string
+	status string
+	code   int
+	after  time.Duration
+}
+
+func (e *statusError) Error() string {
+	return fmt.Sprintf("GET %s: %v %s", e.url, errBadStatus, e.status)
+}
+
+// Unwrap keeps errors.Is(err, errBadStatus) answering for the callers that ask.
+func (e *statusError) Unwrap() error { return errBadStatus }
+
+// retryable reports whether asking again could plausibly serve the schema.
+// Throttling and a server-side failure both say the request was fine and the
+// moment was not; every other status says the request itself is the problem.
+//
+// 404 never reaches here: errNotFound is load-bearing for the extension probe
+// and for falling through to the next location, and a registry that does not
+// carry a version will not grow one while the run waits.
+func (e *statusError) retryable() bool {
+	return e.code == http.StatusTooManyRequests || e.code >= http.StatusInternalServerError
+}
+
+// retryDelay is the wait after a failed attempt: what the endpoint asked for
+// when it said, and an exponential backoff from base otherwise. attempt counts
+// from zero.
+func retryDelay(attempt int, base, asked time.Duration) time.Duration {
+	delay := asked
+	if delay <= 0 {
+		delay = base << attempt
+	}
+
+	return min(delay, maxRetryDelay)
+}
+
+// retryAfter reads the Retry-After header, in either form RFC 9110 gives it: a
+// number of seconds, or the date to wait until. A header that is missing,
+// unreadable, or already past means zero, which leaves the backoff to decide.
+func retryAfter(header http.Header, now time.Time) time.Duration {
+	value := strings.TrimSpace(header.Get(retryAfterHeader))
+	if value == "" {
+		return 0
+	}
+
+	seconds, err := strconv.Atoi(value)
+	if err == nil {
+		return max(time.Duration(seconds)*time.Second, 0)
+	}
+
+	until, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+
+	return max(until.Sub(now), 0)
+}
+
+// sleep holds for the given delay, or gives up early when the run is
+// cancelled. A retry that outlives the context it was started for is a retry
+// nobody is waiting for.
+func sleep(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("waiting to retry: %w", ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}

--- a/pkg/schema/retry_internal_test.go
+++ b/pkg/schema/retry_internal_test.go
@@ -36,9 +36,9 @@ func TestGetRetriesAThrottledRegistry(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := Store{AllowInsecure: true, retryDelay: testRetryDelay}
+	store := Store{AllowInsecure: true, retryDelay: testRetryDelay, NoCache: true}
 
-	body, err := store.get(t.Context(), srv.URL)
+	body, err := store.get(t.Context(), srv.URL, immutable)
 	require.NoError(t, err)
 	assert.Equal(t, "served", string(body))
 	assert.Equal(t, int32(3), requests.Load(), "the throttled attempts should have been retried")
@@ -58,9 +58,9 @@ func TestGetGivesUpAfterTheLastAttempt(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := Store{AllowInsecure: true, retryDelay: testRetryDelay}
+	store := Store{AllowInsecure: true, retryDelay: testRetryDelay, NoCache: true}
 
-	_, err := store.get(t.Context(), srv.URL)
+	_, err := store.get(t.Context(), srv.URL, immutable)
 	require.ErrorIs(t, err, errBadStatus)
 	assert.Contains(t, err.Error(), "503")
 	assert.Contains(t, err.Error(), "gave up after 3 attempts")
@@ -93,9 +93,9 @@ func TestGetDoesNotRetryWhatWillNotChange(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			store := Store{AllowInsecure: true, retryDelay: testRetryDelay}
+			store := Store{AllowInsecure: true, retryDelay: testRetryDelay, NoCache: true}
 
-			_, err := store.get(t.Context(), srv.URL)
+			_, err := store.get(t.Context(), srv.URL, immutable)
 			require.Error(t, err)
 			assert.Equal(t, int32(1), requests.Load(), "one request is all this status is worth")
 		})
@@ -117,9 +117,9 @@ func TestGetStopsRetryingWhenTheRunIsCancelled(t *testing.T) {
 
 	// A minute of backoff, which the cancellation has to cut short for this to
 	// return at all.
-	store := Store{AllowInsecure: true, retryDelay: time.Minute}
+	store := Store{AllowInsecure: true, retryDelay: time.Minute, NoCache: true}
 
-	_, err := store.get(ctx, srv.URL)
+	_, err := store.get(ctx, srv.URL, immutable)
 	require.ErrorIs(t, err, context.Canceled)
 }
 

--- a/pkg/schema/retry_internal_test.go
+++ b/pkg/schema/retry_internal_test.go
@@ -1,0 +1,169 @@
+package schema
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testRetryDelay is what these tests wait between attempts. The retry policy
+// is what is under test, not how long it holds for.
+const testRetryDelay = time.Millisecond
+
+// TestGetRetriesAThrottledRegistry pins that a 429 is a pause rather than the
+// end of the run. The default registry is served from GitHub, which throttles;
+// failing the whole lint on the first one would make a large run a coin toss.
+func TestGetRetriesAThrottledRegistry(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) < 3 {
+			w.Header().Set(retryAfterHeader, "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+
+			return
+		}
+
+		_, _ = w.Write([]byte("served"))
+	}))
+	defer srv.Close()
+
+	store := Store{AllowInsecure: true, retryDelay: testRetryDelay}
+
+	body, err := store.get(t.Context(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "served", string(body))
+	assert.Equal(t, int32(3), requests.Load(), "the throttled attempts should have been retried")
+}
+
+// TestGetGivesUpAfterTheLastAttempt pins that the retries are bounded, and that
+// the error says how many attempts stand behind it: a registry that is simply
+// down should not look like a single unlucky request.
+func TestGetGivesUpAfterTheLastAttempt(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	store := Store{AllowInsecure: true, retryDelay: testRetryDelay}
+
+	_, err := store.get(t.Context(), srv.URL)
+	require.ErrorIs(t, err, errBadStatus)
+	assert.Contains(t, err.Error(), "503")
+	assert.Contains(t, err.Error(), "gave up after 3 attempts")
+	assert.Equal(t, int32(fetchAttempts), requests.Load())
+}
+
+// TestGetDoesNotRetryWhatWillNotChange pins that only a throttle or a
+// server-side failure earns a second request. A 404 is load-bearing -- it is
+// how the extension probe and the next location are reached -- and a 400 says
+// the request itself is wrong, so asking again only spends the rate limit.
+func TestGetDoesNotRetryWhatWillNotChange(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		status int
+	}{
+		{"not found", http.StatusNotFound},
+		{"bad request", http.StatusBadRequest},
+		{"forbidden", http.StatusForbidden},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var requests atomic.Int32
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.WriteHeader(tt.status)
+			}))
+			defer srv.Close()
+
+			store := Store{AllowInsecure: true, retryDelay: testRetryDelay}
+
+			_, err := store.get(t.Context(), srv.URL)
+			require.Error(t, err)
+			assert.Equal(t, int32(1), requests.Load(), "one request is all this status is worth")
+		})
+	}
+}
+
+// TestGetStopsRetryingWhenTheRunIsCancelled pins that a cancelled run does not
+// keep waiting out a backoff nobody is waiting for.
+func TestGetStopsRetryingWhenTheRunIsCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		cancel()
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	// A minute of backoff, which the cancellation has to cut short for this to
+	// return at all.
+	store := Store{AllowInsecure: true, retryDelay: time.Minute}
+
+	_, err := store.get(ctx, srv.URL)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+	for _, tt := range []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"absent", "", 0},
+		{"seconds", "12", 12 * time.Second},
+		{"padded", " 12 ", 12 * time.Second},
+		{"negative seconds", "-12", 0},
+		{"a date ahead", now.Add(30 * time.Second).Format(http.TimeFormat), 30 * time.Second},
+		{"a date already past", now.Add(-time.Hour).Format(http.TimeFormat), 0},
+		{"nonsense", "soon", 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			header := http.Header{}
+			if tt.value != "" {
+				header.Set(retryAfterHeader, tt.value)
+			}
+
+			assert.Equal(t, tt.want, retryAfter(header, now))
+		})
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	t.Parallel()
+
+	base := 500 * time.Millisecond
+
+	assert.Equal(t, base, retryDelay(0, base, 0), "the first wait is the base")
+	assert.Equal(t, 2*base, retryDelay(1, base, 0), "each further wait doubles")
+	assert.Equal(t, 4*time.Second, retryDelay(0, base, 4*time.Second),
+		"what the endpoint asked for wins over the backoff")
+	assert.Equal(t, maxRetryDelay, retryDelay(0, base, time.Hour),
+		"a wait longer than the cap is the cap")
+	assert.Equal(t, maxRetryDelay, retryDelay(20, base, 0), "the backoff is capped too")
+}

--- a/pkg/schema/store.go
+++ b/pkg/schema/store.go
@@ -107,6 +107,10 @@ type Store struct {
 	// Fs is the filesystem local locations are read from. A nil Fs means the
 	// real one. Remote locations go over HTTPClient and ignore it.
 	Fs afero.Fs
+
+	// retryDelay shortens the wait between attempts. It is unexported because
+	// only this package's own tests have a reason to set it.
+	retryDelay time.Duration
 }
 
 // Versions lists every schema the store can serve, newest first. Templated and
@@ -448,15 +452,43 @@ func (s Store) fetch(ctx context.Context, url string) (*Schema, error) {
 }
 
 // get performs the request behind fetch and fetchIndex, and returns what the
-// endpoint served. The body is read here rather than handed to a decoder so
-// that maxRemoteBytes is enforced in one place, and so that a location serving
-// too much is reported as exactly that instead of as a parse failure part-way
-// through a truncated document.
+// endpoint served. A location that throttles or fails transiently is asked
+// again, up to fetchAttempts times; see retry.go for which statuses earn one
+// and how long each wait is.
 func (s Store) get(ctx context.Context, url string) ([]byte, error) {
 	if !s.AllowInsecure && isInsecure(url) {
 		return nil, fmt.Errorf("%w: %s", errInsecureLocation, url)
 	}
 
+	for attempt := 0; ; attempt++ {
+		body, err := s.attempt(ctx, url)
+		if err == nil {
+			return body, nil
+		}
+
+		var status *statusError
+
+		last := attempt == fetchAttempts-1
+		if !errors.As(err, &status) || !status.retryable() || last {
+			if attempt > 0 {
+				return nil, fmt.Errorf("%w (gave up after %d attempts)", err, attempt+1)
+			}
+
+			return nil, err
+		}
+
+		err = sleep(ctx, retryDelay(attempt, s.retryBase(), status.after))
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+// attempt makes one request and returns what it served. The body is read here
+// rather than handed to a decoder so that maxRemoteBytes is enforced in one
+// place, and so that a location serving too much is reported as exactly that
+// instead of as a parse failure part-way through a truncated document.
+func (s Store) attempt(ctx context.Context, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("build request for %s: %w", url, err)
@@ -475,8 +507,24 @@ func (s Store) get(ctx context.Context, url string) ([]byte, error) {
 	case http.StatusNotFound:
 		return nil, errNotFound
 	default:
-		return nil, fmt.Errorf("GET %s: %w %s", url, errBadStatus, resp.Status)
+		return nil, &statusError{
+			url:    url,
+			status: resp.Status,
+			code:   resp.StatusCode,
+			after:  retryAfter(resp.Header, time.Now()),
+		}
 	}
+}
+
+// retryBase is how long the wait after a first failed attempt is. Only a test
+// sets one of its own, so that a retry it is exercising costs milliseconds
+// rather than seconds.
+func (s Store) retryBase() time.Duration {
+	if s.retryDelay > 0 {
+		return s.retryDelay
+	}
+
+	return retryBaseDelay
 }
 
 // readBody reads a response under maxRemoteBytes. One byte past the limit is

--- a/pkg/schema/store.go
+++ b/pkg/schema/store.go
@@ -104,9 +104,17 @@ type Store struct {
 	// anyone able to rewrite one in flight decides what the rules report. Turn
 	// it on for a registry served over loopback, where there is no flight.
 	AllowInsecure bool
-	// Fs is the filesystem local locations are read from. A nil Fs means the
-	// real one. Remote locations go over HTTPClient and ignore it.
+	// Fs is the filesystem local locations are read from, and the on-disk
+	// cache is kept on. A nil Fs means the real one.
 	Fs afero.Fs
+	// NoCache keeps what a registry serves out of the on-disk cache, so every
+	// run fetches it again. It is what to reach for when a published schema
+	// has been corrected under a version already read once.
+	NoCache bool
+	// CacheDir is where what a registry served is kept between runs. An empty
+	// value means $XDG_CACHE_HOME/otelcol-config-lint, or the platform's own
+	// cache directory when the environment names none.
+	CacheDir string
 
 	// retryDelay shortens the wait between attempts. It is unexported because
 	// only this package's own tests have a reason to set it.
@@ -475,7 +483,7 @@ func (s Store) fetchIndex(ctx context.Context, root string) (*Index, error) {
 
 	result := indexResult{index: nil, err: nil}
 
-	body, err := s.get(ctx, join(root, IndexFile))
+	body, err := s.get(ctx, join(root, IndexFile), revalidated)
 	if err == nil {
 		result.index, result.err = ReadIndex(bytes.NewReader(body))
 	} else {
@@ -519,7 +527,7 @@ func isInsecure(loc string) bool {
 
 // fetch reads a schema over the network.
 func (s Store) fetch(ctx context.Context, url string) (*Schema, error) {
-	body, err := s.get(ctx, url)
+	body, err := s.get(ctx, url, immutable)
 	if err != nil {
 		return nil, err
 	}
@@ -528,19 +536,44 @@ func (s Store) fetch(ctx context.Context, url string) (*Schema, error) {
 }
 
 // get performs the request behind fetch and fetchIndex, and returns what the
-// endpoint served. A location that throttles or fails transiently is asked
-// again, up to fetchAttempts times; see retry.go for which statuses earn one
-// and how long each wait is.
-func (s Store) get(ctx context.Context, url string) ([]byte, error) {
+// endpoint served -- or what a previous run did, when the cache holds it and
+// the location is one that does not change under the same URL.
+//
+// A location that throttles or fails transiently is asked again, up to
+// fetchAttempts times; see retry.go for which statuses earn one and how long
+// each wait is.
+func (s Store) get(ctx context.Context, url string, keep freshness) ([]byte, error) {
 	err := s.refuseInsecure(url)
 	if err != nil {
 		return nil, err
 	}
 
+	cache := s.cache()
+
+	cached, etag := s.cached(cache, url, keep)
+	if cached != nil && keep == immutable {
+		return cached, nil
+	}
+
 	for attempt := 0; ; attempt++ {
-		body, err := s.attempt(ctx, url)
+		answer, err := s.attempt(ctx, url, etag)
 		if err == nil {
-			return body, nil
+			if answer.notModified {
+				// Only what was offered can come back unmodified. An endpoint
+				// answering this to a request that offered nothing has served
+				// no body and named nothing to serve instead.
+				if cached == nil {
+					return nil, notModified(url)
+				}
+
+				return cached, nil
+			}
+
+			if cache != nil {
+				cache.save(url, answer.body, answer.etag)
+			}
+
+			return answer.body, nil
 		}
 
 		var status *statusError
@@ -561,6 +594,38 @@ func (s Store) get(ctx context.Context, url string) ([]byte, error) {
 	}
 }
 
+// notModified reports an endpoint answering 304 to a request that offered no
+// validator, which leaves the run with nothing to read.
+func notModified(url string) error {
+	return &statusError{
+		url:    url,
+		status: "304 " + http.StatusText(http.StatusNotModified),
+		code:   http.StatusNotModified,
+		after:  0,
+	}
+}
+
+// cached returns what the cache holds for a URL, and the validator to offer
+// the registry with it. A location whose content cannot change under the same
+// URL is not revalidated, so it carries no validator: the point of caching a
+// published schema is that no request is made at all.
+func (s Store) cached(cache *diskCache, url string, keep freshness) ([]byte, string) {
+	if cache == nil {
+		return nil, ""
+	}
+
+	body, etag, ok := cache.load(url)
+	if !ok {
+		return nil, ""
+	}
+
+	if keep == immutable {
+		return body, ""
+	}
+
+	return body, etag
+}
+
 // refuseInsecure reports the location the store will not read, so that a
 // refusal is raised before anything is fetched -- or remembered.
 func (s Store) refuseInsecure(url string) error {
@@ -571,30 +636,56 @@ func (s Store) refuseInsecure(url string) error {
 	return nil
 }
 
-// attempt makes one request and returns what it served. The body is read here
-// rather than handed to a decoder so that maxRemoteBytes is enforced in one
-// place, and so that a location serving too much is reported as exactly that
-// instead of as a parse failure part-way through a truncated document.
-func (s Store) attempt(ctx context.Context, url string) ([]byte, error) {
+// served is what one attempt came back with: the body, the validator to keep
+// beside it, or word that what the cache already holds still stands.
+type served struct {
+	body []byte
+	// etag validates the body on a later run, and is empty when the endpoint
+	// offered none.
+	etag string
+	// notModified says the endpoint recognised the validator that was offered,
+	// so the cached body is current and was not sent again.
+	notModified bool
+}
+
+// attempt makes one request and returns what it served, offering etag when
+// there is a cached copy to revalidate. The body is read here rather than
+// handed to a decoder so that maxRemoteBytes is enforced in one place, and so
+// that a location serving too much is reported as exactly that instead of as a
+// parse failure part-way through a truncated document.
+func (s Store) attempt(ctx context.Context, url, etag string) (served, error) {
+	none := served{body: nil, etag: "", notModified: false}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
-		return nil, fmt.Errorf("build request for %s: %w", url, err)
+		return none, fmt.Errorf("build request for %s: %w", url, err)
+	}
+
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
 	}
 
 	resp, err := s.client().Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetch %s: %w", url, err)
+		return none, fmt.Errorf("fetch %s: %w", url, err)
 	}
 
 	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return readBody(url, resp.Body)
+		body, err := readBody(url, resp.Body)
+		if err != nil {
+			return none, err
+		}
+
+		return served{body: body, etag: resp.Header.Get("ETag"), notModified: false}, nil
+	case http.StatusNotModified:
+		return served{body: nil, etag: etag, notModified: true}, nil
 	case http.StatusNotFound:
-		return nil, errNotFound
+		return none, errNotFound
 	default:
-		return nil, &statusError{
+		return none, &statusError{
 			url:    url,
 			status: resp.Status,
 			code:   resp.StatusCode,

--- a/pkg/schema/store.go
+++ b/pkg/schema/store.go
@@ -346,7 +346,7 @@ var (
 func (s Store) loadFrom(ctx context.Context, loc, version string) (*Schema, error) {
 	switch kindOf(loc) {
 	case locRemote:
-		return s.loadFromRegistry(loc, version, func(target string) (*Schema, error) {
+		return s.loadFromRegistry(ctx, loc, version, func(target string) (*Schema, error) {
 			return s.fetch(ctx, target)
 		})
 	case locTemplate, locFile:
@@ -355,7 +355,7 @@ func (s Store) loadFrom(ctx context.Context, loc, version string) (*Schema, erro
 		// A directory holding an index is a registry root, laid out by
 		// distribution. Without one it is the flat legacy layout.
 		if s.isRegistryDir(loc) {
-			return s.loadFromRegistry(loc, version, s.readLocal)
+			return s.loadFromRegistry(ctx, loc, version, s.readLocal)
 		}
 
 		return s.loadFlat(loc, version)
@@ -371,10 +371,12 @@ func (s Store) loadOne(ctx context.Context, target string) (*Schema, error) {
 	return s.readLocal(target)
 }
 
-// loadFromRegistry reads "<root>/<distribution>/<version>.<ext>", preferring
-// the readable form when a root carries both.
-func (s Store) loadFromRegistry(root, version string, read func(string) (*Schema, error)) (*Schema, error) {
-	for _, ext := range extensions() {
+// loadFromRegistry reads "<root>/<distribution>/<version>.<ext>", asking the
+// index which extension to use and falling back to trying each in turn.
+func (s Store) loadFromRegistry(
+	ctx context.Context, root, version string, read func(string) (*Schema, error),
+) (*Schema, error) {
+	for _, ext := range s.registryExtensions(ctx, root) {
 		c, err := read(join(root, s.distribution(), version+ext))
 		if err == nil {
 			return c, nil
@@ -386,6 +388,40 @@ func (s Store) loadFromRegistry(root, version string, read func(string) (*Schema
 	}
 
 	return nil, errNotFound
+}
+
+// registryExtensions is the order to look a schema up in: what the index named
+// first, then the rest.
+//
+// The index is only worth consulting for a remote root, where each miss is a
+// request and a 404 the registry counted against the rate limit. Locally a
+// miss is a stat, so the probe costs nothing worth reading a file to avoid.
+// The others stay behind the named one either way: an index can be older than
+// the field, or simply wrong, and the schema is there to be found regardless.
+func (s Store) registryExtensions(ctx context.Context, root string) []string {
+	if kindOf(root) != locRemote {
+		return extensions()
+	}
+
+	idx := s.indexAt(ctx, root)
+	if idx == nil {
+		return extensions()
+	}
+
+	named, ok := idx.Extension(s.distribution())
+	if !ok {
+		return extensions()
+	}
+
+	out := []string{named}
+
+	for _, ext := range extensions() {
+		if ext != named {
+			out = append(out, ext)
+		}
+	}
+
+	return out
 }
 
 // loadFlat reads "<dir>/<version>.<ext>", the layout used before schemas were
@@ -414,15 +450,55 @@ func (s Store) readLocal(path string) (*Schema, error) {
 	return readFile(s.fs(), path)
 }
 
-// fetchIndex reads a remote registry's index.
+// fetchIndex reads a remote registry's index, once per registry.
+//
+// Resolving a version consults the index and so does listing them, so a run
+// that lints against several releases would otherwise fetch the same file once
+// per lookup -- against a rate limit that counts requests, the fetch this
+// field was added to save. A failure is remembered too: a registry that could
+// not answer for the index is not going to answer any faster for being asked
+// again by every version in turn.
 func (s Store) fetchIndex(ctx context.Context, root string) (*Index, error) {
-	body, err := s.get(ctx, join(root, IndexFile))
+	// A location this store may not read is not a fetch, and not an answer to
+	// remember: another store, allowed to read it, would be handed the refusal.
+	err := s.refuseInsecure(root)
 	if err != nil {
 		return nil, err
 	}
 
-	return ReadIndex(bytes.NewReader(body))
+	cached, ok := indexMemo.Load(root)
+	if ok {
+		result, _ := cached.(indexResult)
+
+		return result.index, result.err
+	}
+
+	result := indexResult{index: nil, err: nil}
+
+	body, err := s.get(ctx, join(root, IndexFile))
+	if err == nil {
+		result.index, result.err = ReadIndex(bytes.NewReader(body))
+	} else {
+		result.err = err
+	}
+
+	indexMemo.Store(root, result)
+
+	return result.index, result.err
 }
+
+// indexResult is what one registry's index fetch came to, kept whether it
+// succeeded or not.
+type indexResult struct {
+	index *Index
+	err   error
+}
+
+// indexMemo holds each remote registry's index for the life of the process,
+// keyed by the root it was read from.
+//
+//nolint:gochecknoglobals // a registry has one index, and the point is to fetch it once
+var indexMemo sync.Map
 
 // join appends path segments to a registry root, which is a URL or a local
 // directory. Slashes are right for both: filepath.Join would break URLs on
@@ -456,8 +532,9 @@ func (s Store) fetch(ctx context.Context, url string) (*Schema, error) {
 // again, up to fetchAttempts times; see retry.go for which statuses earn one
 // and how long each wait is.
 func (s Store) get(ctx context.Context, url string) ([]byte, error) {
-	if !s.AllowInsecure && isInsecure(url) {
-		return nil, fmt.Errorf("%w: %s", errInsecureLocation, url)
+	err := s.refuseInsecure(url)
+	if err != nil {
+		return nil, err
 	}
 
 	for attempt := 0; ; attempt++ {
@@ -482,6 +559,16 @@ func (s Store) get(ctx context.Context, url string) ([]byte, error) {
 			return nil, err
 		}
 	}
+}
+
+// refuseInsecure reports the location the store will not read, so that a
+// refusal is raised before anything is fetched -- or remembered.
+func (s Store) refuseInsecure(url string) error {
+	if !s.AllowInsecure && isInsecure(url) {
+		return fmt.Errorf("%w: %s", errInsecureLocation, url)
+	}
+
+	return nil
 }
 
 // attempt makes one request and returns what it served. The body is read here

--- a/pkg/schema/store_test.go
+++ b/pkg/schema/store_test.go
@@ -21,6 +21,22 @@ import (
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 )
 
+// TestMain keeps the on-disk schema cache out of the developer's own cache
+// directory: a test fetching from a local server should not leave anything
+// behind outside its own temporary files.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "schema-cache")
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	_ = os.Setenv("XDG_CACHE_HOME", dir)
+
+	m.Run()
+}
+
 func TestCompare(t *testing.T) {
 	t.Parallel()
 
@@ -750,4 +766,40 @@ func registryServer(t *testing.T, index string, served ...string) (*[]string, *h
 	}))
 
 	return &asked, srv
+}
+
+// TestARegistryIsReadOnceAcrossRuns pins what the cache is for: the schema for
+// a release will never change, so a second run reads it from disk. Against a
+// registry that throttles, re-downloading the same immutable file on every
+// invocation is the worst pattern there is.
+func TestARegistryIsReadOnceAcrossRuns(t *testing.T) {
+	t.Parallel()
+
+	asked, srv := registryServer(t, `{"distributions":{"core":["v0.157.0"]}}`)
+	defer srv.Close()
+
+	// One cache directory, two stores: the second is the next run.
+	dir := t.TempDir()
+
+	for range 2 {
+		store := schema.Store{
+			Locations:     []string{srv.URL},
+			Distribution:  distCore,
+			AllowInsecure: true,
+			CacheDir:      dir,
+		}
+
+		_, err := store.Load(t.Context(), latestVersion)
+		require.NoError(t, err)
+	}
+
+	schemas := 0
+
+	for _, path := range *asked {
+		if strings.HasPrefix(path, "/core/") {
+			schemas++
+		}
+	}
+
+	assert.Equal(t, 1, schemas, "the second run should have read the schema from the cache")
 }

--- a/pkg/schema/store_test.go
+++ b/pkg/schema/store_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -612,4 +613,141 @@ func write(t *testing.T, path, content string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestRemoteRegistryFetchesTheExtensionTheIndexNames pins the request the
+// index saves. A registry publishing JSON used to cost three requests and two
+// 404s for one schema, against a rate limit that counts every one of them.
+func TestRemoteRegistryFetchesTheExtensionTheIndexNames(t *testing.T) {
+	t.Parallel()
+
+	asked, srv := registryServer(t,
+		`{"distributions":{"core":["v0.157.0"]},"extensions":{"core":".json"}}`)
+	defer srv.Close()
+
+	store := schema.Store{Locations: []string{srv.URL}, Distribution: distCore, AllowInsecure: true}
+
+	_, err := store.Load(t.Context(), latestVersion)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"/" + schema.IndexFile, "/core/v0.157.0.json"}, *asked,
+		"the named extension should be fetched outright")
+}
+
+// TestRemoteRegistryProbesAnIndexThatNamesNothing pins the fallback: an index
+// written before the field existed, or one whose releases do not agree on a
+// form, still resolves -- by trying each extension, the way it always did.
+func TestRemoteRegistryProbesAnIndexThatNamesNothing(t *testing.T) {
+	t.Parallel()
+
+	// Published as JSON alone, so the probe has to walk past two misses.
+	asked, srv := registryServer(t, `{"distributions":{"core":["v0.157.0"]}}`, ".json")
+	defer srv.Close()
+
+	store := schema.Store{Locations: []string{srv.URL}, Distribution: distCore, AllowInsecure: true}
+
+	_, err := store.Load(t.Context(), latestVersion)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"/" + schema.IndexFile, "/core/v0.157.0.yaml", "/core/v0.157.0.yml", "/core/v0.157.0.json",
+	}, *asked, "every extension should be probed, in preference order")
+}
+
+// TestRemoteRegistryRefusesAnExtensionItDoesNotRead pins that the index cannot
+// aim a fetch wherever it likes. The value becomes part of a URL and the index
+// comes from the registry, so anything outside the set this package reads is
+// ignored rather than requested.
+func TestRemoteRegistryRefusesAnExtensionItDoesNotRead(t *testing.T) {
+	t.Parallel()
+
+	asked, srv := registryServer(t,
+		`{"distributions":{"core":["v0.157.0"]},"extensions":{"core":"/../../etc/passwd"}}`)
+	defer srv.Close()
+
+	store := schema.Store{Locations: []string{srv.URL}, Distribution: distCore, AllowInsecure: true}
+
+	_, err := store.Load(t.Context(), latestVersion)
+	require.NoError(t, err)
+
+	for _, path := range *asked {
+		assert.NotContains(t, path, "passwd", "the index should not decide what is fetched")
+	}
+}
+
+// TestRemoteRegistryReadsItsIndexOnce pins that resolving several versions
+// does not re-fetch the file that says which versions there are. Against a
+// rate limit that counts requests, an index fetched per lookup would spend
+// more than the extension it names saves.
+func TestRemoteRegistryReadsItsIndexOnce(t *testing.T) {
+	t.Parallel()
+
+	asked, srv := registryServer(t,
+		`{"distributions":{"core":["v0.157.0"]},"extensions":{"core":".json"}}`)
+	defer srv.Close()
+
+	store := schema.Store{Locations: []string{srv.URL}, Distribution: distCore, AllowInsecure: true}
+
+	for range 3 {
+		_, err := store.Load(t.Context(), schema.Latest)
+		require.NoError(t, err)
+	}
+
+	indexes := 0
+
+	for _, path := range *asked {
+		if path == "/"+schema.IndexFile {
+			indexes++
+		}
+	}
+
+	assert.Equal(t, 1, indexes, "the index should be read once per registry, not once per lookup")
+}
+
+// registryServer serves a registry holding one core schema under the given
+// index, published in the named forms (every form when none are named), and
+// records the paths it was asked for.
+func registryServer(t *testing.T, index string, served ...string) (*[]string, *httptest.Server) {
+	t.Helper()
+
+	if len(served) == 0 {
+		served = schema.Extensions()
+	}
+
+	var (
+		lock  sync.Mutex
+		asked []string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lock.Lock()
+
+		asked = append(asked, r.URL.Path)
+
+		lock.Unlock()
+
+		if r.URL.Path == "/"+schema.IndexFile {
+			_, _ = w.Write([]byte(index))
+
+			return
+		}
+
+		for _, ext := range served {
+			if r.URL.Path != "/core/"+latestVersion+ext {
+				continue
+			}
+
+			if ext == ".json" {
+				_, _ = w.Write([]byte(`{"collectorVersion":"v0.157.0","distribution":"core","components":{}}`))
+			} else {
+				_, _ = w.Write([]byte("collectorVersion: v0.157.0\ndistribution: core\ncomponents: {}\n"))
+			}
+
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	return &asked, srv
 }

--- a/pkg/settings/jsonschema.go
+++ b/pkg/settings/jsonschema.go
@@ -99,6 +99,12 @@ func runSchema() object {
 				"what the rules report.",
 			"type": "boolean",
 		},
+		"noCache": object{
+			"description": "Fetch schemas again instead of reading the ones kept from earlier runs. " +
+				"A published schema does not change under its version, so it is kept between runs; " +
+				"this is what picks up a correction to one already read.",
+			"type": "boolean",
+		},
 		"strict": object{
 			"description": "Report unknown component settings as errors instead of warnings.",
 			"type":        "boolean",

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -88,6 +88,10 @@ type RunBlock struct {
 	// otherwise refused: a schema states which components exist, so a transport
 	// anyone can rewrite decides what the rules report.
 	InsecureSchemaLocation *bool `yaml:"insecureSchemaLocation"`
+	// NoCache fetches schemas again rather than reading the ones kept from
+	// earlier runs, which is what picks up a correction to a schema already
+	// published under a version this machine has read.
+	NoCache *bool `yaml:"noCache"`
 	// Strict reports unknown component settings as errors.
 	Strict *bool `yaml:"strict"`
 	// IgnoreMissingSchemas keeps components absent from the schema from


### PR DESCRIPTION
Closes #72.

The fetch path had no answer for a registry that throttles, made more requests
than it needed to, and re-downloaded the same immutable files on every run.
Three commits, one per part.

## Retry a throttled or briefly failing registry

A single 429 or 503 failed the whole lint: anything that was not 200 or 404 was
terminal, and `Retry-After` went unread. A 429 or a 5xx is now asked again --
three attempts, waiting as long as the endpoint asked for and otherwise backing
off from half a second. Everything else stays terminal: a 404 is how the
extension probe and the next location are reached, and a 400 says the request
itself is wrong. A cancelled run stops waiting, and the error that ends a losing
streak says how many attempts stand behind it.

A transport failure is still terminal. Whether a reset connection would answer a
second time is not knowable from here, while a 429 says so outright.

## One request per schema, not three

`index.json` now records the extension each distribution's schemas should be
fetched with, and `schemagen` writes it from what the registry holds -- the
preferred form every release carries, or nothing when the releases disagree and
no single answer would be right. A fetch asks the index first and probes only
when it has no answer, so an index written before this field resolves exactly as
it did. What the index names is held to the extensions this package reads: the
value goes into a URL and the index comes from the registry.

The index itself is now read once per registry rather than once per lookup --
otherwise it would cost more than the extension it names saves.

## Keep what was served

Fetched schemas are kept under `$XDG_CACHE_HOME/otelcol-config-lint` (the
platform's own cache directory when the environment names none). A published
schema is immutable under its version, so a second run reads it from disk
without asking; the index, which grows a line per release, is offered back with
its ETag, so an up-to-date run pays a 304 rather than the file.

The cache never decides whether a run works: an entry that cannot be read or
written is a fetch that goes to the network, not an error. Entries are keyed by
a digest of the URL, and each is written and renamed into place.

`--no-cache` (`run.noCache`) reads nothing and keeps nothing, which is what
picks up a correction to a schema already read. The action leaves the flag out:
a fresh container has no cache to read.

Against the real registry, a repeat run of `run --collector-version v0.157.0`
goes from ~0.84s to ~0.14s, and the 3.6 MB schema is read from disk.

## Testing

- `go test ./...` and `golangci-lint run` pass.
- New tests cover the retry policy (which statuses earn one, `Retry-After` in
  both forms, the backoff and its cap, cancellation), the extension the index
  names (used, refused when it is not one we read, probed when absent, and read
  once), and the cache (immutable served without asking, ETag revalidation in
  both directions, `--no-cache`, and an unwritable cache still being a fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z