### PR TITLE
feat(schema): let the registry say which releases ship a component

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,11 +736,12 @@ otelcol-config-lint run --schema-location ../otelcol-config-schemas config.yaml
 ```
 
 A location is a registry directory or URL (one holding `index.json`, laid out
-as `<distribution>/<version>.<ext>`), a `{{.Version}}`/`{{.Distribution}}`
-template naming a single file, or `default` for the published registry. Repeat
-the flag to search several in order, so a private distribution's schema can take
-precedence over the public ones, or so a vendored copy answers before the
-network is tried.
+as `<distribution>/<version>.<ext>`, optionally with the `components.json`
+described [below](#which-releases-have-a-component)), a
+`{{.Version}}`/`{{.Distribution}}` template naming a single file, or `default`
+for the published registry. Repeat the flag to search several in order, so a
+private distribution's schema can take precedence over the public ones, or so a
+vendored copy answers before the network is tried.
 
 A remote location must be `https://`. The schema is what every rule reasons
 from — which components exist, which settings they take — so anyone able to
@@ -749,6 +750,28 @@ location is refused unless `--insecure-schema-location` says otherwise, which
 is there for a registry served on localhost. One download is capped at 32 MiB,
 so a registry that is hostile or merely broken cannot stream the linter out of
 memory.
+
+### Which releases have a component
+
+An unknown component is worth explaining — `"logging" exists in v0.110.0 but
+not in v0.157.0` says something a "did you mean" cannot — but the question is
+about every release at once, and a schema describes one. Answering it by
+reading them is a multi-megabyte download per release, tens of them, to produce
+a single line of hint, and against a rate limit that counts requests it is the
+shape most likely to be throttled.
+
+So the registry publishes `components.json` beside the index: the releases each
+component type is shipped in, per distribution, as one document read in one
+request. It is only read by a run that actually meets an unknown component, and
+it is written as spans (`from`, and `to` once the component is gone), so a new
+release does not rewrite the entry of everything it left alone.
+
+A registry publishing none is still read the old way, one schema per release —
+without limit for a directory on disk, and no further back than the twelve
+newest releases over the network, which are the ones a hint is usually about. A
+walk that lost half its releases to a throttled registry reports nothing rather
+than naming whichever release happened to answer: a hint that is quietly wrong
+is worse than no hint at all.
 
 ### Caching
 
@@ -799,9 +822,13 @@ repository, along with the `index.json` listing them. The index also records
 the extension each distribution's schemas should be fetched with, so reading
 one over the network costs a single request instead of probing `.yaml`, `.yml`
 and `.json` in turn; a distribution whose releases do not agree on one form
-names none, and is probed as before. The download goes through
-the `go` command, so `GOPROXY`, `GOPRIVATE` and whatever credentials this
-machine builds with apply unchanged: a **private component resolves exactly as
+names none, and is probed as before. `components.json` is written beside it,
+from the schemas the registry is left holding, so that
+[an unknown component can be placed](#which-releases-have-a-component) without
+downloading the registry; a distribution whose releases could not all be read is
+left out of it rather than described from half of them. The download goes
+through the `go` command, so `GOPROXY`, `GOPRIVATE` and whatever credentials
+this machine builds with apply unchanged: a **private component resolves exactly as
 it does for the build that consumes it**, and a `replaces:` entry pointing at a
 checkout is read from there. A component that ships no `metadata.yaml` is still
 recorded, from what the manifest says, so a config naming it is not reported as

--- a/pkg/cmd/schemagen/schemagen.go
+++ b/pkg/cmd/schemagen/schemagen.go
@@ -395,7 +395,8 @@ func (o *Options) registerBuilderFlag(cmd *cobra.Command) {
 //
 // Pruning runs before the index so the index is written from what the registry
 // is left holding, which is the whole point of rebuilding it by listing the
-// directory rather than editing it.
+// directory rather than editing it. The availability index follows the index,
+// so both describe the same releases.
 func (o *Options) publishRegistry() error {
 	if o.registryDir == "" {
 		return nil
@@ -406,7 +407,12 @@ func (o *Options) publishRegistry() error {
 		return err
 	}
 
-	return o.writeIndex()
+	idx, err := o.writeIndex()
+	if err != nil {
+		return err
+	}
+
+	return o.writeComponents(idx)
 }
 
 // checkDestination settles where the schemas are written. A run either writes

--- a/pkg/cmd/schemagen/schemagen_test.go
+++ b/pkg/cmd/schemagen/schemagen_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/cmd/schemagen"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 )
 
@@ -439,6 +440,74 @@ func TestIndexNamesTheExtensionPublished(t *testing.T) {
 
 	_, named = regenerated.Extension("custom")
 	assert.False(t, named, "releases that disagree on a form should name none")
+}
+
+// TestPublishesComponentAvailability covers the document that answers "exists
+// in v0.110.0 but not in v0.157.0". Without it the only way to know is to read
+// every schema the registry serves, which against the published one is a
+// multi-megabyte download per release to produce a single hint.
+func TestPublishesComponentAvailability(t *testing.T) {
+	t.Parallel()
+
+	modules, out := t.TempDir(), t.TempDir()
+	manifest := singleComponentManifest(t, modules)
+
+	// An older release the registry already held, carrying a component this
+	// one no longer ships.
+	require.NoError(t, os.MkdirAll(filepath.Join(out, "custom"), 0o750))
+	writeFile(t, filepath.Join(out, "custom", "v0.150.0.yaml"),
+		"collectorVersion: v0.150.0\ndistribution: custom\ncomponents:\n"+
+			"  receiver:\n    otlp:\n      type: otlp\n    logging:\n      type: logging\n")
+
+	code, _, stderr := run(t, "--builder", "custom="+manifest, "--registry", out,
+		"--formats", "yaml", "--cache", t.TempDir())
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+
+	var comps schema.Components
+
+	require.NoError(t, json.Unmarshal(
+		[]byte(readFile(t, filepath.Join(out, schema.ComponentsFile))), &comps))
+
+	spans := comps.Distributions["custom"][config.KindReceiver]
+
+	// A component the newest release still ships ends its span open, so adding
+	// a release does not rewrite the entry of everything it left alone.
+	assert.Equal(t, []schema.Span{{From: "v0.150.0", To: ""}}, spans["otlp"])
+	assert.Equal(t, []schema.Span{{From: "v0.150.0", To: "v0.150.0"}}, spans["logging"],
+		"a dropped component should be named as ending where it ended")
+
+	// Read back the way a linter reads it: the releases each component is in,
+	// oldest first.
+	avail := comps.Expand("custom", []string{"v0.157.0", "v0.150.0"})
+	assert.Equal(t, []string{"v0.150.0", "v0.157.0"}, avail[config.KindReceiver]["otlp"])
+	assert.Equal(t, []string{"v0.150.0"}, avail[config.KindReceiver]["logging"])
+}
+
+// TestAvailabilityLeavesOutWhatItCouldNotRead pins that a distribution is
+// described from every release it serves or not at all: a release missing from
+// the walk would read as a component dropped and added back, and a reader that
+// finds no entry falls back to the schemas instead.
+func TestAvailabilityLeavesOutWhatItCouldNotRead(t *testing.T) {
+	t.Parallel()
+
+	modules, out := t.TempDir(), t.TempDir()
+	manifest := singleComponentManifest(t, modules)
+
+	// A release the index will list and no schema can be read from.
+	require.NoError(t, os.MkdirAll(filepath.Join(out, "custom"), 0o750))
+	writeFile(t, filepath.Join(out, "custom", "v0.150.0.yaml"), "collectorVersion: v0.150.0\ncomponents: [\n")
+
+	code, _, stderr := run(t, "--builder", "custom="+manifest, "--registry", out,
+		"--formats", "yaml", "--cache", t.TempDir())
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+	assert.Contains(t, stderr, "no availability published",
+		"a distribution left out of the document should say so")
+
+	var comps schema.Components
+
+	require.NoError(t, json.Unmarshal(
+		[]byte(readFile(t, filepath.Join(out, schema.ComponentsFile))), &comps))
+	assert.False(t, comps.Has("custom"), "a half-read distribution should not be described")
 }
 
 // TestWritesOneFile covers the single-manifest form: the schema goes where

--- a/pkg/cmd/schemagen/write.go
+++ b/pkg/cmd/schemagen/write.go
@@ -1,12 +1,14 @@
 package schemagen
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 )
 
@@ -73,13 +75,14 @@ func (o *Options) writeRegistry(cat *schema.Schema, formats []schema.Format) err
 	return nil
 }
 
-// writeIndex records what the registry can serve. It is rebuilt by listing the
-// registry directory, not from the manifests generated in this run, so
+// writeIndex records what the registry can serve, and returns it so that what
+// is published beside it describes the same releases. It is rebuilt by listing
+// the registry directory, not from the manifests generated in this run, so
 // regenerating one distribution leaves the others listed.
-func (o *Options) writeIndex() error {
+func (o *Options) writeIndex() (*schema.Index, error) {
 	entries, err := os.ReadDir(o.registryDir)
 	if err != nil {
-		return fmt.Errorf("read %s: %w", o.registryDir, err)
+		return nil, fmt.Errorf("read %s: %w", o.registryDir, err)
 	}
 
 	idx := &schema.Index{Distributions: map[string][]string{}, Extensions: map[string]string{}}
@@ -107,23 +110,143 @@ func (o *Options) writeIndex() error {
 
 	dest := filepath.Join(o.registryDir, schema.IndexFile)
 
+	err = writeDoc(dest, idx.Write)
+	if err != nil {
+		return nil, err
+	}
+
+	o.logf("wrote %s (%d distributions)\n", dest, len(idx.Distributions))
+
+	return idx, nil
+}
+
+// writeComponents records which releases ship each component type, so that a
+// linter meeting a component the targeted release does not have can say where
+// it does exist without downloading every schema in the registry to find out.
+//
+// It is rebuilt from the schemas the registry is left holding, for the same
+// reason the index is: a run that regenerated one distribution must not
+// republish the others from what this run happens to have in hand.
+func (o *Options) writeComponents(idx *schema.Index) error {
+	comps := &schema.Components{Distributions: map[string]schema.ComponentSpans{}}
+
+	for _, dist := range idx.Names() {
+		versions := idx.Versions(dist)
+
+		spans, err := o.spansIn(dist, versions)
+		if err != nil {
+			// A distribution whose releases could not all be read is left out
+			// rather than described from the ones that could: a release
+			// missing from the walk reads as a component that was dropped and
+			// added back. A reader that finds no entry falls back to the
+			// schemas, which is where it was before this file existed.
+			o.logf("  %s: no availability published (%v)\n", dist, err)
+
+			continue
+		}
+
+		comps.Distributions[dist] = spans
+	}
+
+	dest := filepath.Join(o.registryDir, schema.ComponentsFile)
+
+	err := writeDoc(dest, comps.Write)
+	if err != nil {
+		return err
+	}
+
+	o.logf("wrote %s (%d distributions)\n", dest, len(comps.Distributions))
+
+	return nil
+}
+
+// spansIn works out which of a distribution's releases ship each component
+// type, by reading every schema the registry holds for it.
+func (o *Options) spansIn(dist string, versions []string) (schema.ComponentSpans, error) {
+	// kind -> type -> the releases shipping it.
+	present := map[config.Kind]map[string]map[string]bool{}
+
+	for _, v := range versions {
+		cat, err := readRegistrySchema(filepath.Join(o.registryDir, dist), v)
+		if err != nil {
+			return nil, err
+		}
+
+		for kind, byType := range cat.Components {
+			byName, ok := present[kind]
+			if !ok {
+				byName = map[string]map[string]bool{}
+				present[kind] = byName
+			}
+
+			for typ := range byType {
+				if byName[typ] == nil {
+					byName[typ] = map[string]bool{}
+				}
+
+				byName[typ][v] = true
+			}
+		}
+	}
+
+	out := schema.ComponentSpans{}
+
+	for kind, byType := range present {
+		out[kind] = make(map[string][]schema.Span, len(byType))
+
+		for typ, releases := range byType {
+			out[kind][typ] = schema.SpansOf(versions, releases)
+		}
+	}
+
+	return out, nil
+}
+
+// readRegistrySchema reads one release out of a distribution's directory,
+// whichever form it was published in. JSON comes first here, unlike everywhere
+// else: this reads the whole registry rather than one file, and the two forms
+// hold the same schema.
+func readRegistrySchema(dir, version string) (*schema.Schema, error) {
+	exts := []string{".json"}
+
+	for _, ext := range schema.Extensions() {
+		if ext != ".json" {
+			exts = append(exts, ext)
+		}
+	}
+
+	for _, ext := range exts {
+		path := filepath.Join(dir, version+ext)
+
+		_, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+
+		return schema.ReadFile(path)
+	}
+
+	return nil, fmt.Errorf("%w: %s", errNoSchemaFile, filepath.Join(dir, version))
+}
+
+// errNoSchemaFile reports a release the index lists but the registry has no
+// file for, which is a registry the run should not describe as if it did.
+var errNoSchemaFile = errors.New("no schema file")
+
+// writeDoc writes one of the documents published beside the schemas, replacing
+// whatever was there before.
+func writeDoc(dest string, encode func(io.Writer) error) error {
 	f, err := os.Create(dest)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", dest, err)
 	}
 
-	err = idx.Write(f)
+	err = encode(f)
 	if cerr := f.Close(); err == nil {
 		err = cerr
 	}
 
-	if err != nil {
-		return err
-	}
-
-	o.logf("wrote %s (%d distributions)\n", dest, len(idx.Distributions))
-
-	return nil
+	return err
 }
 
 // extensionIn returns the file extension a distribution's schemas should be

--- a/pkg/lint/availability.go
+++ b/pkg/lint/availability.go
@@ -2,15 +2,24 @@ package lint
 
 import (
 	"context"
+	"slices"
 	"sync"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 )
 
-// VersionIndex answers which collector releases ship a component type, by
-// consulting every schema a store can serve. It is built on first use, so runs
-// that never hit an unknown component pay nothing for it.
+// VersionIndex answers which collector releases ship a component type. It is
+// built on first use, so runs that never hit an unknown component pay nothing
+// for it.
+//
+// The answer comes from the availability index a registry publishes, which
+// covers every release it serves in one document. Only a registry that
+// publishes none is answered by reading the schemas themselves, and then only
+// as far as walkLimit allows: a schema is a multi-megabyte document per
+// release, so working the answer out that way costs the whole registry to
+// produce a single "added in ..." hint, and does it against the rate limit
+// most likely to refuse it.
 type VersionIndex struct {
 	store schema.Store
 
@@ -23,6 +32,15 @@ type versionKey struct {
 	typ  string
 }
 
+// walkLimit is how many releases the fallback reads when each one is a
+// download. The newest releases are the ones a hint is usually about -- a
+// component added recently, or one dropped recently -- and a hint is worth a
+// handful of requests, not a hundred megabytes.
+//
+// A local registry is not bounded by it: there the walk is a file read per
+// release, and the complete answer costs no more than a partial one.
+const walkLimit = 12
+
 // NewVersionIndex returns an index over the schemas in store.
 func NewVersionIndex(store schema.Store) *VersionIndex {
 	return &VersionIndex{store: store, once: sync.Once{}, byKey: nil}
@@ -30,10 +48,10 @@ func NewVersionIndex(store schema.Store) *VersionIndex {
 
 // Versions returns the schema versions containing the component, oldest first.
 //
-// The context is the asking run's: the first question is what walks the store,
-// which for a remote registry means a fetch per release. It is built once, so
-// the first question's context is the one that build runs under; a later
-// question is answered from the map.
+// The context is the asking run's: the first question is what consults the
+// store, which for a remote registry means a fetch. It is built once, so the
+// first question's context is the one that build runs under; a later question
+// is answered from the map.
 func (v *VersionIndex) Versions(ctx context.Context, k config.Kind, typ string) []string {
 	v.once.Do(func() { v.build(ctx) })
 
@@ -42,20 +60,66 @@ func (v *VersionIndex) Versions(ctx context.Context, k config.Kind, typ string) 
 
 func (v *VersionIndex) build(ctx context.Context) {
 	v.byKey = map[versionKey][]string{}
+
+	if v.published(ctx) {
+		return
+	}
+
+	v.walk(ctx)
+}
+
+// published fills the index from the availability index the registry publishes,
+// and reports whether there was one to read.
+func (v *VersionIndex) published(ctx context.Context) bool {
+	avail := v.store.Availability(ctx)
+	if avail == nil {
+		return false
+	}
+
+	for kind, byType := range avail {
+		for typ, versions := range byType {
+			v.byKey[versionKey{kind, typ}] = versions
+		}
+	}
+
+	return true
+}
+
+// walk fills the index by reading the schemas, for a registry that publishes no
+// availability index of its own.
+func (v *VersionIndex) walk(ctx context.Context) {
 	versions := v.store.Versions(ctx)
-	// Store.Versions is newest first; walk backwards so results read oldest
-	// first, which is how a "added in ..." hint wants to be read.
-	for i := len(versions) - 1; i >= 0; i-- {
-		c, err := v.store.Load(ctx, versions[i])
+	// Store.Versions is newest first, so a bound keeps the newest releases,
+	// and walking backwards makes results read oldest first, which is how an
+	// "added in ..." hint wants to be read.
+	if v.store.Remote() && len(versions) > walkLimit {
+		versions = versions[:walkLimit]
+	}
+
+	failed := 0
+
+	for _, version := range slices.Backward(versions) {
+		c, err := v.store.Load(ctx, version)
 		if err != nil {
+			failed++
+
 			continue
 		}
 
 		for kind, byType := range c.Components {
 			for typ := range byType {
 				key := versionKey{kind, typ}
-				v.byKey[key] = append(v.byKey[key], versions[i])
+				v.byKey[key] = append(v.byKey[key], version)
 			}
 		}
+	}
+
+	// A registry that answered for half its releases cannot say where a
+	// component came from or when it went: whichever release throttling
+	// happened to drop is the one the hint would name. Nothing is a better
+	// answer than a plausible wrong one, so the index is emptied and the
+	// finding falls back to the hint it has without one.
+	if failed*2 >= len(versions) {
+		v.byKey = map[versionKey][]string{}
 	}
 }

--- a/pkg/lint/availability_test.go
+++ b/pkg/lint/availability_test.go
@@ -1,0 +1,229 @@
+package lint_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/lint"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// walkLimit is the bound the index puts on reading schemas one release at a
+// time, kept here so the assertions below say what they are testing. It is
+// lint's own constant; a test naming another number is a test of nothing.
+const walkLimit = 12
+
+// TestVersionIndexAsksThePublishedAvailability covers what the whole document
+// is for: one unknown component used to download every schema in the registry,
+// which for the published one is a hundred megabytes to produce a single hint.
+func TestVersionIndexAsksThePublishedAvailability(t *testing.T) {
+	t.Parallel()
+
+	srv, asked := availabilityServer(t, map[string]string{
+		schema.IndexFile: `{"distributions":{"contrib":["v0.157.0","v0.150.0","v0.110.0"]},` +
+			`"extensions":{"contrib":".json"}}`,
+		schema.ComponentsFile: `{"distributions":{"contrib":{"receiver":{` +
+			`"otlp":[{"from":"v0.110.0"}],"logging":[{"from":"v0.110.0","to":"v0.150.0"}]}}}}`,
+	})
+	defer srv.Close()
+
+	index := lint.NewVersionIndex(remoteStore(srv.URL))
+
+	assert.Equal(t, []string{"v0.110.0", "v0.150.0"},
+		index.Versions(t.Context(), config.KindReceiver, "logging"),
+		"the hint should name the releases the component was shipped in")
+	assert.Equal(t, []string{"v0.110.0", "v0.150.0", "v0.157.0"},
+		index.Versions(t.Context(), config.KindReceiver, "otlp"))
+	assert.Empty(t, index.Versions(t.Context(), config.KindReceiver, "nosuch"))
+
+	assert.Empty(t, asked(t, "/contrib/"),
+		"a published availability index should answer without reading a schema")
+}
+
+// TestVersionIndexFallsBackToTheSchemas covers a registry published before the
+// availability index existed, and the checkout of one: the answer is still
+// there, worked out from the schemas themselves.
+func TestVersionIndexFallsBackToTheSchemas(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	localRegistry(t, root, "v0.157.0", "v0.110.0")
+
+	index := lint.NewVersionIndex(schema.Store{Locations: []string{root}})
+
+	// filelog is written into the older release alone, so the walk has to say
+	// where a dropped component did exist.
+	assert.Equal(t, []string{"v0.110.0"},
+		index.Versions(t.Context(), config.KindReceiver, "filelog"))
+	assert.Equal(t, []string{"v0.110.0", "v0.157.0"},
+		index.Versions(t.Context(), config.KindReceiver, "otlp"))
+}
+
+// TestVersionIndexBoundsTheWalkItPaysFor pins the cost of that fallback
+// against a remote registry, where every release read is a multi-megabyte
+// download: the newest releases are what a hint is usually about, and the rest
+// are not worth the requests.
+func TestVersionIndexBoundsTheWalkItPaysFor(t *testing.T) {
+	t.Parallel()
+
+	const releases = walkLimit + 8
+
+	files := map[string]string{schema.ComponentsFile: ""} // published by no registry of this age
+
+	versions := make([]string, 0, releases)
+
+	for i := range releases {
+		v := fmt.Sprintf("v0.%d.0", 157-i)
+		versions = append(versions, v)
+		files["contrib/"+v+".json"] = `{"collectorVersion":"` + v + `","distribution":"contrib",` +
+			`"components":{"receiver":{"otlp":{"type":"otlp"}}}}`
+	}
+
+	listed, err := json.Marshal(versions)
+	require.NoError(t, err)
+
+	files[schema.IndexFile] = `{"distributions":{"contrib":` + string(listed) + `},` +
+		`"extensions":{"contrib":".json"}}`
+
+	srv, asked := availabilityServer(t, files)
+	defer srv.Close()
+
+	index := lint.NewVersionIndex(remoteStore(srv.URL))
+
+	got := index.Versions(t.Context(), config.KindReceiver, "otlp")
+	assert.Len(t, got, walkLimit, "the walk read more releases than it is allowed to")
+	assert.Equal(t, versions[0], got[len(got)-1], "the newest release should be among them")
+	assert.NotContains(t, got, versions[len(versions)-1],
+		"the oldest releases are what the bound gives up")
+	assert.Len(t, asked(t, "/contrib/"), walkLimit)
+}
+
+// TestVersionIndexDropsAWalkItCouldNotFinish covers the failure the hint used
+// to hide: a throttled registry drops releases from the walk, and whichever
+// one it dropped is the one the hint would have named. Nothing is a better
+// answer than a plausible wrong one.
+func TestVersionIndexDropsAWalkItCouldNotFinish(t *testing.T) {
+	t.Parallel()
+
+	versions := []string{"v0.157.0", "v0.150.0", "v0.140.0", "v0.110.0"}
+	files := map[string]string{
+		schema.IndexFile: `{"distributions":{"contrib":["v0.157.0","v0.150.0","v0.140.0","v0.110.0"]},` +
+			`"extensions":{"contrib":".json"}}`,
+		schema.ComponentsFile: "",
+	}
+
+	// The two oldest releases answer; the newer ones are throttled, which is
+	// the shape a rate limit takes when a walk asks for a registry at once.
+	for _, v := range versions[2:] {
+		files["contrib/"+v+".json"] = `{"collectorVersion":"` + v + `","distribution":"contrib",` +
+			`"components":{"receiver":{"otlp":{"type":"otlp"}}}}`
+	}
+
+	srv, _ := availabilityServer(t, files)
+	defer srv.Close()
+
+	index := lint.NewVersionIndex(remoteStore(srv.URL))
+
+	assert.Empty(t, index.Versions(t.Context(), config.KindReceiver, "otlp"),
+		"half a registry cannot say where a component was added")
+}
+
+// remoteStore reads a registry served by one of the test servers below. The
+// cache is off: what a test served should not outlive it.
+func remoteStore(url string) schema.Store {
+	return schema.Store{Locations: []string{url}, AllowInsecure: true, NoCache: true}
+}
+
+// availabilityServer serves a registry from the files it is given, recording
+// what was asked for. A file with empty content is one the registry does not
+// publish; every other path is answered as throttled, which is what a registry
+// under a rate limit does.
+func availabilityServer(t *testing.T, files map[string]string) (*httptest.Server, func(*testing.T, string) []string) {
+	t.Helper()
+
+	var (
+		lock  sync.Mutex
+		asked []string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lock.Lock()
+
+		asked = append(asked, r.URL.Path)
+
+		lock.Unlock()
+
+		body, ok := files[strings.TrimPrefix(r.URL.Path, "/")]
+
+		switch {
+		case ok && body != "":
+			_, _ = w.Write([]byte(body))
+		case ok:
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			// 403 is what GitHub answers a rate-limited reader with, and is not
+			// retried, so a test spends no time waiting on it.
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}))
+
+	return srv, func(t *testing.T, prefix string) []string {
+		t.Helper()
+
+		lock.Lock()
+		defer lock.Unlock()
+
+		var out []string
+
+		for _, path := range asked {
+			if strings.HasPrefix(path, prefix) {
+				out = append(out, path)
+			}
+		}
+
+		return out
+	}
+}
+
+// localRegistry writes a registry directory holding one contrib schema per
+// release. The oldest carries filelog as well, so a walk has a component that
+// was dropped along the way to report on.
+func localRegistry(t *testing.T, root string, versions ...string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "contrib"), 0o750))
+
+	listed, err := json.Marshal(versions)
+	require.NoError(t, err)
+
+	writeAt(t, filepath.Join(root, schema.IndexFile),
+		`{"distributions":{"contrib":`+string(listed)+`}}`)
+
+	for i, v := range versions {
+		components := `"otlp":{"type":"otlp"}`
+		if i == len(versions)-1 {
+			components += `,"filelog":{"type":"filelog"}`
+		}
+
+		writeAt(t, filepath.Join(root, "contrib", v+".json"),
+			`{"collectorVersion":"`+v+`","distribution":"contrib",`+
+				`"components":{"receiver":{`+components+`}}}`)
+	}
+}
+
+func writeAt(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}

--- a/pkg/schema/components.go
+++ b/pkg/schema/components.go
@@ -1,0 +1,215 @@
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/spf13/afero"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+)
+
+// ComponentsFile is the name a registry publishes its component availability
+// index under.
+const ComponentsFile = "components.json"
+
+// Components says which releases ship each component type. It is what answers
+// "exists in v0.110.0 but not in v0.157.0" without reading a schema: the
+// question is about every release at once, and a schema describes one, so
+// asking them one by one means downloading the whole registry to learn a
+// single date.
+//
+// It is published beside the index rather than inside it because the index is
+// read by every run, and this document only by a run that met a component the
+// targeted release does not have.
+type Components struct {
+	// Distributions maps each distribution to the components it has shipped.
+	// Coverage differs between them, the same way it does in the index: a
+	// component in contrib says nothing about core.
+	Distributions map[string]ComponentSpans `json:"distributions"`
+}
+
+// ComponentSpans is one distribution's components, indexed by kind
+// ("receiver", "processor", ...) and then by component type ("otlp",
+// "batch", ...).
+type ComponentSpans map[config.Kind]map[string][]Span
+
+// Span is a run of consecutive releases shipping one component type.
+//
+// Releases rather than a list of versions because a component is added once
+// and then carried: a span stays one line as the registry grows, where a list
+// would gain an entry per component per release, and adding a release would
+// rewrite every line of the file.
+type Span struct {
+	// From is the oldest release in the run.
+	From string `json:"from"`
+	// To is the newest. It is left out while the component is still shipped,
+	// which is the usual case and keeps a new release from touching the entry
+	// of every component that release did not change.
+	To string `json:"to,omitempty"`
+}
+
+// Covers reports whether a release falls inside the span. An open span covers
+// everything from its start on, which is what "still shipped" means when the
+// answer is read against the releases the registry serves now.
+func (s Span) Covers(version string) bool {
+	if Compare(version, s.From) < 0 {
+		return false
+	}
+
+	return s.To == "" || Compare(version, s.To) <= 0
+}
+
+// SpansOf collapses the releases a component appears in into spans. releases
+// is every release the distribution serves, in any order; present says which
+// of them ship the component.
+//
+// The newest release ends its span open rather than named, so that the entry
+// of a component that is still shipped does not change when the next release
+// is added.
+func SpansOf(releases []string, present map[string]bool) []Span {
+	ordered := oldestFirst(releases)
+
+	var spans []Span
+
+	cur := -1
+
+	for _, v := range ordered {
+		if !present[v] {
+			cur = -1
+
+			continue
+		}
+
+		if cur < 0 {
+			spans = append(spans, Span{From: v, To: v})
+			cur = len(spans) - 1
+
+			continue
+		}
+
+		spans[cur].To = v
+	}
+
+	if len(spans) > 0 && len(ordered) > 0 && spans[len(spans)-1].To == ordered[len(ordered)-1] {
+		spans[len(spans)-1].To = ""
+	}
+
+	return spans
+}
+
+// Expand returns which of releases ship each of a distribution's component
+// types, oldest first, which is how an "added in ..." hint wants to be read.
+// An unknown distribution has none.
+//
+// The releases are the caller's rather than the ones the document was written
+// against: a registry that has since dropped an old release should not be
+// quoted as still serving it.
+func (c *Components) Expand(distribution string, releases []string) map[config.Kind]map[string][]string {
+	byKind, ok := c.Distributions[distribution]
+	if !ok {
+		return nil
+	}
+
+	ordered := oldestFirst(releases)
+	out := make(map[config.Kind]map[string][]string, len(byKind))
+
+	for kind, byType := range byKind {
+		out[kind] = make(map[string][]string, len(byType))
+
+		for typ, spans := range byType {
+			var versions []string
+
+			for _, v := range ordered {
+				if covers(spans, v) {
+					versions = append(versions, v)
+				}
+			}
+
+			out[kind][typ] = versions
+		}
+	}
+
+	return out
+}
+
+// Has reports whether the document covers a distribution. One that does not is
+// no answer at all, rather than an answer of "nothing was ever shipped".
+func (c *Components) Has(distribution string) bool {
+	_, ok := c.Distributions[distribution]
+
+	return ok
+}
+
+// covers reports whether any span holds the release.
+func covers(spans []Span, version string) bool {
+	for _, s := range spans {
+		if s.Covers(version) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// oldestFirst returns the releases sorted the way an availability answer reads,
+// leaving the caller's slice alone.
+func oldestFirst(releases []string) []string {
+	out := make([]string, len(releases))
+	copy(out, releases)
+
+	sort.Slice(out, func(i, j int) bool { return Compare(out[i], out[j]) < 0 })
+
+	return out
+}
+
+// ReadComponents decodes a component availability index.
+func ReadComponents(r io.Reader) (*Components, error) {
+	var comps Components
+
+	err := json.NewDecoder(r).Decode(&comps)
+	if err != nil {
+		return nil, fmt.Errorf("decode components: %w", err)
+	}
+
+	return &comps, nil
+}
+
+// ReadComponentsFile decodes a component availability index from a file on
+// disk.
+func ReadComponentsFile(path string) (*Components, error) {
+	return readComponentsFile(afero.NewOsFs(), path)
+}
+
+// readComponentsFile decodes a component availability index from a file on the
+// given filesystem.
+func readComponentsFile(fsys afero.Fs, path string) (*Components, error) {
+	f, err := fsys.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open components: %w", err)
+	}
+
+	defer func() { _ = f.Close() }()
+
+	comps, err := ReadComponents(f)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	return comps, nil
+}
+
+// Write encodes the component availability index as JSON.
+func (c *Components) Write(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	err := enc.Encode(c)
+	if err != nil {
+		return fmt.Errorf("encode components: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/schema/components_test.go
+++ b/pkg/schema/components_test.go
@@ -1,0 +1,237 @@
+package schema_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// The releases the availability fixtures below are written against, newest
+// first, the way a registry lists them.
+//
+//nolint:gochecknoglobals // a fixture the tests in this file share
+var fixtureReleases = []string{"v0.157.0", "v0.150.0", "v0.140.0", "v0.130.0", "v0.110.0"}
+
+func TestSpansOfIsOpenAtTheNewestRelease(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		present []string
+		want    []schema.Span
+	}{{
+		name:    "shipped throughout",
+		present: fixtureReleases,
+		want:    []schema.Span{{From: "v0.110.0", To: ""}},
+	}, {
+		name:    "added along the way",
+		present: []string{"v0.157.0", "v0.150.0"},
+		want:    []schema.Span{{From: "v0.150.0", To: ""}},
+	}, {
+		name:    "dropped along the way",
+		present: []string{"v0.110.0", "v0.130.0"},
+		want:    []schema.Span{{From: "v0.110.0", To: "v0.130.0"}},
+	}, {
+		name:    "dropped and brought back",
+		present: []string{"v0.110.0", "v0.140.0", "v0.157.0"},
+		want: []schema.Span{
+			{From: "v0.110.0", To: "v0.110.0"},
+			{From: "v0.140.0", To: "v0.140.0"},
+			{From: "v0.157.0", To: ""},
+		},
+	}, {
+		name:    "never shipped",
+		present: nil,
+		want:    nil,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := schema.SpansOf(fixtureReleases, set(tt.present))
+			assert.Equal(t, tt.want, got)
+
+			// Whatever the spans came out as, reading them back names the
+			// releases they were built from.
+			comps := components(got)
+			assert.ElementsMatch(t, tt.present,
+				comps.Expand(distContrib, fixtureReleases)[config.KindReceiver]["otlp"])
+		})
+	}
+}
+
+// TestExpandIsAskedAgainstTheReleasesServedNow pins that an open span means
+// "still shipped", not "shipped for ever": a registry that has dropped its
+// oldest releases must not be quoted as still serving them, and one that has
+// gained a release since is answered for the releases it has.
+func TestExpandIsAskedAgainstTheReleasesServedNow(t *testing.T) {
+	t.Parallel()
+
+	comps := components([]schema.Span{{From: "v0.130.0", To: ""}})
+
+	pruned := []string{"v0.157.0", "v0.150.0", "v0.140.0"}
+	assert.Equal(t, []string{"v0.140.0", "v0.150.0", "v0.157.0"},
+		comps.Expand(distContrib, pruned)[config.KindReceiver]["otlp"])
+
+	assert.Empty(t, comps.Expand("nosuch", fixtureReleases),
+		"a distribution the document does not cover has no answer")
+	assert.False(t, comps.Has("nosuch"))
+	assert.True(t, comps.Has(distContrib))
+}
+
+func TestComponentsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	comps := components([]schema.Span{{From: "v0.110.0", To: "v0.130.0"}, {From: "v0.150.0", To: ""}})
+
+	var buf bytes.Buffer
+
+	require.NoError(t, comps.Write(&buf))
+
+	// The open span is what keeps a new release from rewriting the entry of
+	// every component it did not change.
+	assert.NotContains(t, buf.String(), `"to": "v0.157.0"`)
+
+	read, err := schema.ReadComponents(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	assert.Equal(t, comps, read)
+
+	_, err = schema.ReadComponents(strings.NewReader("{"))
+	require.Error(t, err, "a truncated document should not decode")
+}
+
+func TestReadComponentsFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, schema.ComponentsFile)
+
+	write(t, path, `{"distributions":{"contrib":{"receiver":{"otlp":[{"from":"v0.110.0"}]}}}}`)
+
+	comps, err := schema.ReadComponentsFile(path)
+	require.NoError(t, err)
+	assert.True(t, comps.Has(distContrib))
+
+	_, err = schema.ReadComponentsFile(filepath.Join(dir, "absent.json"))
+	require.Error(t, err)
+}
+
+// TestAvailabilityFromADirectory covers the registry a checkout serves: the
+// document sits beside the index and is read for the store's distribution.
+func TestAvailabilityFromADirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	registry(t, root)
+	write(t, filepath.Join(root, schema.ComponentsFile),
+		`{"distributions":{`+
+			`"contrib":{"receiver":{"otlp":[{"from":"v0.157.0"}],"logging":[{"from":"v0.110.0","to":"v0.150.0"}]}},`+
+			`"core":{"receiver":{"otlp":[{"from":"v0.157.0"}]}}}}`)
+
+	// The index this fixture writes lists v0.157.0 alone, so a span that ended
+	// before it names nothing the registry can still serve.
+	store := schema.Store{Locations: []string{root}}
+
+	avail := store.Availability(t.Context())
+	require.NotNil(t, avail)
+	assert.Equal(t, []string{latestVersion}, avail[config.KindReceiver]["otlp"])
+	assert.Empty(t, avail[config.KindReceiver]["logging"])
+
+	// A distribution the document does not cover is no answer at all, so the
+	// caller can tell it apart from "nothing was ever shipped".
+	assert.Nil(t, store.WithDistribution("k8s").Availability(t.Context()),
+		"an uncovered distribution should not answer")
+}
+
+// TestAvailabilityIsOneFetch is the point of the whole document: a registry
+// that publishes one is asked once, instead of once per release.
+func TestAvailabilityIsOneFetch(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+
+		switch r.URL.Path {
+		case "/" + schema.IndexFile:
+			_, _ = w.Write([]byte(`{"distributions":{"contrib":["v0.157.0","v0.150.0","v0.110.0"]}}`))
+		case "/" + schema.ComponentsFile:
+			_, _ = w.Write([]byte(`{"distributions":{"contrib":{"receiver":{` +
+				`"otlp":[{"from":"v0.110.0"}],"logging":[{"from":"v0.110.0","to":"v0.150.0"}]}}}}`))
+		default:
+			t.Errorf("unexpected request for %s: a published index answers without reading a schema", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	store := schema.Store{
+		Locations:     []string{srv.URL},
+		AllowInsecure: true,
+		NoCache:       true,
+	}
+
+	avail := store.Availability(t.Context())
+	require.NotNil(t, avail)
+	assert.Equal(t, []string{"v0.110.0", "v0.150.0", "v0.157.0"}, avail[config.KindReceiver]["otlp"])
+	assert.Equal(t, []string{"v0.110.0", "v0.150.0"}, avail[config.KindReceiver]["logging"],
+		"a closed span should stop where the component was dropped")
+
+	// The index and the availability document, once each; asking again is
+	// answered from what the process already read.
+	assert.Equal(t, int64(2), requests.Load())
+
+	store.Availability(t.Context())
+	assert.Equal(t, int64(2), requests.Load(), "a second question should not be a second fetch")
+}
+
+// TestAvailabilityWithoutADocument covers every registry published before this
+// file existed: there is no answer, rather than an empty one.
+func TestAvailabilityWithoutADocument(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	registry(t, root)
+
+	assert.Nil(t, schema.Store{Locations: []string{root}}.Availability(t.Context()))
+	assert.Nil(t, schema.Store{Locations: []string{repoSchemas + "/contrib/v0.157.0.json"}}.
+		Availability(t.Context()), "a location naming one file publishes nothing")
+}
+
+func TestRemoteReportsWhatCostsARequest(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, schema.Store{}.Remote(), "the default location is the published registry")
+	assert.True(t, schema.Store{Locations: []string{schema.Default}}.Remote())
+	assert.True(t, schema.Store{Locations: []string{repoSchemas, schema.Default}}.Remote(),
+		"a store that falls through to the network reads over it")
+	assert.False(t, schema.Store{Locations: []string{repoSchemas}}.Remote())
+}
+
+// components wraps one component's spans in a document, which is what most of
+// the assertions above are about.
+func components(spans []schema.Span) *schema.Components {
+	return &schema.Components{Distributions: map[string]schema.ComponentSpans{
+		distContrib: {config.KindReceiver: {"otlp": spans}},
+	}}
+}
+
+// set turns a list of releases into what SpansOf takes.
+func set(versions []string) map[string]bool {
+	out := map[string]bool{}
+	for _, v := range versions {
+		out[v] = true
+	}
+
+	return out
+}

--- a/pkg/schema/store.go
+++ b/pkg/schema/store.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -17,6 +18,8 @@ import (
 	"time"
 
 	"github.com/spf13/afero"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 )
 
 // Extensions returns the schema file suffixes, in preference order. The
@@ -143,6 +146,37 @@ func (s Store) Versions(ctx context.Context) []string {
 	return out
 }
 
+// Availability returns which releases ship each component type in the store's
+// distribution, oldest first, and nil when no location publishes the component
+// index that says so.
+//
+// It is the whole registry's answer for one fetch. Working it out from the
+// schemas instead means loading every release the registry serves -- a
+// multi-megabyte document each, against a rate limit that counts requests --
+// to learn which releases one component type appears in.
+//
+// The answer is read against the releases that location serves now, so a
+// registry that has since dropped an old release is not quoted as still
+// serving it.
+func (s Store) Availability(ctx context.Context) map[config.Kind]map[string][]string {
+	for _, loc := range s.locations() {
+		comps := s.componentsAt(ctx, loc)
+		if comps == nil || !comps.Has(s.distribution()) {
+			continue
+		}
+
+		return comps.Expand(s.distribution(), s.versionsAt(ctx, loc))
+	}
+
+	return nil
+}
+
+// Remote reports whether any location is fetched over the network, where
+// reading a schema costs a request rather than a file read.
+func (s Store) Remote() bool {
+	return slices.ContainsFunc(s.locations(), isRemote)
+}
+
 // Distributions lists the distributions the store can serve, sorted. Only a
 // registry says what it carries, so other location kinds report none.
 func (s Store) Distributions(ctx context.Context) []string {
@@ -253,6 +287,30 @@ func (s Store) indexAt(ctx context.Context, loc string) *Index {
 		}
 
 		return idx
+	default:
+		return nil
+	}
+}
+
+// componentsAt reads a location's component availability index, or nil when it
+// publishes none. A registry written before the index existed is one of those,
+// and so is every location that is not a registry at all.
+func (s Store) componentsAt(ctx context.Context, loc string) *Components {
+	switch kindOf(loc) {
+	case locRemote:
+		comps, err := s.fetchComponents(ctx, loc)
+		if err != nil {
+			return nil
+		}
+
+		return comps
+	case locDir:
+		comps, err := readComponentsFile(s.fs(), filepath.Join(loc, ComponentsFile))
+		if err != nil {
+			return nil
+		}
+
+		return comps
 	default:
 		return nil
 	}
@@ -474,39 +532,73 @@ func (s Store) fetchIndex(ctx context.Context, root string) (*Index, error) {
 		return nil, err
 	}
 
-	cached, ok := indexMemo.Load(root)
+	return indexMemo.do(root, func() (*Index, error) {
+		// The index grows a line per release, so what is cached from a previous
+		// run is offered back with its validator rather than trusted outright.
+		body, err := s.get(ctx, join(root, IndexFile), revalidated)
+		if err != nil {
+			return nil, err
+		}
+
+		return ReadIndex(bytes.NewReader(body))
+	})
+}
+
+// fetchComponents reads a remote registry's component availability index, once
+// per registry and on the same terms as its index: a registry publishing none
+// answers 404, and remembering that is what keeps the next unknown component
+// from asking again.
+func (s Store) fetchComponents(ctx context.Context, root string) (*Components, error) {
+	err := s.refuseInsecure(root)
+	if err != nil {
+		return nil, err
+	}
+
+	return componentsMemo.do(root, func() (*Components, error) {
+		// It gains an entry per component added or dropped, so it is
+		// revalidated rather than kept, the way the index is.
+		body, err := s.get(ctx, join(root, ComponentsFile), revalidated)
+		if err != nil {
+			return nil, err
+		}
+
+		return ReadComponents(bytes.NewReader(body))
+	})
+}
+
+// docMemo holds what reading one registry document came to, keyed by the root
+// it was read from and kept for the life of the process.
+type docMemo[T any] struct{ m sync.Map }
+
+// docResult is one read, kept whether it succeeded or not.
+type docResult[T any] struct {
+	doc T
+	err error
+}
+
+// do returns what the root was read as, reading it only the first time it is
+// asked for.
+func (d *docMemo[T]) do(root string, read func() (T, error)) (T, error) {
+	cached, ok := d.m.Load(root)
 	if ok {
-		result, _ := cached.(indexResult)
+		result, _ := cached.(docResult[T])
 
-		return result.index, result.err
+		return result.doc, result.err
 	}
 
-	result := indexResult{index: nil, err: nil}
+	doc, err := read()
+	d.m.Store(root, docResult[T]{doc: doc, err: err})
 
-	body, err := s.get(ctx, join(root, IndexFile), revalidated)
-	if err == nil {
-		result.index, result.err = ReadIndex(bytes.NewReader(body))
-	} else {
-		result.err = err
-	}
-
-	indexMemo.Store(root, result)
-
-	return result.index, result.err
+	return doc, err
 }
 
-// indexResult is what one registry's index fetch came to, kept whether it
-// succeeded or not.
-type indexResult struct {
-	index *Index
-	err   error
-}
-
-// indexMemo holds each remote registry's index for the life of the process,
-// keyed by the root it was read from.
+// The documents a registry publishes beside its schemas, each read once.
 //
-//nolint:gochecknoglobals // a registry has one index, and the point is to fetch it once
-var indexMemo sync.Map
+//nolint:gochecknoglobals // a registry has one of each, and the point is to fetch them once
+var (
+	indexMemo      docMemo[*Index]
+	componentsMemo docMemo[*Components]
+)
 
 // join appends path segments to a registry root, which is a URL or a local
 // directory. Slashes are right for both: filepath.Join would break URLs on


### PR DESCRIPTION
Closes #73.

## The cost being removed

`VersionIndex.build` loaded the full schema for every release the store knows
about. One unrecognised component type therefore meant a sequential download of
the whole contrib registry — 31 releases at ~3.6 MB each, over 100 MB — to
produce one line of hint. The failure was silent too: `if err != nil { continue }`
dropped a throttled release on the floor, so under a rate limit most releases
were missing and the hint either disappeared or named the wrong first release.

`DistributionIndex` is bounded by the number of distributions and is left alone,
as the issue asks.

## What this does

**Option 1 from the issue: the registry publishes the answer.** `schemagen`
writes `components.json` beside `index.json`, rebuilt from the schemas the
registry is left holding (after pruning, like the index):

```json
{"distributions": {"contrib": {"receiver": {"otlp": [{"from": "v0.70.0"}]}}}}
```

Spans rather than version lists: an entry stays one line however many releases
the registry gains, and a span stays open (`to` omitted) while the component is
still shipped, so adding a release does not rewrite the entry of every component
it left alone. For the published registry the whole document is ~40 KB against
~110 MB of schemas. A distribution whose releases could not all be read is left
out rather than described from half of them — a missing release would read as a
component dropped and added back.

`Store.Availability` reads it — once per process, revalidated with an ETag like
the index — and expands the spans against the releases that location serves
*now*, so a pruned registry is not quoted as still serving what it dropped.

**Fallbacks, for a registry that publishes none** (including the published one
until it is next regenerated): the walk is still there, unbounded for a
directory on disk, and bounded to the twelve newest releases when each one is a
download. Together with the on-disk cache the walk is then paid once per machine
rather than once per run.

**No more silent loss.** A walk that could not read half its releases empties
the index and the finding falls back to its "did you mean" hint — nothing is a
better answer than a plausible wrong one.

## Tests

- `pkg/schema`: span building and expansion (added, dropped, brought back,
  pruned registry), read/write round trip, and a counting server pinning that a
  registry with the document is asked exactly twice — index and availability,
  with no schema fetched.
- `pkg/lint`: the published path, the local walk, the remote walk stopping at
  twelve releases, and a throttled registry producing no hint at all.
- `pkg/cmd/schemagen`: the document generated for a registry holding an older
  release, and a distribution left out when one of its releases cannot be read.

Verified end to end that the hint is unchanged either way:

```console
$ otelcol-config-lint run --schema-location <registry-without-components.json> …
    hint: "logging" exists in v0.110.0 but not in v0.157.0
$ otelcol-config-lint run --schema-location <same-registry-with-components.json> …
    hint: "logging" exists in v0.110.0 but not in v0.157.0
```

The published registry starts answering the cheap way as soon as it is next
regenerated; until then it takes the bounded walk, which is why that path keeps
its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z