### PR TITLE
fix(schema): order pre-releases the way semver does

### DIFF
--- a/pkg/schema/store.go
+++ b/pkg/schema/store.go
@@ -932,8 +932,9 @@ func Normalize(v string) string {
 
 // Compare orders two collector versions. It returns a negative number when a is
 // older than b, zero when they are equal, and a positive number otherwise. A
-// pre-release sorts before the release it leads up to, and unparsable segments
-// compare as zero so malformed versions sort as oldest.
+// pre-release sorts before the release it leads up to, two pre-releases sort
+// the way semver orders them, and unparsable segments compare as zero so
+// malformed versions sort as oldest.
 func Compare(a, b string) int {
 	pa, pb := parseVersion(a), parseVersion(b)
 	for i := range pa {
@@ -951,8 +952,84 @@ func Compare(a, b string) int {
 	case rb == "":
 		return -1
 	default:
-		return strings.Compare(ra, rb)
+		return comparePrerelease(ra, rb)
 	}
+}
+
+// comparePrerelease orders two pre-release suffixes, e.g. "rc.2" against
+// "rc.10". Both are non-empty: a release against a pre-release is decided by
+// Compare before it gets here.
+//
+// Semver compares the suffix field by field rather than byte by byte, which is
+// what keeps rc.2 below rc.10, and a list that runs out first sorts below the
+// longer one that shares its prefix, so "rc" is below "rc.1".
+func comparePrerelease(ra, rb string) int {
+	fieldsA, fieldsB := strings.Split(ra, "."), strings.Split(rb, ".")
+	for i := range min(len(fieldsA), len(fieldsB)) {
+		if c := compareIdentifier(fieldsA[i], fieldsB[i]); c != 0 {
+			return c
+		}
+	}
+
+	return len(fieldsA) - len(fieldsB)
+}
+
+// compareIdentifier orders one field of a pre-release suffix. Two all-digit
+// fields compare as numbers, anything else compares as text, and a numeric
+// field sorts below an alphanumeric one.
+func compareIdentifier(a, b string) int {
+	numA, numB := isNumeric(a), isNumeric(b)
+
+	switch {
+	case numA && numB:
+		return compareNumeric(a, b)
+	case numA:
+		return -1
+	case numB:
+		return 1
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
+// compareNumeric orders two all-digit fields as numbers, without converting
+// them: a field is only bounded by how long the string is, and a version that
+// overflows an int should still sort rather than wrap.
+func compareNumeric(a, b string) int {
+	a, b = trimLeadingZeros(a), trimLeadingZeros(b)
+	if len(a) != len(b) {
+		return len(a) - len(b)
+	}
+
+	return strings.Compare(a, b)
+}
+
+// trimLeadingZeros drops the padding of a digit string, keeping the last digit
+// so "000" stays a number. Semver forbids the padding, but a registry is free
+// to publish it and the ordering should not turn on that.
+func trimLeadingZeros(s string) string {
+	trimmed := strings.TrimLeft(s, "0")
+	if trimmed == "" {
+		return "0"
+	}
+
+	return trimmed
+}
+
+// isNumeric reports whether a pre-release field is all digits, which is what
+// makes it compare as a number.
+func isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
 }
 
 // prerelease returns the suffix after the first "-", e.g. "rc.1".

--- a/pkg/schema/store_test.go
+++ b/pkg/schema/store_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -51,6 +52,19 @@ func TestCompare(t *testing.T) {
 		{"v0.110.1", "v0.110.0", 1},
 		{"v1.0.0", "v0.999.0", 1},
 		{"v0.157.0-rc.1", "v0.157.0", -1},
+		// A pre-release suffix is compared field by field, and a field of
+		// digits as a number: byte order would put rc.10 below rc.2.
+		{"v0.130.0-rc.2", "v0.130.0-rc.10", -1},
+		{"v0.130.0-rc.9", "v0.130.0-rc.10", -1},
+		{"v0.130.0-rc.10", "v0.130.0-rc.2", 1},
+		{"v0.130.0-alpha", "v0.130.0-beta", -1},
+		{"v0.130.0-rc", "v0.130.0-rc.1", -1},
+		{"v0.130.0-rc.1", "v0.130.0-rc.1.1", -1},
+		{"v0.130.0-rc.1", "v0.130.0-rc.1", 0},
+		// A numeric field sorts below an alphanumeric one.
+		{"v0.130.0-1", "v0.130.0-alpha", -1},
+		// Padding a number does not change which number it is.
+		{"v0.130.0-rc.02", "v0.130.0-rc.10", -1},
 	} {
 		got := schema.Compare(tt.a, tt.b)
 		if sign(got) != tt.want {
@@ -67,6 +81,63 @@ func sign(n int) int {
 		return -1
 	default:
 		return 0
+	}
+}
+
+// TestCompareSortsPrereleasesInSemverOrder pins the whole chain rather than
+// each neighbouring pair, because Latest and Nearest read a sorted list: an
+// ordering that is right pairwise and wrong overall still hands the wrong
+// release to --collector-version.
+func TestCompareSortsPrereleasesInSemverOrder(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		"v0.130.0-alpha",
+		"v0.130.0-alpha.1",
+		"v0.130.0-beta",
+		"v0.130.0-rc",
+		"v0.130.0-rc.1",
+		"v0.130.0-rc.1.1",
+		"v0.130.0-rc.2",
+		"v0.130.0-rc.9",
+		"v0.130.0-rc.10",
+		"v0.130.0",
+		"v0.130.1-rc.1",
+	}
+
+	shuffled := []string{
+		"v0.130.0-rc.10", "v0.130.0", "v0.130.0-rc.2", "v0.130.0-alpha.1",
+		"v0.130.1-rc.1", "v0.130.0-rc", "v0.130.0-beta", "v0.130.0-rc.9",
+		"v0.130.0-rc.1.1", "v0.130.0-alpha", "v0.130.0-rc.1",
+	}
+
+	sort.Slice(shuffled, func(i, j int) bool { return schema.Compare(shuffled[i], shuffled[j]) < 0 })
+
+	if !slices.Equal(shuffled, want) {
+		t.Errorf("sorted to %v, want %v", shuffled, want)
+	}
+}
+
+// TestNearestSkipsNewerPrereleases pins that the fallback reads the ordering:
+// asking for a release the registry does not have should land on the newest
+// pre-release below it, not on whichever one sorts last as text.
+func TestNearestSkipsNewerPrereleases(t *testing.T) {
+	t.Parallel()
+
+	unknown := &schema.UnknownVersionError{
+		Version: "v0.130.0-rc.9",
+		// Available is sorted newest first, the way Versions returns it.
+		Available: []string{"v0.130.0-rc.10", "v0.130.0-rc.2", "v0.130.0-rc.1"},
+		Tried:     nil,
+	}
+
+	near, found := unknown.Nearest()
+	if !found {
+		t.Fatal("want a nearest version")
+	}
+
+	if near != "v0.130.0-rc.2" {
+		t.Errorf("nearest = %q, want v0.130.0-rc.2", near)
 	}
 }
 


### PR DESCRIPTION
## Why

`Compare` orders the numeric segments properly and then hands the pre-release suffix to `strings.Compare`. Byte order is not semver order:

- `v0.130.0-rc.10` vs `v0.130.0-rc.2` → `rc.10` reads as older.
- `v0.130.0-rc.9` vs `v0.130.0-rc.10` → `rc.9` sorts last and wins `Latest`.

`Latest` and `Nearest` are both built on `Compare`, so a registry carrying `-rc.N` schemas can hand `--collector-version` the wrong release and the config is checked against a component set nobody asked for. The failure is silent: the version printed back is a real release, just not the nearest one.

## What

The suffix is compared field by field, the way semver does it:

- two all-digit fields compare as numbers, anything else as text
- a numeric field sorts below an alphanumeric one
- a shorter field list sorts below the longer one that shares its prefix, so `rc` < `rc.1`

Digits compare by length rather than through `strconv`, so a field too long for an `int` sorts rather than wraps, and padding is trimmed first because a registry is free to publish `rc.02` even though semver forbids it.

`parseVersion` still reads an unparsable segment as zero, so a malformed version sorts as oldest — deliberate and unchanged.

## Tests

- `TestCompare` gains the pairs from the issue plus numeric-below-alphanumeric and the padded case.
- `TestCompareSortsPrereleasesInSemverOrder` sorts a shuffled chain and pins the whole order, because `Latest` and `Nearest` read a sorted list — an ordering that is right pairwise and wrong overall still hands back the wrong release.
- `TestNearestSkipsNewerPrereleases` pins that the fallback lands on `rc.2` rather than `rc.10` when `rc.9` is asked for.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z