### PR TITLE
feat(run): end the run on a release the registry does not have

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ from it.
 | `--schema-location` | `run.schemaLocations` | where to find schemas: a registry directory or URL, a `{{.Version}}`/`{{.Distribution}}` template, or `default`. Repeat to search several in order |
 | `--insecure-schema-location` | `run.insecureSchemaLocation` | allow a plain `http://` schema location, which is otherwise refused. For a registry served on localhost |
 | `--no-cache` | `run.noCache` | fetch schemas again instead of reading the ones kept from earlier runs |
+| `--allow-nearest-fallback` | `run.allowNearestFallback` | check against the nearest older release when the registry has no schema for the one asked for. Without it, that is a usage error |
 | `--strict` | `run.strict` | unknown component settings become errors instead of warnings |
 | `--ignore-missing-schemas` | `run.ignoreMissingSchemas` | do not fail on components absent from the schema (custom distributions) |
 | `--exclude` | `run.exclude` | glob patterns to skip when walking directories |
@@ -154,7 +155,11 @@ from it.
 a comma-separated list, and may also be repeated.
 
 Exit codes: `0` everything passed, `1` at least one file failed, `2` the command
-could not run.
+could not run. A `--collector-version` the registry has no schema for is that
+last case: the run ends naming the nearest release available, because checking
+the config against a release nobody asked for and exiting `0` says nothing that
+CI can read. Pass `--allow-nearest-fallback` to check against it anyway, for a
+repository deliberately tracking ahead of the registry.
 
 ```sh
 otelcol-config-lint run config.yaml                               # lint one file
@@ -849,10 +854,9 @@ deprecated alias. Both resolve, and using the old name reports
 Nobody has to remember. The [`schemas`](.github/workflows/schemas.yaml) workflow
 runs weekly, reads upstream's release tags, and for each one the registry does
 not have yet generates the schemas and opens a pull request against
-`otelcol-config-schemas`, one per release. A release with no schema is not a gap
-the linter reports — `--collector-version v0.158.0` falls back to the newest
-release it does have and checks the config against the wrong component set — so
-the registry has to keep up on its own. Dispatch the workflow with a version to
+`otelcol-config-schemas`, one per release. A release with no schema stops the
+run — `--collector-version v0.158.0` is a usage error naming the newest release
+the registry does have — so the registry has to keep up on its own. Dispatch the workflow with a version to
 generate one by hand, present or not.
 
 The generated diff is several megabytes of YAML, so the pull request leads with

--- a/otelcol-config-lint.schema.json
+++ b/otelcol-config-lint.schema.json
@@ -284,6 +284,10 @@
       "additionalProperties": false,
       "description": "What to check, and against which collector.",
       "properties": {
+        "allowNearestFallback": {
+          "description": "Check against the nearest older release when the registry has no schema for collectorVersion, instead of ending the run. Without it a release nobody published is a usage error, because the config would otherwise be checked against a component set nobody asked for.",
+          "type": "boolean"
+        },
         "collectorVersion": {
           "description": "Collector release to validate against. \"latest\" uses the newest schema available.",
           "examples": [

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -300,17 +300,60 @@ func TestTheDistributionIsNamedInDiagnostics(t *testing.T) {
 	}
 }
 
-func TestUnknownVersionFallsBackToTheNearestOlder(t *testing.T) {
+// TestUnknownVersionEndsTheRun pins that a release the registry does not carry
+// is a usage error rather than a green run against some other release. The
+// exit code is the only thing CI reads.
+func TestUnknownVersionEndsTheRun(t *testing.T) {
 	t.Parallel()
 
 	code, _, errOut := lint(t, "", "--collector-version", "v0.155.0", "--min-severity", "error", validConfig)
-	if code != 0 {
-		t.Fatalf("want a fallback, got exit %d: %s", code, errOut)
-	}
+	require.Equal(t, 2, code, "an unavailable release should be a usage error: %s", errOut)
 
-	if !strings.Contains(errOut, "falling back to") {
-		t.Errorf("the fallback should be announced: %q", errOut)
-	}
+	assert.Contains(t, errOut, "v0.155.0", "the error should name what was asked for")
+	assert.Contains(t, errOut, "the nearest release available is v0.110.0",
+		"the error should name the nearest release, so the fix is one edit away")
+	assert.Contains(t, errOut, "--allow-nearest-fallback",
+		"the error should name the flag that accepts the older schema")
+}
+
+// TestAllowNearestFallbackChecksAgainstTheOlderRelease pins the opt-in, for a
+// repository deliberately tracking ahead of the registry.
+func TestAllowNearestFallbackChecksAgainstTheOlderRelease(t *testing.T) {
+	t.Parallel()
+
+	code, _, errOut := lint(t, "", "--collector-version", "v0.155.0", "--allow-nearest-fallback",
+		"--min-severity", "error", validConfig)
+	require.Equal(t, 0, code, "want a fallback, got exit %d: %s", code, errOut)
+
+	assert.Contains(t, errOut, "falling back to", "the fallback should still be announced")
+}
+
+// TestAllowNearestFallbackIsAlsoASettingsKey pins that the opt-in can be
+// committed, since a repository tracking ahead of the registry does so for
+// every run rather than one.
+func TestAllowNearestFallbackIsAlsoASettingsKey(t *testing.T) {
+	t.Parallel()
+
+	path := writeSettings(t, "run:\n  allowNearestFallback: true\n  collectorVersion: v0.155.0\n")
+
+	code, _, errOut := lint(t, "", "--config", path, "--min-severity", "error", validConfig)
+	require.Equal(t, 0, code, "the key should permit the fallback: %s", errOut)
+
+	assert.Contains(t, errOut, "falling back to", "the fallback should still be announced")
+}
+
+// TestNoNearestReleaseIsStillAUsageError pins the case with nothing older to
+// name: the store's own error is what a reader gets, rather than a hint that
+// would name no release.
+func TestNoNearestReleaseIsStillAUsageError(t *testing.T) {
+	t.Parallel()
+
+	code, _, errOut := lint(t, "", "--collector-version", "v0.1.0", "--allow-nearest-fallback",
+		"--min-severity", "error", validConfig)
+	require.Equal(t, 2, code, "a release older than every schema should not resolve: %s", errOut)
+
+	assert.Contains(t, errOut, "no schema for collector version v0.1.0")
+	assert.NotContains(t, errOut, "the nearest release available")
 }
 
 func TestSchemaLocationOverridesTheBuiltins(t *testing.T) {

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint_test.go
@@ -1292,11 +1292,14 @@ func TestSharedFlagsAgreeAcrossCommands(t *testing.T) {
 		"no-config":       {{"run"}, {"list", "rules"}, {"list", "versions"}},
 	}
 
-	root := otelcolconfiglint.NewCommand(nil)
-
 	for name, paths := range shared {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
+			// A command tree of its own per subtest. cobra merges a parent's
+			// persistent flags into a child the first time either is looked
+			// at, so subtests sharing one root write to it as they read it.
+			root := otelcolconfiglint.NewCommand(nil)
 
 			var first []string
 

--- a/pkg/cmd/otelcol-config-lint/run/run.go
+++ b/pkg/cmd/otelcol-config-lint/run/run.go
@@ -37,6 +37,34 @@ var (
 	ErrFilesInvalid = errors.New("at least one file is invalid")
 )
 
+// NoExactSchemaError reports that no location carries the requested release.
+// It ends the run rather than standing in for the release, and it is a usage
+// error because what has to change is the request: either the version asked
+// for, or the flag that says an older schema will do.
+type NoExactSchemaError struct {
+	// Err is what the store reported, which names what it did find.
+	Err *schema.UnknownVersionError
+	// Nearest is the newest release that is not newer than the request, and
+	// HasNearest says whether there is one to name.
+	Nearest    string
+	HasNearest bool
+}
+
+func (e *NoExactSchemaError) Error() string {
+	if !e.HasNearest {
+		return e.Err.Error()
+	}
+
+	return fmt.Sprintf("%s; the nearest release available is %s"+
+		"\npass --collector-version %s to check against it, or --allow-nearest-fallback"+
+		" to keep asking for %s and be checked against %s",
+		e.Err.Error(), e.Nearest, e.Nearest, e.Err.Version, e.Nearest)
+}
+
+// Unwrap keeps the store's error readable through errors.As, so a caller can
+// still ask what the registry had.
+func (e *NoExactSchemaError) Unwrap() error { return e.Err }
+
 // maxDefaultWorkers caps the default parallelism; beyond this the run is bound
 // by reading files, not by checking them.
 const maxDefaultWorkers = 8
@@ -58,6 +86,7 @@ type options struct {
 	schemaLocations        []string
 	insecureSchemaLocation bool
 	noCache                bool
+	allowNearestFallback   bool
 	// Which rules run, and at what level.
 	ruleDefault string
 	enable      []string
@@ -163,6 +192,8 @@ func (o *options) declareFlags(cmd *cobra.Command) {
 		"allow a plain http:// schema location, for a registry served on localhost")
 	flags.BoolVar(&o.noCache, "no-cache", false,
 		"fetch schemas again instead of reading the ones kept from earlier runs")
+	flags.BoolVar(&o.allowNearestFallback, "allow-nearest-fallback", false,
+		"check against the nearest older release when the registry has no schema for the one asked for")
 	flags.StringVar(&o.ruleDefault, "default", "",
 		"rule set to start from: "+ruleset.DefaultAll+" (the default) or "+ruleset.DefaultNone)
 	flags.StringSliceVarP(&o.enable, "enable", "E", nil, "rules to turn on, on top of --default")
@@ -206,6 +237,7 @@ func (o *options) prepare(cmd *cobra.Command) error {
 	fold.List("schema-location", &o.schemaLocations, file.Run.SchemaLocations)
 	fold.Bool("insecure-schema-location", &o.insecureSchemaLocation, file.Run.InsecureSchemaLocation)
 	fold.Bool("no-cache", &o.noCache, file.Run.NoCache)
+	fold.Bool("allow-nearest-fallback", &o.allowNearestFallback, file.Run.AllowNearestFallback)
 	fold.Str("memory-request", &o.memoryRequest, file.Run.Kubernetes.MemoryRequest)
 	fold.Str("memory-limit", &o.memoryLimit, file.Run.Kubernetes.MemoryLimit)
 
@@ -428,8 +460,14 @@ func (o *options) newLinter(cmd *cobra.Command) (*lint.Linter, error) {
 	}), nil
 }
 
-// loadSchema resolves the targeted release, falling back to the newest
-// schema that is not newer than the request when there is no exact match.
+// loadSchema resolves the targeted release.
+//
+// A release the registry does not carry ends the run: the exit code is the
+// only thing CI reads, and a run that silently checked the config against some
+// other release passed green while saying nothing an annotation would carry.
+// The nearest release is named instead, so the fix is one edit away, and
+// --allow-nearest-fallback checks against it for a run that is deliberately
+// tracking ahead of the registry.
 func (o *options) loadSchema(cmd *cobra.Command) (*schema.Schema, error) {
 	cat, err := o.store.Load(cmd.Context(), o.collectorVersion)
 	if err == nil {
@@ -442,8 +480,8 @@ func (o *options) loadSchema(cmd *cobra.Command) (*schema.Schema, error) {
 	}
 
 	near, hasNear := unknown.Nearest()
-	if !hasNear {
-		return nil, fmt.Errorf("load schema: %w", err)
+	if !hasNear || !o.allowNearestFallback {
+		return nil, &NoExactSchemaError{Err: unknown, Nearest: near, HasNearest: hasNear}
 	}
 
 	cmd.PrintErrf("otelcol-config-lint: no schema for %s, falling back to %s\n", unknown.Version, near)

--- a/pkg/settings/jsonschema.go
+++ b/pkg/settings/jsonschema.go
@@ -105,6 +105,13 @@ func runSchema() object {
 				"this is what picks up a correction to one already read.",
 			"type": "boolean",
 		},
+		"allowNearestFallback": object{
+			"description": "Check against the nearest older release when the registry has no schema " +
+				"for collectorVersion, instead of ending the run. Without it a release nobody " +
+				"published is a usage error, because the config would otherwise be checked against " +
+				"a component set nobody asked for.",
+			"type": "boolean",
+		},
 		"strict": object{
 			"description": "Report unknown component settings as errors instead of warnings.",
 			"type":        "boolean",

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -92,6 +92,12 @@ type RunBlock struct {
 	// earlier runs, which is what picks up a correction to a schema already
 	// published under a version this machine has read.
 	NoCache *bool `yaml:"noCache"`
+	// AllowNearestFallback checks against the newest release that is not newer
+	// than collectorVersion when the registry has no schema for it, instead of
+	// ending the run. For a repository deliberately tracking ahead of the
+	// registry; otherwise a release nobody published is a mistake worth
+	// hearing about.
+	AllowNearestFallback *bool `yaml:"allowNearestFallback"`
 	// Strict reports unknown component settings as errors.
 	Strict *bool `yaml:"strict"`
 	// IgnoreMissingSchemas keeps components absent from the schema from


### PR DESCRIPTION
## Why

`loadSchema` resolved a release the registry does not have by quietly dropping to the nearest older one — one line on stderr, then the run continued and exited `0`.

What a user sees is a green check on a pipeline that asked for `v0.158.0`. What actually happened is that the config was checked against, say, `v0.152.0`: a receiver added in `v0.155.0` reads as an unknown component, and a setting removed since `v0.152.0` is accepted. Both directions are wrong and both are invisible in the annotation output, because the fallback line is not a diagnostic — `--format github` swallowed it entirely.

The typo case is worse than the lag case: `--collector-version v0.999.0` is a plain user error, and it linted against whatever the newest schema was and passed.

## What

The exact release becomes the default and the fallback becomes the opt-in, which is the first option the issue lays out.

- No exact match ends the run with exit `2`, naming the nearest release the registry does have and the flag that accepts it:

  ```
  otelcol-config-lint: no schema for collector version v0.155.0 (available: v0.157.0, v0.110.0); the nearest release available is v0.110.0
  pass --collector-version v0.110.0 to check against it, or --allow-nearest-fallback to keep asking for v0.155.0 and be checked against v0.110.0
  ```

- `--allow-nearest-fallback` restores today's behaviour, stderr line and all, for a repository deliberately tracking ahead of the registry.
- `run.allowNearestFallback` mirrors it in the settings file, since a repository in that position is in it for every run rather than one. The committed JSON Schema is regenerated.
- A request with nothing older to fall back on still reports what the store found, rather than a hint that would name no release.

The formatter-level `warning` diagnostic the issue lists as the fallback plan is not here: it is the alternative for a default that stays lenient, and this default does not.

## Tests

- `TestUnknownVersionEndsTheRun` — exit 2, and the error names the request, the nearest release and the flag.
- `TestAllowNearestFallbackChecksAgainstTheOlderRelease` — the opt-in still lints and still announces.
- `TestAllowNearestFallbackIsAlsoASettingsKey` — the key does the same.
- `TestNoNearestReleaseIsStillAUsageError` — nothing older to name.

README: the flag table, the exit-code paragraph, and the registry section that documented the old behaviour.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z