### PR TITLE
fix(config): resolve merge keys and aliases the way the collector does

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,17 @@ data, the queue sizes and `otelcol_exporter_send_failed_*` among them.
 **Security** — `insecure-tls`, `receiver-binds-all-interfaces`,
 `debug-extension-exposed`, `hardcoded-secret`.
 
+Every rule reads the config the collector will read, not the one on the page.
+YAML anchors, aliases and `<<` merge keys are resolved when the file is parsed,
+the way confmap resolves them through yaml.v3 before the collector sees a single
+setting — so a component whose settings come from a shared base is checked
+against what it will actually run with, and `<<` is never reported as a setting,
+because it is not one. A key a component writes itself still wins over the one
+its merge supplies, which is the merge key's purpose, so `duplicate-key` reads
+the document as written and stays quiet about the override. Findings keep the
+line they were written on: a setting a merge supplies is reported against the
+line in the anchor, which is the line to edit.
+
 Every practice, telemetry and security rule cites the upstream page it rests on
 — the `memorylimiterprocessor`, `batchprocessor`, `exporterhelper`,
 `debugexporter`, `tailsamplingprocessor` and `probabilisticsamplerprocessor`
@@ -482,10 +493,11 @@ its own. Where only some of them do, the pipeline is under-batched on the legs
 that do not, so the finding names the exporter and sits on the line that wires
 it in — that exporter's settings are where the fix is written. A connector in
 the exporter slot is not a leg out of the collector and is not counted; it feeds
-another pipeline, which has exporters of its own. An exporter whose settings
-come from a merge key or an expansion counts as unknown rather than as not
-batching, for the same reason the field rules leave what they cannot resolve
-alone.
+another pipeline, which has exporters of its own. An exporter whose queue is built from
+an expansion counts as unknown rather than as not batching, for the same reason
+the field rules leave what they cannot resolve alone. A merge key is not one of
+those: it is resolved when the file is parsed, the way the collector resolves
+it, so what an anchor supplies is read like anything written in place.
 
 What the document writes decides whether there is a finding; what the field
 schema describes decides only which fix the hint may name. The queue batcher is
@@ -661,8 +673,9 @@ default in `v0.110`. So is a hostname other than `localhost`, since what a name
 resolves to is a property of the network rather than of the file, and an
 address supplied by `${env:...}`. An expansion standing in for only the *port*
 is still reported — `0.0.0.0:${env:PPROF_PORT}` says plainly who can reach it —
-and an endpoint a `<<` merge supplies is read from the mapping it merges, so
-sharing one debugging block between extensions does not hide it.
+and an endpoint a `<<` merge supplies is read like one written in place, since
+merges are resolved when the file is parsed, so sharing one debugging block
+between extensions does not hide it.
 
 `hardcoded-secret` is the one rule about the file rather than the collector.
 Configs live in git, and exporter credentials are written in the same file as

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -214,7 +214,14 @@ func Parse(path string, src []byte) (*File, error) {
 
 	f.Root = root
 
+	// Duplicates are collected from the document as written, before anything
+	// is merged into it: a key the config writes itself replaces one a merge
+	// supplies, and that is the merge key's purpose rather than a key declared
+	// twice.
 	f.DuplicateKeys = collectDuplicates(root, "")
+
+	resolve(root)
+
 	for _, e := range entries(root, "") {
 		kind, isSection := SectionKind(e.Key)
 

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -1,0 +1,177 @@
+package config
+
+import "gopkg.in/yaml.v3"
+
+// MergeTag is the tag yaml.v3 gives the YAML merge key, "<<". The tag rather
+// than the spelling is what says a key is one: a quoted "<<" is a plain string
+// and stays a key of its own, which is how yaml.v3 reads it too.
+const MergeTag = "!!merge"
+
+// resolve rewrites the document into the one the collector will read: every
+// alias replaced by what it points at, and every merge key replaced by the
+// entries it supplies.
+//
+// The linter walks the node tree rather than a decoded value, and the tree is
+// the document as written -- a merge key is a key called "<<" whose value is
+// an alias, and an alias is a node standing in for the mapping it names. The
+// collector resolves both before it sees a single setting, because confmap
+// unmarshals through yaml.v3, so without this a rule reads a different config
+// from the one that will run and reports settings as absent that are plainly
+// in the file.
+//
+// Nodes are reused rather than copied, so a merged setting keeps the position
+// it was written at: a finding about it lands on the line in the anchor, which
+// is the line the reader has to edit.
+func resolve(root *yaml.Node) {
+	r := resolver{active: map[*yaml.Node]bool{}, walked: map[*yaml.Node]bool{}}
+	r.value(root)
+}
+
+// resolver carries what a single pass over one document has to remember.
+type resolver struct {
+	// active is the aliases currently being followed, which is what stops an
+	// anchor that contains itself from recursing forever. yaml.v3 refuses such
+	// a document when it decodes one, but it hands back the node tree without
+	// complaint, so the linter has to survive it to report anything at all.
+	active map[*yaml.Node]bool
+	// walked is the nodes already rewritten. An anchor merged into a dozen
+	// components is one node reached a dozen times, and rewriting it once is
+	// both faster and what keeps its own merges from being applied twice.
+	walked map[*yaml.Node]bool
+}
+
+// value returns what a node stands for: an alias becomes the node it names,
+// and anything else is rewritten in place and handed back as it is.
+func (r *resolver) value(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+
+	if n.Kind != yaml.AliasNode {
+		r.walk(n)
+
+		return n
+	}
+
+	// An alias naming no anchor, or one that leads back to itself, is left as
+	// it was written: there is nothing to put in its place, and a document
+	// holding either does not load for the collector either.
+	if n.Alias == nil || r.active[n] {
+		return n
+	}
+
+	r.active[n] = true
+	defer delete(r.active, n)
+
+	return r.value(n.Alias)
+}
+
+// walk rewrites a node's children, once per node however many aliases reach it.
+func (r *resolver) walk(n *yaml.Node) {
+	if r.walked[n] {
+		return
+	}
+
+	r.walked[n] = true
+
+	if n.Kind == yaml.MappingNode {
+		r.mapping(n)
+
+		return
+	}
+
+	for i, c := range n.Content {
+		n.Content[i] = r.value(c)
+	}
+}
+
+// mapping rewrites one mapping: its values resolved, and the entries its merge
+// keys supply spliced in behind the keys it writes itself.
+func (r *resolver) mapping(n *yaml.Node) {
+	local := make([]*yaml.Node, 0, len(n.Content))
+
+	var merged []*yaml.Node
+
+	for i := 0; i+1 < len(n.Content); i += mappingStride {
+		k, v := n.Content[i], n.Content[i+1]
+
+		sources, isMerge := r.mergeSources(k, v)
+		if isMerge {
+			merged = append(merged, sources...)
+
+			continue
+		}
+
+		local = append(local, k, r.value(v))
+	}
+
+	local = append(local, mergedEntries(local, merged)...)
+	n.Content = local
+}
+
+// mergeSources returns the mappings an entry merges in, and whether the entry
+// is a merge at all.
+//
+// A merge whose value is neither a mapping nor a list of them is not one the
+// collector can load -- yaml.v3 fails the decode outright -- so it is left in
+// place as the key it was written as, where the rules can say something about
+// it rather than the linter quietly dropping it.
+func (r *resolver) mergeSources(k, v *yaml.Node) ([]*yaml.Node, bool) {
+	if k.Tag != MergeTag {
+		return nil, false
+	}
+
+	val := r.value(v)
+
+	switch {
+	case val == nil:
+		return nil, false
+	case val.Kind == yaml.MappingNode:
+		return []*yaml.Node{val}, true
+	case val.Kind != yaml.SequenceNode:
+		return nil, false
+	}
+
+	out := make([]*yaml.Node, 0, len(val.Content))
+
+	for _, item := range val.Content {
+		if item.Kind != yaml.MappingNode {
+			return nil, false
+		}
+
+		out = append(out, item)
+	}
+
+	return out, true
+}
+
+// mergedEntries returns the key/value pairs the merges supply that the mapping
+// does not already have. A key the mapping writes itself wins outright, which
+// is the merge key's whole purpose, and among several merges the first to
+// carry a key wins, which is the order yaml.v3 applies them in.
+func mergedEntries(local, merged []*yaml.Node) []*yaml.Node {
+	if len(merged) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool, len(local)/mappingStride)
+	for i := 0; i < len(local); i += mappingStride {
+		seen[local[i].Value] = true
+	}
+
+	var out []*yaml.Node
+
+	for _, src := range merged {
+		for i := 0; i+1 < len(src.Content); i += mappingStride {
+			k, v := src.Content[i], src.Content[i+1]
+			if seen[k.Value] {
+				continue
+			}
+
+			seen[k.Value] = true
+			out = append(out, k, v)
+		}
+	}
+
+	return out
+}

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -1,0 +1,265 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+)
+
+// settings returns the settings a processor was parsed with, as key to value,
+// so a test can say what a rule reading that component would find.
+func settings(t *testing.T, f *config.File, id string) map[string]string {
+	t.Helper()
+
+	c, found := f.Component(config.KindProcessor, config.ParseID(id))
+	require.True(t, found, "processor %s should be declared", id)
+	require.NotNil(t, c.ValueNode, "processor %s should have settings", id)
+
+	out := map[string]string{}
+	for i := 0; i+1 < len(c.ValueNode.Content); i += 2 {
+		out[c.ValueNode.Content[i].Value] = c.ValueNode.Content[i+1].Value
+	}
+
+	return out
+}
+
+func parse(t *testing.T, src string) *config.File {
+	t.Helper()
+
+	f, err := config.Parse("test.yaml", []byte(src))
+	require.NoError(t, err)
+
+	return f
+}
+
+// TestAMergeKeySuppliesSettings pins the shape the issue opens with: the
+// collector resolves the merge before it reads a single setting, so a rule has
+// to see the merged mapping rather than a key called "<<".
+func TestAMergeKeySuppliesSettings(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, `
+processors:
+  memory_limiter/base: &shared
+    check_interval: 1s
+    limit_mib: 512
+  memory_limiter:
+    <<: *shared
+    spike_limit_mib: 128
+`)
+
+	assert.Equal(t, map[string]string{
+		"check_interval":  "1s",
+		"limit_mib":       "512",
+		"spike_limit_mib": "128",
+	}, settings(t, f, "memory_limiter"))
+}
+
+// TestAKeyWrittenLocallyWinsOverAMergedOne pins the merge key's whole purpose:
+// the anchor is the base and what the component writes itself is the override.
+func TestAKeyWrittenLocallyWinsOverAMergedOne(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, `
+processors:
+  batch/base: &base
+    send_batch_size: 500
+    timeout: 5s
+  batch:
+    <<: *base
+    send_batch_size: 8000
+`)
+
+	assert.Equal(t, "8000", settings(t, f, "batch")["send_batch_size"],
+		"the local key should win over the merged one")
+}
+
+// TestAKeyWrittenAfterTheMergeStillWins pins that precedence is the merge
+// key's, not the file's order: yaml.v3 lets the override sit below the "<<"
+// line, and most configs write it that way.
+func TestAKeyWrittenAfterTheMergeStillWins(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, "processors:\n  batch/base: &base {timeout: 5s}\n  batch:\n    <<: *base\n    timeout: 10s\n")
+
+	assert.Equal(t, "10s", settings(t, f, "batch")["timeout"])
+}
+
+// TestAnAliasIsTheWholeComponentBody pins the shape the issue calls worse,
+// because nothing in the old report hinted at the cause: every setting read as
+// absent and the rules reported the absence.
+func TestAnAliasIsTheWholeComponentBody(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, `
+processors:
+  memory_limiter/base: &shared
+    check_interval: 1s
+    limit_mib: 512
+  memory_limiter: *shared
+`)
+
+	assert.Equal(t, map[string]string{"check_interval": "1s", "limit_mib": "512"},
+		settings(t, f, "memory_limiter"))
+}
+
+// TestASequenceOfMergesAppliesTheFirstThatCarriesTheKey pins the order
+// yaml.v3 applies "<<: [*a, *b]" in.
+func TestASequenceOfMergesAppliesTheFirstThatCarriesTheKey(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, `
+processors:
+  batch/first: &first
+    timeout: 1s
+  batch/second: &second
+    timeout: 2s
+    send_batch_size: 500
+  batch:
+    <<: [*first, *second]
+`)
+
+	assert.Equal(t, map[string]string{"timeout": "1s", "send_batch_size": "500"},
+		settings(t, f, "batch"),
+		"the earlier merge should win the key both carry, and the later one should still supply its own")
+}
+
+// TestAMergeInsideAnAnchorIsResolvedToo pins that an anchor built on another
+// anchor arrives merged, however many levels deep the base goes.
+func TestAMergeInsideAnAnchorIsResolvedToo(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, `
+processors:
+  batch/root: &root
+    timeout: 5s
+  batch/middle: &middle
+    <<: *root
+    send_batch_size: 500
+  batch:
+    <<: *middle
+    send_batch_max_size: 1000
+`)
+
+	assert.Equal(t, map[string]string{
+		"timeout":             "5s",
+		"send_batch_size":     "500",
+		"send_batch_max_size": "1000",
+	}, settings(t, f, "batch"))
+}
+
+// TestAMergedSettingKeepsThePositionItWasWrittenAt pins where a finding about
+// a merged setting lands: on the line in the anchor, which is the line the
+// reader has to edit. Repositioning it onto the component would point at a
+// line that does not hold the setting.
+func TestAMergedSettingKeepsThePositionItWasWrittenAt(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, "processors:\n  batch/base: &base\n    timeout: 5s\n  batch:\n    <<: *base\n")
+
+	c, found := f.Component(config.KindProcessor, config.ParseID("batch"))
+	require.True(t, found)
+	require.Len(t, c.ValueNode.Content, 2)
+
+	assert.Equal(t, 3, f.Pos(c.ValueNode.Content[1]).Line, "the value should keep the anchor's line")
+}
+
+// TestAQuotedMergeKeyIsAKeyOfItsOwn pins that the tag decides, not the
+// spelling: yaml.v3 reads a quoted "<<" as a plain string key, and so does the
+// collector.
+func TestAQuotedMergeKeyIsAKeyOfItsOwn(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, "processors:\n  batch/base: &base {timeout: 5s}\n  batch:\n    \"<<\": *base\n")
+
+	assert.Contains(t, settings(t, f, "batch"), "<<",
+		"a quoted key is not a merge key")
+}
+
+// TestAMergeOfSomethingThatIsNotAMappingIsLeftAlone pins the one merge the
+// collector cannot load either: yaml.v3 fails the decode outright, so dropping
+// the key quietly would leave nothing for a rule to report.
+func TestAMergeOfSomethingThatIsNotAMappingIsLeftAlone(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, "processors:\n  batch:\n    <<: hello\n")
+
+	assert.Contains(t, settings(t, f, "batch"), "<<")
+}
+
+// TestACyclicAliasDoesNotHang pins that a document yaml.v3 refuses to decode
+// still parses: the node tree comes back with the loop in it, and a linter
+// that recursed into it would never report anything at all.
+func TestACyclicAliasDoesNotHang(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		_, err := config.Parse("test.yaml", []byte("processors:\n  batch: &loop\n    nested: [*loop]\n"))
+		assert.NoError(t, err)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("parsing an anchor that contains itself did not finish")
+	}
+}
+
+// TestALocalOverrideIsNotADuplicateKey pins that duplicates are read from the
+// document as written. Merging first would make every override look like the
+// same key declared twice, which is the merge key's purpose rather than a bug
+// in the config.
+func TestALocalOverrideIsNotADuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, `
+processors:
+  batch/base: &base
+    timeout: 5s
+  batch:
+    <<: *base
+    timeout: 10s
+`)
+
+	assert.Empty(t, f.DuplicateKeys)
+}
+
+// TestADuplicateInsideAnAnchorIsStillReported pins the other half: resolving
+// does not hide a key the anchor itself declares twice.
+func TestADuplicateInsideAnAnchorIsStillReported(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, "processors:\n  batch/base: &base\n    timeout: 5s\n    timeout: 10s\n  batch:\n    <<: *base\n")
+
+	require.Len(t, f.DuplicateKeys, 1)
+	assert.Equal(t, "timeout", f.DuplicateKeys[0].Key)
+}
+
+// TestAnAnchorMergedTwiceIsResolvedOnce pins that a base shared by several
+// components is applied to each of them and not to itself twice over.
+func TestAnAnchorMergedTwiceIsResolvedOnce(t *testing.T) {
+	t.Parallel()
+
+	f := parse(t, `
+processors:
+  batch/base: &base
+    timeout: 5s
+  batch/one:
+    <<: *base
+  batch/two:
+    <<: *base
+`)
+
+	want := map[string]string{"timeout": "5s"}
+	assert.Equal(t, want, settings(t, f, "batch/one"))
+	assert.Equal(t, want, settings(t, f, "batch/two"))
+	assert.Equal(t, want, settings(t, f, "batch/base"))
+}

--- a/pkg/rule/batchsizebounds/rule.go
+++ b/pkg/rule/batchsizebounds/rule.go
@@ -50,10 +50,6 @@ type batchProcessor struct {
 	// written. The entries are read where the duplicates are reported, since
 	// each finding names the entry it found.
 	metadataKeys *yaml.Node
-	// merged reports a YAML merge key among the settings. The document is read
-	// as written, so a key the merge supplies looks absent here, and a check
-	// that would otherwise fill in a default has to say nothing instead.
-	merged bool
 }
 
 // New builds the rule.
@@ -85,7 +81,6 @@ func readBatch(c config.Component) batchProcessor {
 		sendBatchMaxSize: rule.Absent(),
 		timeout:          rule.Absent(),
 		metadataKeys:     nil,
-		merged:           false,
 	}
 
 	if c.ValueNode == nil || c.ValueNode.Kind != yaml.MappingNode {
@@ -102,8 +97,6 @@ func readBatch(c config.Component) batchProcessor {
 			proc.timeout = rule.ReadDuration(e.Node)
 		case "metadata_keys":
 			proc.metadataKeys = e.Node
-		case rule.MergeKey:
-			proc.merged = true
 		default:
 			// Every other setting is the field schema's business.
 		}
@@ -143,15 +136,8 @@ func (r batchSizeBounds) checkSizes(ctx *rule.Context, proc batchProcessor) {
 	}
 
 	size := int64(defaultSendBatchSize)
-
-	switch {
-	case proc.sendBatchSize.Known:
+	if proc.sendBatchSize.Known {
 		size = proc.sendBatchSize.Num
-	case proc.merged:
-		// The merge key may be what sets send_batch_size, and the collector
-		// resolves it before either number is read. Filling in the default
-		// here would report a figure the config overrides.
-		return
 	}
 
 	if proc.sendBatchMaxSize.Num >= size {

--- a/pkg/rule/debugextensionexposed/rule.go
+++ b/pkg/rule/debugextensionexposed/rule.go
@@ -104,46 +104,10 @@ func endpointNode(settings *yaml.Node) mo.Option[*yaml.Node] {
 		return mo.None[*yaml.Node]()
 	}
 
-	var merges []*yaml.Node
-
-	for _, e := range rule.MapEntries(settings, "") {
-		switch e.Key {
-		case rule.EndpointKey:
-			// A key the component writes itself replaces a merged one
-			// outright, so there is nothing further to look at.
-			return rule.EndpointScalar(e.Node)
-		case rule.MergeKey:
-			merges = append(merges, e.Node)
-		default:
-			// Every other setting is another rule's business.
-		}
+	node, held := rule.ChildNode(settings, rule.EndpointKey).Get()
+	if !held {
+		return mo.None[*yaml.Node]()
 	}
 
-	return mergedEndpoint(merges)
-}
-
-// mergedEndpoint reads the endpoint a merge key supplies to a component that
-// wrote none of its own. The value of a merge is one mapping or a list of
-// them, and the first that holds the key wins, which is what the merge does at
-// load time.
-func mergedEndpoint(merges []*yaml.Node) mo.Option[*yaml.Node] {
-	for _, merge := range merges {
-		merge = rule.ResolveAlias(merge)
-		if merge == nil {
-			continue
-		}
-
-		targets := []*yaml.Node{merge}
-		if merge.Kind == yaml.SequenceNode {
-			targets = merge.Content
-		}
-
-		for _, target := range targets {
-			if node, held := rule.ChildNode(target, rule.EndpointKey).Get(); held {
-				return rule.EndpointScalar(node)
-			}
-		}
-	}
-
-	return mo.None[*yaml.Node]()
+	return rule.EndpointScalar(node)
 }

--- a/pkg/rule/hardcodedsecret/rule.go
+++ b/pkg/rule/hardcodedsecret/rule.go
@@ -40,6 +40,12 @@ func New() rule.Rule {
 type hardcodedSecret struct{ rule.Base }
 
 func (r hardcodedSecret) Check(ctx *rule.Context) {
+	// A value written once behind an anchor and used by several components is
+	// one node, reached once per use. It is one credential in one place to
+	// edit, so it is reported once: repeating it under each component would
+	// put the same line in the report as many times as the config aliases it.
+	reported := map[*yaml.Node]bool{}
+
 	for _, kind := range config.Kinds() {
 		sec := ctx.File.Sections[kind]
 		if sec == nil {
@@ -48,6 +54,12 @@ func (r hardcodedSecret) Check(ctx *rule.Context) {
 
 		for _, c := range sec.Components {
 			for _, hit := range findSecrets(c.ValueNode, kind.Section()+"."+c.ID.String(), "", false) {
+				if reported[hit.node] {
+					continue
+				}
+
+				reported[hit.node] = true
+
 				ctx.Report(rule.Finding{
 					Node: hit.node, Path: hit.path,
 					// The value is never quoted back. Printing it would copy the
@@ -102,10 +114,9 @@ func findSecrets(n *yaml.Node, path, key string, inHeaders bool) []secretHit {
 			out = append(out, secretHit{node: n, path: path})
 		}
 	default:
-		// An alias is a value written once and used twice, and the anchor is
-		// reported where it is written whenever that is somewhere this walk
-		// reaches. Following it here would report the same credential at every
-		// use, and only one of them is somewhere to edit.
+		// Aliases are resolved at parse time, so the only node left here is one
+		// that could not be: an anchor that contains itself, which the
+		// collector refuses to load at all.
 	}
 
 	return out

--- a/pkg/rule/hardcodedsecret/rule_test.go
+++ b/pkg/rule/hardcodedsecret/rule_test.go
@@ -281,9 +281,9 @@ service:
 	assert.Equal(t, "exporters.otlp.backends[0].token", found[1].Path)
 }
 
-// An alias is the anchor it points at, written once and used twice. Following
-// it would report the same credential in two places, and only one of them is
-// somewhere to edit.
+// An alias is the anchor it points at, written once and used twice. The parser
+// resolves it, so both exporters carry the same node, and reporting it per use
+// would put the same line in the report twice with only one place to edit.
 func TestHardcodedSecretReportsAnAnchorOnce(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/rule/missingbatch/rule.go
+++ b/pkg/rule/missingbatch/rule.go
@@ -246,33 +246,21 @@ const (
 func readQueueBatching(c config.Component) batching {
 	var block *yaml.Node
 
-	merged := false
-
 	settings := rule.ResolveAlias(c.ValueNode)
 	if settings != nil && settings.Kind == yaml.MappingNode {
 		for _, e := range rule.MapEntries(settings, "") {
-			switch e.Key {
-			case rule.SendingQueueKey:
+			if e.Key == rule.SendingQueueKey {
 				block = rule.ResolveAlias(e.Node)
-			case rule.MergeKey:
-				// The merge may be what supplies the whole block.
-				merged = true
-			default:
-				// Every other setting is another rule's business.
 			}
 		}
 	}
 
 	switch {
 	case block != nil && block.Kind == yaml.MappingNode:
-		// A merge outside the block cannot reach into one the exporter writes
-		// itself: a key present locally replaces the merged value outright.
 		return readBatchBlock(block)
 	case block != nil && !rule.IsNull(block):
 		// A queue the collector builds from an expansion may well be one that
 		// batches, and nothing here can see what it holds.
-		return batchUnknown
-	case merged:
 		return batchUnknown
 	}
 
@@ -289,21 +277,10 @@ func readQueueBatching(c config.Component) batching {
 // an exporter that names a batcher has said what it wants, and telling it to
 // batch would be advising the setting it already writes.
 func readBatchBlock(block *yaml.Node) batching {
-	merged := false
-
 	for _, e := range rule.MapEntries(block, "") {
-		switch e.Key {
-		case rule.BatchKey:
+		if e.Key == rule.BatchKey {
 			return batchQueue
-		case rule.MergeKey:
-			merged = true
-		default:
-			// Every other queue setting is another rule's business.
 		}
-	}
-
-	if merged {
-		return batchUnknown
 	}
 
 	return batchNone

--- a/pkg/rule/missingbatch/rule_test.go
+++ b/pkg/rule/missingbatch/rule_test.go
@@ -107,8 +107,15 @@ func TestMissingBatch(t *testing.T) {
 			settings: "    sending_queue: ${env:QUEUE}",
 			want:     false,
 		},
-		"a queue built from a merge key": {
+		// A merge key is resolved before a rule sees it, so what it supplies is
+		// read like anything else: this queue is sized and persisted and does
+		// not batch, which is the finding.
+		"a queue a merge key fills in with no batcher": {
 			settings: "    sending_queue:\n      <<: &queue {queue_size: 5000}\n      storage: file_storage",
+			want:     true,
+		},
+		"a queue a merge key gives a batcher": {
+			settings: "    sending_queue:\n      <<: &queue {batch: {min_size: 100}}\n      storage: file_storage",
 			want:     false,
 		},
 	}

--- a/pkg/rule/node.go
+++ b/pkg/rule/node.go
@@ -13,11 +13,6 @@ import (
 // "false" is not mistaken for the value.
 const BoolTag = "!!bool"
 
-// MergeKey is the YAML merge key. A key it supplies looks absent to a rule
-// reading the document as written, so a check that would otherwise fill in a
-// default has to say nothing instead.
-const MergeKey = "<<"
-
 // mappingStride is the step between keys in a yaml.Node mapping, whose Content
 // alternates key, value, key, value.
 const mappingStride = 2
@@ -109,6 +104,11 @@ func WalkSettings(n *yaml.Node, path string, depth int, visit func(*yaml.Node, s
 }
 
 // ResolveAlias follows an anchor reference to the node it stands for.
+//
+// The parser resolves every alias it can, so what is left for this to follow
+// is the one it cannot: an anchor that contains itself, which yaml.v3 refuses
+// to decode and the collector therefore never loads. The depth bound is what
+// makes that safe to walk.
 func ResolveAlias(n *yaml.Node) *yaml.Node {
 	for i := 0; n != nil && n.Kind == yaml.AliasNode && i < MaxSettingsDepth; i++ {
 		n = n.Alias

--- a/pkg/rule/nopersistentqueue/rule.go
+++ b/pkg/rule/nopersistentqueue/rule.go
@@ -82,11 +82,10 @@ type sendingQueue struct {
 	// counts: it resolves to an extension the linter cannot see, not to
 	// nothing. Only an empty or null value is nobody naming anything.
 	persisted bool
-	// unresolved reports that the document does not settle the question here: a
-	// merge key that may be what supplies storage, or an enabled the collector
-	// only learns once an expansion resolves. Either way the queue read here is
-	// not necessarily the queue that runs, and a finding would be about a
-	// config nobody wrote.
+	// unresolved reports that the document does not settle the question here:
+	// an enabled the collector only learns once an expansion resolves. The
+	// queue read here is then not necessarily the queue that runs, and a
+	// finding would be about a config nobody wrote.
 	unresolved bool
 }
 
@@ -116,14 +115,8 @@ func readSendingQueue(c config.Component) sendingQueue {
 	var block *yaml.Node
 
 	for _, e := range rule.MapEntries(settings, "") {
-		switch e.Key {
-		case rule.SendingQueueKey:
+		if e.Key == rule.SendingQueueKey {
 			queue.node, queue.written, block = e.Node, true, rule.ResolveAlias(e.Node)
-		case rule.MergeKey:
-			// The merge may be what supplies the whole block.
-			queue.unresolved = true
-		default:
-			// Every other setting is another rule's business.
 		}
 	}
 
@@ -131,10 +124,6 @@ func readSendingQueue(c config.Component) sendingQueue {
 		return queue
 	}
 
-	// A merge outside the block cannot reach into one the exporter writes
-	// itself: a key present locally replaces the merged value outright. Only
-	// what is inside the block can still leave the queue unsettled.
-	queue.unresolved = false
 	readQueueBlock(block, &queue)
 
 	return queue
@@ -166,8 +155,6 @@ func readQueueBlock(block *yaml.Node, queue *sendingQueue) {
 			// Whether what was written is a name the collector can resolve is
 			// invalid-value's and undefined-extension-reference's to say.
 			queue.persisted = !rule.IsNull(val) && (val.Kind != yaml.ScalarNode || val.Value != "")
-		case rule.MergeKey:
-			queue.unresolved = true
 		default:
 			// Every other queue setting is the field schema's business.
 		}

--- a/pkg/ruleset/ruleset_test.go
+++ b/pkg/ruleset/ruleset_test.go
@@ -829,3 +829,125 @@ func TestNoBuiltInRuleTakesSettingsYet(t *testing.T) {
 		}
 	}
 }
+
+// mergedClean is ruletest.Clean with the memory limiter's settings moved into
+// an anchor and merged back in -- the shape #66 opens with, and one the
+// collector accepts as written, because confmap resolves the merge before it
+// reads a setting.
+const mergedClean = `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  memory_limiter/base: &shared
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  memory_limiter:
+    <<: *shared
+    spike_limit_mib: 64
+  batch:
+exporters:
+  otlp:
+    endpoint: backend:4317
+extensions:
+  zpages:
+service:
+  extensions: [zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp]
+    traces/base:
+      receivers: [otlp]
+      processors: [memory_limiter/base, batch]
+      exporters: [otlp]
+`
+
+// TestAMergedConfigIsAsQuietAsTheOneItWasWrittenFrom is the whole point of
+// resolving merges: a false error on a config that starts fine teaches people
+// to stop believing the tool.
+func TestAMergedConfigIsAsQuietAsTheOneItWasWrittenFrom(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, check(t, mergedClean))
+}
+
+// TestAnAliasedComponentBodyIsAsQuietToo pins the shape #66 calls worse,
+// because the old report named settings that are plainly in the file and
+// nothing in it hinted at the alias.
+func TestAnAliasedComponentBodyIsAsQuietToo(t *testing.T) {
+	t.Parallel()
+
+	src := strings.Replace(mergedClean,
+		"  memory_limiter:\n    <<: *shared\n    spike_limit_mib: 64\n",
+		"  memory_limiter: *shared\n", 1)
+	require.NotEqual(t, mergedClean, src, "the fixture should still hold the merged limiter")
+
+	assert.Empty(t, check(t, src))
+}
+
+// mergedExporter merges an exporter's settings out of an anchor, which is what
+// puts the merge in front of the rules that read a field schema. The processors
+// in ruletest.Schema have no fields, so the limiter above cannot exercise them.
+const mergedExporter = `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+exporters:
+  otlp/base: &base
+    endpoint: backend:4317
+    timeout: 30s
+  otlp:
+    <<: *base
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp, otlp/base]
+`
+
+// TestTheFieldRulesReadWhatTheMergeSupplies pins the three rules that read a
+// field schema. Before the merge was resolved, "<<" was an unknown setting,
+// the required endpoint it supplies read as absent, and the values it carries
+// were never checked at all.
+func TestTheFieldRulesReadWhatTheMergeSupplies(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"unknown-field", "required-field", "invalid-value"} {
+		assert.Emptyf(t, checkRule(t, name, mergedExporter), "%s should be quiet on a merged config", name)
+	}
+}
+
+// TestAMergedValueIsStillChecked pins the other direction: resolving the merge
+// is what puts the value in front of the rule, so a bad one supplied by an
+// anchor is reported rather than skipped.
+func TestAMergedValueIsStillChecked(t *testing.T) {
+	t.Parallel()
+
+	src := strings.Replace(mergedExporter, "timeout: 30s", "timeout: soon", 1)
+
+	found := checkRule(t, "invalid-value", src)
+	require.Len(t, found, 2, "the anchor and the exporter that merges it both carry the value")
+
+	paths := []string{found[0].Path, found[1].Path}
+	assert.Contains(t, paths, "exporters.otlp.timeout",
+		"the exporter that merges the value should be reported, not only the anchor it came from")
+}
+
+// TestWrongNodeTypeReportsWhatAnAliasResolvesTo pins that resolution does not
+// quiet the shape rules: an alias standing in for a scalar where a mapping
+// belongs is still an error, reported for what it resolves to rather than for
+// being an alias.
+func TestWrongNodeTypeReportsWhatAnAliasResolvesTo(t *testing.T) {
+	t.Parallel()
+
+	found := checkRule(t, "wrong-node-type", "_base: &base not-a-mapping\nreceivers: *base\n")
+	require.Len(t, found, 1)
+	assert.Contains(t, found[0].Message, "got a scalar")
+}


### PR DESCRIPTION
## Why

The linter walked the `yaml.Node` tree as written: a merge key is a key called `<<` whose value is an alias, and an alias is an `AliasNode` rather than the mapping it points at. The collector resolves both before it sees a single setting — confmap unmarshals through yaml.v3 — so every rule that read a component's settings was reading a different config from the one that will run.

```yaml
processors:
  memory_limiter/base: &shared
    check_interval: 1s
    limit_mib: 512
  memory_limiter:
    <<: *shared
    spike_limit_mib: 128
```

```
error: processor "memory_limiter" has no check_interval, and its default of 0s is rejected [memory-limiter-config]
error: processor "memory_limiter" sets neither limit_mib nor limit_percentage [memory-limiter-config]
warning: unknown setting "<<" for processors.memory_limiter [unknown-field]
```

An alias used as a whole component body was worse — two errors naming settings that are plainly in the file, and nothing hinting at the cause.

## What

Merges and aliases are resolved once, in `pkg/config` at parse time, in a new `resolve.go`. `f.Root` is rewritten in place, so every existing rule is correct without choosing anything, and a rule needs no knowledge of `<<` at all.

**Positions.** Nodes are reused rather than copied, so a merged setting keeps the position it was written at: a finding about it lands on the line in the anchor, which is the line to edit.

**Precedence.** A key written locally wins over one a merge supplies, whether it is written above or below the `<<` line. Among several merges (`<<: [*a, *b]`) the first to carry a key wins, which is the order yaml.v3 applies them in.

**Recursion.** A merge inside an anchor is resolved too, however deep the base goes. An anchor that contains itself is left alone rather than followed: yaml.v3 refuses to decode one, so the collector never loads it, and the linter has to survive it to report anything at all. A merge whose value is neither a mapping nor a list of them is left in place for the same reason — dropping it quietly would hide a file the collector cannot load.

**The details the issue asked to settle.**

- `duplicate-key` still reads the document as written: duplicates are collected before anything is merged in, so an override is not a key declared twice. A key the *anchor* declares twice is still reported.
- `wrong-node-type` reports what an alias resolves to (`got a scalar`) rather than that it saw an alias.
- `unknown-top-level-key` is untouched, so an anchor parked under `_shared:` is still the error it is.
- A quoted `"<<"` stays a key of its own, because the `!!merge` tag decides rather than the spelling — the same call yaml.v3 makes.

**Workarounds removed.** The `merged` flag in `batch-size-bounds` (#44, PR #65), the merge branches in `no-persistent-queue`, `missing-batch` and `debug-extension-exposed`, and `rule.MergeKey` itself. `ResolveAlias` stays for the one alias the parser deliberately leaves: the cyclic one.

`hardcoded-secret` now reports a credential node once however many components alias it. That is what it always did — an anchor is one place to edit — but the reason changed: the node is shared rather than followed, so the rule dedupes on it.

## Behaviour changes worth naming

`missing-batch` used to call a queue built from a merge key "unknown" and stay quiet. It can now read what the merge supplies, so a merged queue with no batcher is reported and one with a batcher is not. The test case is split in two accordingly.

## Tests

`pkg/config/resolve_test.go` covers the merge supplying settings, local override (above and below the `<<`), an alias as a whole component body, a sequence of merges, a nested merge, position preservation, a quoted `"<<"`, an unmergeable value, a cyclic alias that must not hang, duplicates across the override and inside the anchor, and one anchor merged twice.

`pkg/ruleset/ruleset_test.go` covers the whole set staying quiet on both shapes from the issue, the three field rules reading what the merge supplies, a bad merged value still being reported for the component that merges it, and `wrong-node-type` still speaking up.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z