### PR TITLE
fix: five small correctness slips

### DIFF
--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -401,50 +402,109 @@ func join(parent, key string) string {
 }
 
 // SyntaxError is a YAML parse failure with a position, when one is available.
+//
+// One parse can fail more than once: a yaml.TypeError carries an entry for
+// every value in the document that could not be unmarshalled. The first is
+// this error's own position and message and [SyntaxError.Rest] holds the
+// others, so a config with three type errors reports three rather than
+// handing them out one re-run at a time.
 type SyntaxError struct {
 	Path         string
+	Line, Column int
+	Msg          string
+	// Rest is the further failures from the same parse, in the order the
+	// parser reported them. It is empty for a parse that failed once, which
+	// is every plain syntax error.
+	Rest []Fault
+}
+
+// Fault is one parse failure, without the file it was found in: the
+// *SyntaxError carrying it already names that.
+type Fault struct {
 	Line, Column int
 	Msg          string
 }
 
 func (e *SyntaxError) Error() string {
-	p := diag.Position{File: e.Path, Line: e.Line, Column: e.Column}
-
-	return p.String() + ": " + e.Msg
-}
-
-// Diagnostic renders the syntax error as a linter finding.
-func (e *SyntaxError) Diagnostic() diag.Diagnostic {
-	return diag.Diagnostic{
-		Rule:     "yaml-syntax",
-		Severity: diag.Error,
-		Message:  e.Msg,
-		Position: diag.Position{File: e.Path, Line: e.Line, Column: e.Column},
+	msgs := make([]string, 0, len(e.Rest)+1)
+	for _, f := range e.faults() {
+		p := diag.Position{File: e.Path, Line: f.Line, Column: f.Column}
+		msgs = append(msgs, p.String()+": "+f.Msg)
 	}
+
+	return strings.Join(msgs, "; ")
 }
 
-// syntaxError converts a yaml.v3 error into a *SyntaxError, recovering the line
-// number that yaml.v3 only reports inside the message text.
+// Diagnostic renders the first failure as a linter finding.
+func (e *SyntaxError) Diagnostic() diag.Diagnostic {
+	return e.Diagnostics()[0]
+}
+
+// Diagnostics renders every failure the parse reported as a linter finding.
+func (e *SyntaxError) Diagnostics() diag.Diagnostics {
+	out := make(diag.Diagnostics, 0, len(e.Rest)+1)
+	for _, f := range e.faults() {
+		out = append(out, diag.Diagnostic{
+			Rule:     "yaml-syntax",
+			Severity: diag.Error,
+			Message:  f.Msg,
+			Position: diag.Position{File: e.Path, Line: f.Line, Column: f.Column},
+		})
+	}
+
+	return out
+}
+
+// faults is the error as the flat list it stands for, first failure included.
+func (e *SyntaxError) faults() []Fault {
+	return append([]Fault{{Line: e.Line, Column: e.Column, Msg: e.Msg}}, e.Rest...)
+}
+
+// unlocated is added to a message the parser reported no line for, so a
+// diagnostic that lands at the top of the file says why it is there rather
+// than reading as a finding about the first line.
+const unlocated = " (the parser reported no line for this)"
+
+// syntaxError converts a yaml.v3 error into a *SyntaxError, keeping every
+// failure it reported and recovering the line numbers that yaml.v3 only
+// reports inside the message text.
 func syntaxError(path string, err error) error {
 	var te *yaml.TypeError
 
-	msg := err.Error()
+	msgs := []string{err.Error()}
 	if errors.As(err, &te) && len(te.Errors) > 0 {
-		msg = te.Errors[0]
+		msgs = te.Errors
 	}
 
+	first := fault(msgs[0])
+
+	out := &SyntaxError{Path: path, Line: first.Line, Column: first.Column, Msg: first.Msg}
+	for _, msg := range msgs[1:] {
+		out.Rest = append(out.Rest, fault(msg))
+	}
+
+	return out
+}
+
+// fault splits one yaml.v3 message into the position it names and the rest of
+// what it says.
+func fault(msg string) Fault {
 	msg = strings.TrimPrefix(msg, "yaml: ")
-	line := 0
 
-	if rest, ok := strings.CutPrefix(msg, "line "); ok {
-		num, tail, found := strings.Cut(rest, ":")
-		if found {
-			_, convErr := fmt.Sscanf(num, "%d", &line)
-			if convErr == nil {
-				msg = strings.TrimSpace(tail)
-			}
-		}
+	rest, ok := strings.CutPrefix(msg, "line ")
+	if !ok {
+		return Fault{Msg: msg + unlocated}
 	}
 
-	return &SyntaxError{Path: path, Line: line, Msg: msg}
+	num, tail, found := strings.Cut(rest, ":")
+	if !found {
+		return Fault{Msg: msg + unlocated}
+	}
+
+	line, convErr := strconv.Atoi(strings.TrimSpace(num))
+	if convErr != nil {
+		return Fault{Msg: msg + unlocated}
+	}
+
+	return Fault{Line: line, Msg: strings.TrimSpace(tail)}
 }

--- a/pkg/config/parse_internal_test.go
+++ b/pkg/config/parse_internal_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestSyntaxErrorKeepsEveryFailure covers what a parse failure is allowed to
+// lose. A yaml.TypeError carries one entry per value that would not decode,
+// and reporting only the first would hand them to the reader one re-run at a
+// time.
+func TestSyntaxErrorKeepsEveryFailure(t *testing.T) {
+	t.Parallel()
+
+	// Decoding into a yaml.Node does not produce a *yaml.TypeError today; the
+	// branch that reads one is there for a decode into a value, and what it
+	// does with the entries is worth pinning either way.
+	err := syntaxError("bad.yaml", &yaml.TypeError{Errors: []string{
+		"line 3: cannot unmarshal !!str into int",
+		"line 7: cannot unmarshal !!seq into map",
+	}})
+
+	var syn *SyntaxError
+
+	require.ErrorAs(t, err, &syn)
+
+	diags := syn.Diagnostics()
+	require.Len(t, diags, 2)
+	assert.Equal(t, 3, diags[0].Position.Line)
+	assert.Equal(t, "cannot unmarshal !!str into int", diags[0].Message)
+	assert.Equal(t, 7, diags[1].Position.Line)
+	assert.Equal(t, "cannot unmarshal !!seq into map", diags[1].Message)
+
+	for _, d := range diags {
+		assert.Equal(t, "yaml-syntax", d.Rule)
+		assert.Equal(t, "bad.yaml", d.Position.File)
+	}
+
+	// The error itself still says everything, for a caller that only logs it.
+	assert.Contains(t, err.Error(), "bad.yaml:3")
+	assert.Contains(t, err.Error(), "bad.yaml:7")
+
+	// Diagnostic stays the first of them, which is what a caller wanting one
+	// finding asked for.
+	assert.Equal(t, diags[0], syn.Diagnostic())
+}
+
+// TestSyntaxErrorSaysWhenItHasNoLine covers a message yaml.v3 formatted some
+// other way: the diagnostic lands at the top of the file, and has to say that
+// is where the position ran out rather than read as a finding about line 1.
+func TestSyntaxErrorSaysWhenItHasNoLine(t *testing.T) {
+	t.Parallel()
+
+	for name, msg := range map[string]string{
+		"no line prefix":              "yaml: control characters are not allowed",
+		"no colon after line":         "yaml: line 4 is where it went wrong",
+		"a line that is not a number": "yaml: line four: something went wrong",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var syn *SyntaxError
+
+			require.ErrorAs(t, syntaxError("bad.yaml", errors.New(msg)), &syn) //nolint:err113 // stands in for yaml.v3
+			assert.Equal(t, 0, syn.Line)
+			assert.True(t, strings.HasSuffix(syn.Msg, unlocated), "message should say it has no line: %q", syn.Msg)
+			assert.Contains(t, syn.Msg, strings.TrimPrefix(msg, "yaml: "))
+		})
+	}
+}

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -177,7 +177,7 @@ func (l *Linter) Lint(ctx context.Context, path string, src []byte) Result {
 		if ok := asSyntaxError(err, &syn); ok {
 			return Result{
 				Path: path, Status: Invalid,
-				Diagnostics: diag.Diagnostics{syn.Diagnostic()},
+				Diagnostics: syn.Diagnostics(),
 				Err:         err,
 			}
 		}

--- a/pkg/lint/output.go
+++ b/pkg/lint/output.go
@@ -333,9 +333,14 @@ func (f *tapFormatter) Result(r Result) error {
 }
 
 func (f *tapFormatter) Finish(Summary) error {
-	err := writef(f.w, "1..%d\n%s\n", f.n, strings.Join(f.lines, "\n"))
+	// A run with nothing to say is the plan and no more. Joining an empty set
+	// of lines onto it would leave a blank line a strict consumer need not
+	// accept.
+	if len(f.lines) == 0 {
+		return writef(f.w, "1..%d\n", f.n)
+	}
 
-	return err
+	return writef(f.w, "1..%d\n%s\n", f.n, strings.Join(f.lines, "\n"))
 }
 
 // githubFormatter emits GitHub Actions workflow commands so findings show up as

--- a/pkg/lint/output_test.go
+++ b/pkg/lint/output_test.go
@@ -1,0 +1,33 @@
+package lint_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/lint"
+)
+
+// TestTAPOutputIsWellFormedWhenEmpty covers the run with nothing in it: the
+// plan is the whole output, and the blank line that used to follow it is
+// something a strict TAP consumer need not accept.
+func TestTAPOutputIsWellFormedWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	f, err := lint.NewFormatter("tap", &buf, lint.FormatterOptions{Verbose: false, Summary: false, Color: false})
+	require.NoError(t, err)
+	require.NoError(t, f.Finish(lint.Summary{}))
+	assert.Equal(t, "1..0\n", buf.String())
+
+	buf.Reset()
+
+	f, err = lint.NewFormatter("tap", &buf, lint.FormatterOptions{Verbose: false, Summary: false, Color: false})
+	require.NoError(t, err)
+	require.NoError(t, f.Result(lint.Result{Path: "a.yaml", Status: lint.Valid, Diagnostics: nil, Err: nil}))
+	require.NoError(t, f.Finish(lint.Summary{}))
+	assert.Equal(t, "1..1\nok 1 - a.yaml\n", buf.String())
+}

--- a/pkg/rule/fieldwalker.go
+++ b/pkg/rule/fieldwalker.go
@@ -67,11 +67,13 @@ func (w FieldWalker) walk(field *schema.Field, node *yaml.Node, path string) {
 		return
 	}
 
-	if node.Kind == yaml.AliasNode {
-		node = node.Alias // validate what the anchor resolves to
-		if node == nil {
-			return
-		}
+	// Validate what the anchor resolves to. An anchor can name an alias, so
+	// one hop is not always enough; what is left after the whole chain is an
+	// anchor that contains itself, which is not a document the collector
+	// loads either and not one to report a type error against.
+	node = ResolveAlias(node)
+	if node == nil || node.Kind == yaml.AliasNode {
+		return
 	}
 
 	if IsNull(node) {

--- a/pkg/rule/fieldwalker_internal_test.go
+++ b/pkg/rule/fieldwalker_internal_test.go
@@ -1,0 +1,70 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// TestWalkFollowsAWholeAliasChain covers the alias that names an alias, which
+// is what an anchor written onto one produces: `b: &y *x` and then `c: *y`.
+// Stopping after a single hop left the type check reading an alias node and
+// reporting the value as the wrong type.
+func TestWalkFollowsAWholeAliasChain(t *testing.T) {
+	t.Parallel()
+
+	chained, cyclic := aliasChain(t)
+
+	for name, node := range map[string]*yaml.Node{
+		"an alias naming an alias":    chained,
+		"an anchor containing itself": cyclic,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var got []string
+
+			w := FieldWalker{
+				Ctx:        nil,
+				OnUnknown:  nil,
+				OnRequired: nil,
+				OnInvalid: func(_ *yaml.Node, path, want string) {
+					got = append(got, path+": "+want)
+				},
+				OnDeprecated: nil,
+			}
+			w.walk(&schema.Field{Type: "string"}, node, "receivers.otlp.endpoint")
+
+			assert.Empty(t, got, "a resolved alias is the value it stands for, not a type error")
+		})
+	}
+}
+
+// aliasChain returns an alias whose target is itself an alias, and then one
+// that leads back to itself. The parser resolves every alias it can, so both
+// are built by rewiring what it produced for a single hop.
+func aliasChain(t *testing.T) (*yaml.Node, *yaml.Node) {
+	t.Helper()
+
+	var doc yaml.Node
+
+	require.NoError(t, yaml.Unmarshal([]byte("a: &x localhost:4317\nb: *x\nc: *x\n"), &doc))
+
+	root := doc.Content[0]
+	first, second := root.Content[3], root.Content[5]
+
+	require.Equal(t, yaml.AliasNode, first.Kind)
+	require.Equal(t, yaml.AliasNode, second.Kind)
+
+	second.Alias = first
+
+	cyclic := &yaml.Node{} //nolint:exhaustruct // the zero node is rewired into an alias to itself
+	cyclic.Kind = yaml.AliasNode
+	cyclic.Alias = cyclic
+
+	return second, cyclic
+}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -227,6 +227,10 @@ const yamlIndent = 2
 // errEmptySchema reports a schema file with no document in it.
 var errEmptySchema = errors.New("decode schema: empty document")
 
+// errMultiDocumentSchema reports a schema file holding more than one YAML
+// document, where everything after the first would otherwise be dropped.
+var errMultiDocumentSchema = errors.New("decode schema: more than one document")
+
 // Format is a schema serialisation format.
 type Format string
 
@@ -251,6 +255,20 @@ func Read(r io.Reader) (*Schema, error) {
 			return nil, errEmptySchema
 		}
 
+		return nil, fmt.Errorf("decode schema: %w", err)
+	}
+
+	// A schema is one document. A stray "---" in a generated file would
+	// otherwise validate against whatever came first and take the rest with
+	// it in silence, which is not something the outcome would ever show.
+	var extra Schema
+
+	err = dec.Decode(&extra)
+	if err == nil {
+		return nil, errMultiDocumentSchema
+	}
+
+	if !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("decode schema: %w", err)
 	}
 

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -1,0 +1,41 @@
+package schema_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// TestReadTakesTheWholeFile covers what a schema file is allowed to hold. A
+// second document is the interesting one: everything after the first would be
+// dropped, and nothing about the outcome would say a component went missing.
+func TestReadTakesTheWholeFile(t *testing.T) {
+	t.Parallel()
+
+	const one = "collectorVersion: v0.157.0\ncomponents:\n  receiver:\n    otlp: {}\n"
+
+	sch, err := schema.Read(strings.NewReader(one))
+	require.NoError(t, err)
+	assert.Equal(t, "v0.157.0", sch.CollectorVersion)
+
+	// The type is filled in from the key it was written under.
+	comp, ok := sch.Lookup(config.KindReceiver, "otlp")
+	require.True(t, ok)
+	assert.Equal(t, "otlp", comp.Type)
+
+	_, err = schema.Read(strings.NewReader(one + "---\n" + one))
+	require.Error(t, err, "a second document should not be dropped in silence")
+
+	// The second document is read strictly too, so a broken one is reported as
+	// what it is rather than as an extra document.
+	_, err = schema.Read(strings.NewReader(one + "---\nnotAField: true\n"))
+	require.Error(t, err)
+
+	_, err = schema.Read(strings.NewReader(""))
+	require.Error(t, err, "an empty file is not a schema")
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,8 +9,9 @@
 package version
 
 import (
+	"fmt"
+	"regexp"
 	"runtime/debug"
-	"strings"
 )
 
 const (
@@ -30,9 +31,13 @@ const (
 	shortRevisionLen = 7
 
 	// pseudoRevisionLen is how much of a commit a module pseudo-version
-	// carries, and so how much of one to look for in a version to recognise
-	// that the toolchain derived it rather than a person choosing it.
+	// carries, and so how much of one to compare against a version to
+	// recognise that the toolchain derived it rather than a person choosing it.
 	pseudoRevisionLen = 12
+
+	// pseudoStampLen is the length of the UTC build timestamp a pseudo-version
+	// carries just before the commit, e.g. 20260808131440.
+	pseudoStampLen = 14
 
 	// dirtySuffix marks a build from a tree with uncommitted changes. The
 	// toolchain writes "+dirty" onto a version derived from a tag; this is the
@@ -99,6 +104,14 @@ func render(moduleVersion, revision string, modified bool) string {
 	return short
 }
 
+// pseudoVersionRE matches what every module pseudo-version ends in: the build
+// timestamp and the commit it was derived from, with the toolchain's "+dirty"
+// left in place. What comes before differs with the last tag -- there may be
+// none, or "-0." or "-<pre>.0." after one -- so the tail is what says the
+// toolchain wrote the version rather than a person choosing it.
+var pseudoVersionRE = regexp.MustCompile(
+	fmt.Sprintf(`[-.][0-9]{%d}-([0-9a-f]{%d})(?:\+[0-9A-Za-z.-]+)?$`, pseudoStampLen, pseudoRevisionLen))
+
 // derivedFrom reports whether a module version is a pseudo-version standing in
 // for the given commit rather than a tag someone chose.
 func derivedFrom(moduleVersion, revision string) bool {
@@ -106,5 +119,7 @@ func derivedFrom(moduleVersion, revision string) bool {
 		return false
 	}
 
-	return strings.Contains(moduleVersion, revision[:pseudoRevisionLen])
+	m := pseudoVersionRE.FindStringSubmatch(moduleVersion)
+
+	return m != nil && m[1] == revision[:pseudoRevisionLen]
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -43,6 +43,26 @@ func TestRender(t *testing.T) {
 			modified:      false,
 			want:          "b7dbdd5",
 		},
+		"a pseudo-version cut after a tag gives way to the commit too": {
+			moduleVersion: "v1.2.4-0.20260808131440-b7dbdd5cfc07",
+			revision:      revision,
+			modified:      false,
+			want:          "b7dbdd5",
+		},
+		"a tag that happens to carry the commit is still the tag": {
+			// Not a pseudo-version: no build timestamp before the commit, so
+			// it is a name someone chose and what the binary should report.
+			moduleVersion: "v1.2.3-b7dbdd5cfc07",
+			revision:      revision,
+			modified:      false,
+			want:          "v1.2.3-b7dbdd5cfc07",
+		},
+		"a pseudo-version standing in for another commit is reported as it is": {
+			moduleVersion: "v0.0.0-20260808131440-0123456789ab",
+			revision:      revision,
+			modified:      false,
+			want:          "v0.0.0-20260808131440-0123456789ab",
+		},
 		"an untagged dirty tree is named the way git describe names it": {
 			moduleVersion: "v0.0.0-20260808131440-b7dbdd5cfc07+dirty",
 			revision:      revision,


### PR DESCRIPTION
Closes #74.

Five independent fixes, one commit each.

**`schema.Read` kept only the first YAML document.** The decoder was asked once. A file with a stray `---` validated against what came first and dropped the rest in silence. It now decodes a second time and reports both a second document and a second document that does not decode.

**`syntaxError` lost every failure after the first, and sometimes the line.** A `yaml.TypeError` carries an entry per value that would not decode; only the first survived, so three type errors were handed over one re-run at a time. `SyntaxError` now carries the rest in `Rest []Fault` and `Diagnostics()` renders all of them, which is what the linter reports. When the line cannot be recovered from the message text, the message says so rather than landing at the top of the file as if the finding were there. (`Diagnostic()` still returns the first, for callers that want one.)

**`tapFormatter.Finish` emitted a stray blank line.** A run with no diagnostics wrote `1..0\n\n`; it now writes the plan alone.

**`fieldWalker.walk` dereferenced an alias exactly once.** An anchor written onto an alias (`b: &y *x`, then `c: *y`) gives an alias whose target is an alias, and the type check then ran against the `AliasNode` and called a good value the wrong type. It now uses `ResolveAlias`, which already loops with a depth bound, and skips what is left after the chain — an anchor containing itself, which the collector does not load either. Related to #66.

**`derivedFrom` matched a substring instead of a pseudo-version.** Any module version containing the first twelve characters of the commit read as a pseudo-version, so a tag named after a commit would have reported the bare commit instead of itself. It now matches the timestamp-and-revision tail the toolchain writes (all three pseudo-version shapes, `+dirty` included) and compares the revision.

## Testing

- `go test ./...` passes.
- `make lint` reports the same 50 pre-existing `goconst` findings as `origin/main`, and nothing new.
- New tests: schema multi-document rejection, every-fault-kept and no-line-reported for parse errors, empty TAP output, the alias chain (verified failing against the old single hop), and the pseudo-version cases including a tag that merely carries a commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z