### PR TITLE
feat: let the schema say which settings name an extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,9 @@ There is deliberately no flag form of the overrides.
 extension a component's own settings name — an exporter's
 `sending_queue.storage`, an `auth.authenticator` — that nothing declares, or
 that is declared and then left out of `service.extensions`, which the collector
-refuses to start on), `unused-component`, `duplicate-reference`,
+refuses to start on; the field schema is what says which settings hold one, so
+a setting upstream adds is checked as soon as its schema lands),
+`unused-component`, `duplicate-reference`,
 `connector-wiring` (a connector must export from one pipeline and receive into
 another, and must not close a loop).
 
@@ -921,6 +923,24 @@ References between those schemas are followed across modules, so a component's
 shared settings — `sending_queue`, `retry_on_failure`, TLS, gRPC client options
 — are expanded in full. What cannot be resolved stays open rather than being
 reported, so partial coverage never produces false positives.
+
+A setting that decodes into a `component.ID` is marked, since nothing in the
+value says so — a storage id and a directory path are both strings:
+
+```yaml
+sending_queue:
+  type: map
+  children:
+    storage: {type: string, extensionRef: storage}
+```
+
+That marker is what `undefined-extension-reference` reads, so which settings
+name an extension is derived from the sources rather than maintained as a list
+in the linter. The role — `storage`, `auth`, or a plain `extension` for a key
+the generator has no name for — is only what the diagnostic calls it. Schemas
+generated before the marker existed keep working: the rule still knows
+`sending_queue.storage` and `auth.authenticator` on its own, and that fallback
+falls away as the registry is regenerated.
 
 ## Layout
 

--- a/pkg/cmd/schemagen/fields.go
+++ b/pkg/cmd/schemagen/fields.go
@@ -254,6 +254,10 @@ func (s *schemaSet) merge(into, from *schema.Field) *schema.Field {
 		into.Enum = from.Enum
 	}
 
+	if into.ExtensionRef == "" {
+		into.ExtensionRef = from.ExtensionRef
+	}
+
 	if from.Open {
 		into.Open = true
 	}
@@ -401,6 +405,10 @@ func enrich(primary, secondary *schema.Field) {
 
 	if len(primary.Enum) == 0 {
 		primary.Enum = secondary.Enum
+	}
+
+	if primary.ExtensionRef == "" {
+		primary.ExtensionRef = secondary.ExtensionRef
 	}
 
 	if secondary.Open {

--- a/pkg/cmd/schemagen/gosource.go
+++ b/pkg/cmd/schemagen/gosource.go
@@ -23,6 +23,13 @@ import (
 // maxAliasHops bounds how far an alias chain is followed.
 const maxAliasHops = 8
 
+// componentIDType is the type a setting that names another component decodes
+// into. Inside a component's own config the component it names is an
+// extension: nothing else is addressable from there. It is what makes an
+// extension reference something the sources state rather than something this
+// generator has to be told about one setting at a time.
+const componentIDType = coreModuleRoot + "/component.ID"
+
 // goType is a type declaration found in the sources, kept with the imports of
 // the file that declared it so its own field types can be resolved.
 type goType struct {
@@ -187,7 +194,28 @@ func (g *goIndex) addStructField(out *schema.Field, decl *goType, f *ast.Field, 
 		out.Children = map[string]*schema.Field{}
 	}
 
-	out.Children[name] = g.field(decl, f.Type, firstLine(docText(f)), seen, depth)
+	child := g.field(decl, f.Type, firstLine(docText(f)), seen, depth)
+	if g.resolve(decl, f.Type) == componentIDType {
+		child.ExtensionRef = extensionRole(name)
+	}
+
+	out.Children[name] = child
+}
+
+// extensionRole says what the extension a setting names is used for. The type
+// is what identifies the reference, and it is component.ID either way, so
+// which kind of extension it is comes from the key it is written under. A key
+// this does not recognise is still a reference; it just reads as a plain
+// extension in a diagnostic instead of a storage or an auth one.
+func extensionRole(key string) string {
+	switch key {
+	case "storage":
+		return schema.RoleStorage
+	case "authenticator":
+		return schema.RoleAuth
+	default:
+		return schema.RoleExtension
+	}
 }
 
 // field maps a Go type onto a schema field, resolving named types through the

--- a/pkg/cmd/schemagen/schemagen_test.go
+++ b/pkg/cmd/schemagen/schemagen_test.go
@@ -322,6 +322,60 @@ replaces:
 	assert.NotContains(t, stdout, "type: int", "a text-decoded type was read as its underlying number")
 }
 
+// A setting that decodes into a component.ID names an extension, and that is
+// the only thing that says so: a storage id and a directory path are both
+// strings by the time they reach the schema. Marking it here is what lets
+// undefined-extension-reference find a reference without carrying a list of
+// the settings that hold one.
+func TestExtensionReferencesAreMarked(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	component := module(t, root, "go.opentelemetry.io/collector/component", map[string]string{
+		"identifiable.go": "package component\n\ntype ID struct{}\n\n" +
+			"func (id *ID) UnmarshalText(text []byte) error { return nil }\n",
+	})
+	exporter := module(t, root, "example.com/collector/exporter/otlpexporter", map[string]string{
+		"metadata.yaml": "type: otlp\nstatus:\n  class: exporter\n" +
+			"  stability:\n    beta: [traces]\n",
+		"config.go": "package otlpexporter\n\n" +
+			"import \"go.opentelemetry.io/collector/component\"\n\n" +
+			"type Config struct {\n" +
+			"\tEndpoint string `mapstructure:\"endpoint\"`\n" +
+			"\tQueue QueueConfig `mapstructure:\"sending_queue\"`\n" +
+			"\tAuth AuthConfig `mapstructure:\"auth\"`\n}\n\n" +
+			"type QueueConfig struct {\n" +
+			"\tStorageID *component.ID `mapstructure:\"storage\"`\n}\n\n" +
+			"type AuthConfig struct {\n" +
+			"\tAuthenticatorID component.ID `mapstructure:\"authenticator\"`\n" +
+			"\tWatcherID component.ID `mapstructure:\"watcher\"`\n}\n",
+	})
+
+	path := filepath.Join(root, "manifest.yaml")
+	writeFile(t, path, fmt.Sprintf(`
+dist:
+  name: custom
+  otelcol_version: 0.157.0
+exporters:
+  - gomod: example.com/collector/exporter/otlpexporter v0.0.0
+replaces:
+  - example.com/collector/exporter/otlpexporter => %s
+  - go.opentelemetry.io/collector/component => %s
+`, exporter, component))
+
+	code, stdout, stderr := run(t, "--builder", path, "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+	assert.Contains(t, stdout, "extensionRef: storage")
+	assert.Contains(t, stdout, "extensionRef: auth")
+	// A key the generator has no name for is still a reference. Saying so is
+	// what keeps a setting upstream adds from going unchecked until someone
+	// here notices it.
+	assert.Contains(t, stdout, "extensionRef: extension")
+	assert.Equal(t, 3, strings.Count(stdout, "extensionRef:"),
+		"a plain string setting was marked as an extension reference")
+}
+
 // TestGenerate runs the whole pipeline against modules on disk: the manifest
 // replaces every component with a local checkout, which is both what a
 // distribution under development does and what keeps this test off the network.

--- a/pkg/lint/linter.go
+++ b/pkg/lint/linter.go
@@ -188,7 +188,7 @@ func (l *Linter) Lint(ctx context.Context, path string, src []byte) Result {
 	ruleCtx := rule.Context{
 		File:   f,
 		Schema: l.opts.Schema,
-		Index:  rule.NewIndex(f),
+		Index:  rule.NewIndex(f, l.opts.Schema),
 		Avail:  nil,
 		Dists:  nil,
 		Strict: l.opts.Strict,

--- a/pkg/rule/index.go
+++ b/pkg/rule/index.go
@@ -5,6 +5,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 )
 
 // Index resolves references from the service block to component declarations,
@@ -29,14 +30,16 @@ type Index struct {
 	asExporter map[config.ID][]config.Pipeline
 }
 
-// NewIndex builds an index over a parsed config.
-func NewIndex(f *config.File) *Index {
+// NewIndex builds an index over a parsed config. The schema, which may be nil,
+// is what says which settings hold an extension reference; without one the
+// built-in list is all there is.
+func NewIndex(f *config.File, sch *schema.Schema) *Index {
 	idx := &Index{
 		File:       f,
 		declared:   map[config.Kind]map[config.ID]config.Component{},
 		used:       map[config.Kind]map[config.ID]bool{},
 		enabled:    map[config.ID]bool{},
-		extRefs:    extensionRefs(f),
+		extRefs:    extensionRefs(f, sch),
 		asReceiver: map[config.ID][]config.Pipeline{},
 		asExporter: map[config.ID][]config.Pipeline{},
 	}
@@ -173,18 +176,26 @@ type ExtensionRef struct {
 	Docs string
 }
 
-// extensionField is a settings key whose value names an extension. The list is
-// hardcoded because nothing in the field schema marks a string as an extension
-// id: neither configauth.Config nor the queue config says so, so a schema walk
-// cannot find these on its own.
+// Subject names the reference for a message: "storage extension", or a plain
+// "extension" when all the schema said is that the value has to resolve.
+func (r ExtensionRef) Subject() string {
+	if r.Role == "" || r.Role == schema.RoleExtension {
+		return "extension"
+	}
+
+	return r.Role + " extension"
+}
+
+// extensionField is a settings key whose value names an extension, for the
+// releases whose published schemas predate the extensionRef marker. A schema
+// that carries markers finds these on its own, and finds the ones this list
+// never had.
 type extensionField struct {
 	// parent is the key holding the reference, e.g. "sending_queue", and key
 	// is the field inside it that carries the id.
 	parent, key string
 	// role says what the extension is used for, for the message.
 	role string
-	// docs is the upstream page describing the setting.
-	docs string
 }
 
 // extensionFields lists the settings that name an extension. They are matched
@@ -195,14 +206,28 @@ type extensionField struct {
 // It returns a fresh slice so callers cannot alter what everyone else sees.
 func extensionFields() []extensionField {
 	return []extensionField{
-		{parent: SendingQueueKey, key: StorageKey, role: "storage", docs: ExporterQueueDocs},
-		{parent: "auth", key: "authenticator", role: "auth", docs: AuthDocs},
+		{parent: SendingQueueKey, key: StorageKey, role: schema.RoleStorage},
+		{parent: "auth", key: "authenticator", role: schema.RoleAuth},
+	}
+}
+
+// extensionRefDocs is the upstream page a reference of the given role is
+// described on. It is derived from the role rather than carried in the schema,
+// which would put a URL beside every marked field to say one of two things.
+func extensionRefDocs(role string) string {
+	switch role {
+	case schema.RoleStorage:
+		return ExporterQueueDocs
+	case schema.RoleAuth:
+		return AuthDocs
+	default:
+		return ""
 	}
 }
 
 // extensionRefs collects every extension reference in the file's component
 // settings, in declaration order.
-func extensionRefs(f *config.File) []ExtensionRef {
+func extensionRefs(f *config.File, sch *schema.Schema) []ExtensionRef {
 	return lo.FlatMap(config.Kinds(), func(kind config.Kind, _ int) []ExtensionRef {
 		sec := f.Sections[kind]
 		if sec == nil {
@@ -210,35 +235,117 @@ func extensionRefs(f *config.File) []ExtensionRef {
 		}
 
 		return lo.FlatMap(sec.Components, func(c config.Component, _ int) []ExtensionRef {
-			return componentExtensionRefs(c)
+			return componentExtensionRefs(c, settingsSchema(sch, kind, c))
 		})
 	})
 }
 
-func componentExtensionRefs(c config.Component) []ExtensionRef {
-	var out []ExtensionRef
+// settingsSchema is the field schema describing a component's settings, or nil
+// when the release being targeted has nothing to say about the component.
+func settingsSchema(sch *schema.Schema, kind config.Kind, c config.Component) *schema.Field {
+	if sch == nil {
+		return nil
+	}
 
+	comp, found := sch.Lookup(kind, c.ID.Type)
+	if !found {
+		return nil
+	}
+
+	return comp.Fields
+}
+
+// componentExtensionRefs collects the extension references in one component's
+// settings, in document order.
+//
+// The schema is what finds them: a field marked extensionRef says the scalar
+// written under it names an extension, whatever the key is called and wherever
+// it sits, so a setting upstream adds is checked as soon as its schema lands.
+// The built-in pairs are the fallback, for a component the schema does not
+// describe and for the published schemas generated before the marker existed.
+func componentExtensionRefs(c config.Component, fields *schema.Field) []ExtensionRef {
+	w := &refWalker{comp: c, out: nil}
+	w.walk(fields, c.ValueNode, c.Kind.Section()+"."+c.ID.String(), 0)
+
+	return w.out
+}
+
+// refWalker descends a component's settings alongside the schema describing
+// them, collecting the extension references it finds.
+type refWalker struct {
+	comp config.Component
+	out  []ExtensionRef
+}
+
+func (w *refWalker) walk(field *schema.Field, n *yaml.Node, path string, depth int) {
+	n = ResolveAlias(n)
+	if n == nil || depth > MaxSettingsDepth {
+		return
+	}
+
+	switch n.Kind {
+	case yaml.MappingNode:
+		w.walkMap(field, n, path, depth)
+	case yaml.SequenceNode:
+		item := childSchema(field, "item")
+		for i, el := range n.Content {
+			w.walk(item, el, IndexPath(path, i), depth+1)
+		}
+	default:
+		// A scalar the schema did not mark is just a value.
+	}
+}
+
+func (w *refWalker) walkMap(field *schema.Field, n *yaml.Node, path string, depth int) {
 	fields := extensionFields()
 
-	WalkSettings(c.ValueNode, c.Kind.Section()+"."+c.ID.String(), 0, func(n *yaml.Node, path string) {
-		for _, e := range MapEntries(n, path) {
-			field, held := lo.Find(fields, func(f extensionField) bool { return f.parent == e.Key })
-			if !held {
-				continue
+	for _, e := range MapEntries(n, path) {
+		child := childSchema(field, e.Key)
+
+		if child != nil && child.ExtensionRef != "" {
+			if name, named := ScalarName(e.Node).Get(); named {
+				w.record(name, e.Path, child.ExtensionRef)
 			}
 
-			name, named := ScalarChild(e.Node, field.key).Get()
-			if !named {
-				continue
-			}
-
-			out = append(out, ExtensionRef{
-				ID: config.ParseID(name.Value), Node: name,
-				Path: JoinPath(e.Path, field.key), Component: c,
-				Role: field.role, Docs: field.docs,
-			})
+			continue
 		}
-	})
 
-	return out
+		// The built-in pair reaches a level further down than the marker does,
+		// so it is skipped where the schema marks the leaf itself; taking both
+		// would report the same name twice.
+		builtin, held := lo.Find(fields, func(f extensionField) bool { return f.parent == e.Key })
+		if held && !marked(child, builtin.key) {
+			if name, named := ScalarChild(e.Node, builtin.key).Get(); named {
+				w.record(name, JoinPath(e.Path, builtin.key), builtin.role)
+			}
+		}
+
+		w.walk(child, e.Node, e.Path, depth+1)
+	}
+}
+
+func (w *refWalker) record(name *yaml.Node, path, role string) {
+	w.out = append(w.out, ExtensionRef{
+		ID: config.ParseID(name.Value), Node: name, Path: path,
+		Component: w.comp, Role: role, Docs: extensionRefDocs(role),
+	})
+}
+
+// childSchema is what the schema says about one key, or nil where it says
+// nothing -- an unknown component, an open map, a release generated before the
+// key existed.
+func childSchema(field *schema.Field, key string) *schema.Field {
+	if field == nil {
+		return nil
+	}
+
+	return field.Children[key]
+}
+
+// marked reports whether the schema already says the named child is an
+// extension reference.
+func marked(field *schema.Field, key string) bool {
+	child := childSchema(field, key)
+
+	return child != nil && child.ExtensionRef != ""
 }

--- a/pkg/rule/node.go
+++ b/pkg/rule/node.go
@@ -63,20 +63,26 @@ func ChildNode(n *yaml.Node, key string) mo.Option[*yaml.Node] {
 }
 
 // ScalarChild returns the named scalar of a mapping, when it holds a name
-// worth resolving. An empty value is not a reference, and one built from a
-// confmap expansion is only known once the collector starts.
+// worth resolving.
 func ScalarChild(n *yaml.Node, key string) mo.Option[*yaml.Node] {
 	val, written := ChildNode(n, key).Get()
 	if !written {
 		return mo.None[*yaml.Node]()
 	}
 
-	val = ResolveAlias(val)
-	if val == nil || val.Kind != yaml.ScalarNode || val.Value == "" || HasExpansion(val.Value) {
+	return ScalarName(val)
+}
+
+// ScalarName returns the node when it holds a name worth resolving. An empty
+// value is not a reference, and one built from a confmap expansion is only
+// known once the collector starts.
+func ScalarName(n *yaml.Node) mo.Option[*yaml.Node] {
+	n = ResolveAlias(n)
+	if n == nil || n.Kind != yaml.ScalarNode || n.Value == "" || HasExpansion(n.Value) {
 		return mo.None[*yaml.Node]()
 	}
 
-	return mo.Some(val)
+	return mo.Some(n)
 }
 
 // WalkSettings visits every mapping inside a component's settings, together

--- a/pkg/rule/ruletest/ruletest.go
+++ b/pkg/rule/ruletest/ruletest.go
@@ -62,7 +62,7 @@ func Context(src string, opts Options) (rule.Context, error) {
 	return rule.Context{
 		File:   f,
 		Schema: sch,
-		Index:  rule.NewIndex(f),
+		Index:  rule.NewIndex(f, sch),
 		Strict: opts.Strict,
 		Env:    opts.Env,
 	}, nil

--- a/pkg/rule/undefinedextensionreference/rule.go
+++ b/pkg/rule/undefinedextensionreference/rule.go
@@ -25,7 +25,7 @@ type undefinedExtensionReference struct{ rule.Base }
 func (r undefinedExtensionReference) Check(ctx *rule.Context) {
 	for _, ref := range ctx.Index.ExtensionRefs() {
 		subject := string(ref.Component.Kind) + " " + rule.Quote(ref.Component.ID.String()) +
-			" references " + ref.Role + " extension " + rule.Quote(ref.ID.String())
+			" references " + ref.Subject() + " " + rule.Quote(ref.ID.String())
 
 		if _, declared := ctx.Index.Declared(config.KindExtension, ref.ID); !declared {
 			// A name declared under another section lands here too; the hint

--- a/pkg/rule/undefinedextensionreference/rule_test.go
+++ b/pkg/rule/undefinedextensionreference/rule_test.go
@@ -6,9 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/minuk-dev/otelcol-config-lint/pkg/config"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/diag"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/rule/ruletest"
 	"github.com/minuk-dev/otelcol-config-lint/pkg/rule/undefinedextensionreference"
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 )
 
 // check runs the rule over src, which every test in this package starts from.
@@ -265,4 +267,102 @@ service:
 
 	found := check(t, src)
 	require.Len(t, found, 2, "each exporter names the extension")
+}
+
+// The schema is what lets the rule find a reference nobody taught it about.
+// "checkpoint.store" is not a pair the rule carries; the marker on the field is
+// the whole reason it is checked, which is what stops the check falling behind
+// upstream one setting at a time.
+func TestUndefinedExtensionReferenceFollowsASchemaMarker(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers:
+  filelog:
+    checkpoint:
+      store: file_storage
+exporters: {debug: }
+service:
+  pipelines:
+    logs: {receivers: [filelog], exporters: [debug]}
+`
+
+	found := marked(t, src)
+	require.Len(t, found, 1)
+	assert.Equal(t,
+		`receiver "filelog" references storage extension "file_storage" `+
+			`which is not declared under extensions`,
+		found[0].Message)
+	assert.Equal(t, "receivers.filelog.checkpoint.store", found[0].Path)
+	assert.Equal(t, 5, found[0].Position.Line)
+}
+
+// A marker that only says the value has to resolve still reports, and reads as
+// a plain extension rather than as a role the schema never named.
+func TestUndefinedExtensionReferenceWithoutARole(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers:
+  filelog:
+    helper: my_helper
+exporters: {debug: }
+service:
+  pipelines:
+    logs: {receivers: [filelog], exporters: [debug]}
+`
+
+	found := marked(t, src)
+	require.Len(t, found, 1)
+	assert.Equal(t,
+		`receiver "filelog" references extension "my_helper" which is not declared under extensions`,
+		found[0].Message)
+}
+
+// The built-in pair and the marker reach the same scalar from different
+// levels, and a config checked against a schema carrying both must not be told
+// about it twice.
+func TestUndefinedExtensionReferenceReportsAMarkedQueueOnce(t *testing.T) {
+	t.Parallel()
+
+	src := `
+receivers: {otlp: }
+exporters:
+  otlphttp:
+    endpoint: https://backend:4318
+    sending_queue:
+      storage: file_storage
+service:
+  pipelines:
+    traces: {receivers: [otlp], exporters: [otlphttp]}
+`
+
+	found := marked(t, src)
+	require.Len(t, found, 1)
+	assert.Equal(t, "exporters.otlphttp.sending_queue.storage", found[0].Path)
+	assert.Contains(t, found[0].Docs, "exporter/exporterhelper/README.md")
+}
+
+// marked runs the rule against a schema whose markers stand in for the ones a
+// generated schema carries, since the fixture schema is otherwise unmarked.
+func marked(t *testing.T, src string) diag.Diagnostics {
+	t.Helper()
+
+	sch := ruletest.Schema()
+	sch.Components[config.KindReceiver]["filelog"].Fields = &schema.Field{
+		Type: "map",
+		Children: map[string]*schema.Field{
+			"checkpoint": {Type: "map", Children: map[string]*schema.Field{
+				"store": {Type: "string", ExtensionRef: schema.RoleStorage},
+			}},
+			"helper": {Type: "string", ExtensionRef: schema.RoleExtension},
+		},
+	}
+	sch.Components[config.KindExporter]["otlphttp"].
+		Fields.Children["sending_queue"].Children["storage"].ExtensionRef = schema.RoleStorage
+
+	found, err := ruletest.RunWith(undefinedextensionreference.New(), src, ruletest.Options{Schema: sch})
+	require.NoError(t, err, "parse")
+
+	return found
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -105,7 +105,27 @@ type Field struct {
 	Deprecated string `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	// Doc is a one-line description used in diagnostics hints.
 	Doc string `json:"doc,omitempty" yaml:"doc,omitempty"`
+	// ExtensionRef marks a setting whose value names an extension, and says
+	// what the extension is used for: RoleStorage, RoleAuth, or RoleExtension
+	// when nothing narrower is known. Nothing in the YAML tells the two apart
+	// -- a storage id and a directory path are both strings -- so this is the
+	// only thing that says a name has to resolve to a declared extension.
+	ExtensionRef string `json:"extensionRef,omitempty" yaml:"extensionRef,omitempty"`
 }
+
+// The roles an ExtensionRef can carry. The role is what a diagnostic calls the
+// reference, so it names the job the extension does rather than the setting it
+// is written under.
+const (
+	// RoleStorage marks a reference to a storage extension, such as the one a
+	// persistent queue writes through.
+	RoleStorage = "storage"
+	// RoleAuth marks a reference to an authenticator extension.
+	RoleAuth = "auth"
+	// RoleExtension marks a reference whose purpose the generator could not
+	// name. It is still a reference, and still has to resolve.
+	RoleExtension = "extension"
+)
 
 // Lookup returns the component of the given kind and type.
 func (c *Schema) Lookup(k config.Kind, typ string) (*Component, bool) {


### PR DESCRIPTION
Closes #75.

## Why

`undefined-extension-reference` matched two hardcoded `parent`/`key` pairs, so it only ever saw `sending_queue.storage` and `auth.authenticator`. Anything else that names an extension — a bare `storage` key at a component's root, an `auth` block under a differently named parent — was a startup failure the rule stayed quiet about, and each one added was another struct literal keeping the list permanently behind upstream.

## What

**The schema says it.** `schema.Field` gains `extensionRef`, carrying the role the extension plays:

```yaml
sending_queue:
  type: map
  children:
    storage: {type: string, extensionRef: storage}
```

**It is derived, not maintained.** schemagen marks any setting that decodes into a `component.ID`. Inside a component's own config the only component addressable is an extension, so the Go type is the whole test — a new auth extension upstream is checked the week its schema lands, with nothing to add here. The type is `component.ID` either way, so the *role* comes from the key: `storage`, `auth`, or a plain `extension` for a key the generator has no name for. An unfamiliar setting is still checked; it just reads as "references extension \"x\"" rather than naming a job.

**The rule reads it.** The index now walks a component's settings alongside the field schema describing them, so a marked field is a reference whatever it is called and wherever it sits. `rule.NewIndex` takes the schema for this reason.

## The two pairs stay, as a fallback

The published registry predates the marker, so dropping them would leave the rule silent for every existing user until every schema is regenerated. They also cover components the schema resolved nothing for. Where the schema marks the same leaf, the fallback stands aside so a name is not reported twice — there is a test for exactly that.

## Two judgement calls worth flagging

- **`extensionRef`, not `extension_ref`.** The issue wrote the latter; the schema spells its other compound keys `aliasOf`, `collectorVersion`, `generatedAt`, so this follows the file it lives in. Happy to switch if you would rather match the issue.
- **Docs derived from the role, not carried in the marker.** The issue asked for `docs` to come along in the schema. Storing it would put a URL beside every marked field to say one of two things; `extensionRefDocs(role)` gives the same answer without the weight. The role itself is carried, as asked.

## Tests

- schemagen end to end: a `component.ID` field comes out marked with the right role, a generic key comes out as a plain `extension`, and a plain string setting is not marked at all.
- rule: a marker on a key the rule has never heard of (`checkpoint.store`) is found and anchored; a role-less marker reads as a plain extension; a marked `sending_queue.storage` reports once, not twice.

`go test ./...` passes. `make lint` reports the same 50 pre-existing goconst issues as `origin/main` — no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z