### PR TITLE
fix(action): per-run report path, pinned apk packages, documented file-name constraint

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -84,6 +84,24 @@ jobs:
           test "${{ steps.invalid.outputs.invalid }}" = "2"
           test "${{ steps.invalid.outputs.valid }}" = "0"
 
+      # The json output is the one path that reads the report file back out
+      # rather than re-running the linter, so it is what covers the temporary
+      # file the entrypoint draws per run and removes on the way out.
+      - name: A JSON run prints the report and still reports the counts
+        id: json
+        uses: ./
+        with:
+          files: testdata/valid
+          collector-version: v0.157.0
+          schema-location: testdata/schemas
+          output: json
+
+      - name: The counts are the same whichever format was asked for
+        run: |
+          test "${{ steps.json.outputs.exit-code }}" = "0"
+          test "${{ steps.json.outputs.valid }}" = "1"
+          test "${{ steps.json.outputs.invalid }}" = "0"
+
       - name: A rule that is turned off is not reported
         id: disabled
         uses: ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,36 @@ FROM alpine:3.22
 # bash for the entrypoint's arrays, jq to read the summary out of the report,
 # and the CA bundle because schemas are fetched from the published registry
 # over HTTPS unless the workflow points schema-location somewhere local.
-RUN apk add --no-cache bash jq ca-certificates
+#
+# bash and jq are pinned with apk's prefix operator, which fixes the upstream
+# version and leaves the -rN revision free. An exact pin is the wrong shape
+# here: action.yml says `image: Dockerfile`, so this is rebuilt on every
+# consumer's runner on every run, and Alpine's repository carries only the
+# current revision of a package. The day 3.22 rebuilds bash for a CVE, an
+# exact pin stops resolving and every workflow using this action fails on
+# `apk add` -- and no automation in this repository bumps it back: dependabot
+# reads go.mod and workflow `uses:` lines, not apk constraints. A prefix pin
+# still fails loudly if the version itself ever moves, which within one Alpine
+# stable branch it does not.
+#
+# ca-certificates is deliberately left unpinned. Its version is the date the
+# bundle was cut, so a pin of either shape freezes the trust store at a set of
+# roots -- and breaks the build outright the day a new bundle lands.
+RUN apk add --no-cache 'bash~5.2.37' 'jq~1.8.1' ca-certificates
 
 COPY --from=bin /usr/local/bin/otelcol-config-lint /usr/local/bin/otelcol-config-lint
 COPY build/docker/action-entrypoint.sh /usr/local/bin/action-entrypoint
 
 WORKDIR /github/workspace
 
+# No USER, deliberately, however much the released image's distroless nonroot
+# invites one here. GitHub's own Dockerfile guidance for container actions is
+# "do not use the USER instruction in your Dockerfile, because you won't be
+# able to access the GITHUB_WORKSPACE directory", and the runner backs that up:
+# $GITHUB_OUTPUT is a file the runner process creates on the host and mounts
+# in, owned by the uid the runner runs as and not group- or world-writable, so
+# any other uid gets EACCES appending to it. The entrypoint writes its counts
+# there under `set -e`, which would turn a clean lint into a failed step for
+# every consumer. Dropping privileges here needs the runner to stop handing out
+# files only root can write, not a line in this file.
 ENTRYPOINT ["/usr/local/bin/action-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ is invalid, and reports a usage error — a rule that does not exist, an unreada
 settings file — distinctly, with exit code 2.
 
 Every input is the `run` flag of the same name, so the flag table below is the
-whole reference: `files` (default `.`, whitespace-separated, globs allowed),
-`collector-version`, `distribution`, `schema-location` (one per line to search
-several in order), `strict`, `ignore-missing-schemas`, `min-severity`,
-`fail-on`, `default`, `enable`, `disable`, `severity`, `exclude`, `output`
-(default `github`), `config`, `no-config`, `summary` (default `true`),
-`verbose` and `exit-on-error`. `--concurrency`, `--no-color`, `--no-cache` and
+whole reference: `files` (default `.`, whitespace-separated and so unable to
+carry a path with a space in it, globs allowed), `collector-version`,
+`distribution`, `schema-location` (one per line to search several in order),
+`strict`, `ignore-missing-schemas`, `min-severity`, `fail-on`, `default`,
+`enable`, `disable`, `severity`, `exclude`, `output` (default `github`),
+`config`, `no-config`, `summary` (default `true`), `verbose` and
+`exit-on-error`. `--concurrency`, `--no-color`, `--no-cache` and
 `--insecure-schema-location` are left out: a runner gains nothing from the
 first two, a fresh container has no cache to read, and a workflow that reads
 its schemas over plain HTTP is one whose findings anyone on the path can

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,11 @@ branding:
 # are left out; a runner has nothing to gain from either.
 inputs:
   files:
-    description: Files, directories or globs to check, separated by spaces or newlines.
+    description: >-
+      Files, directories or globs to check, separated by spaces or newlines. A
+      path cannot contain a space: the list is split on whitespace, which is
+      also what lets a glob such as configs/*.yaml be expanded against the
+      workspace. Point the input at the containing directory instead.
     required: false
     default: "."
   collector-version:

--- a/build/docker/action-entrypoint.sh
+++ b/build/docker/action-entrypoint.sh
@@ -110,7 +110,9 @@ while IFS= read -r location; do
 done <<<"${in_schema_location}"
 
 # Deliberately unquoted: files are separated by whitespace, and a glob such as
-# configs/*.yaml is expanded here, against the workspace.
+# configs/*.yaml is expanded here, against the workspace. The cost is that a
+# path containing a space is split into two paths that do not exist, which is
+# why action.yml says the input cannot hold one.
 # shellcheck disable=SC2206
 files=(${in_files})
 if [ ${#files[@]} -eq 0 ]; then
@@ -122,7 +124,15 @@ fi
 # The second pass re-reads the schema, from the registry over the network when
 # no --schema-location is given; one schema for one release is a small download,
 # and it buys the same numbers whichever format was asked for.
-report="${TMPDIR:-/tmp}/otelcol-config-lint.json"
+#
+# The name is drawn per run rather than fixed. A hosted runner gives each job a
+# container of its own and a fixed name would do, but a self-hosted runner with
+# a reused workspace, or two matrix legs sharing a TMPDIR, would have two runs
+# writing and reading one file -- and the summary one of them published would
+# be the other's. No suffix on the template: busybox mktemp only accepts the
+# X's at the end, and nothing here reads the report by extension.
+report="$(mktemp "${TMPDIR:-/tmp}/otelcol-config-lint.XXXXXX")"
+trap 'rm -f "${report}"' EXIT
 
 code=0
 otelcol-config-lint run "${flags[@]}" --output json "${files[@]}" >"${report}" || code=$?


### PR DESCRIPTION
Closes #76 — three of the four bullets as written, and the fourth answered rather than done. Details below.

## Done

**The report path is drawn per run.** `mktemp` replaces the fixed `${TMPDIR:-/tmp}/otelcol-config-lint.json`, with a trap that removes it however the script leaves. Reproduced the bug first, two overlapping runs sharing a `TMPDIR`:

| | leg A reports | leg B reports | temp file left behind |
|---|---|---|---|
| before | `valid=22` (wrong — it was 11) | `valid=22` | yes |
| after | `valid=11` | `valid=22` | no |

The template carries no `.json` suffix: busybox `mktemp` only accepts the `X`s at the end, and nothing reads the report by extension.

**bash and jq are pinned**, with apk's prefix operator (`bash~5.2.37`, `jq~1.8.1`) rather than an exact `-rN`. See below for why.

**The `files:` constraint is documented** in `action.yml`, the README, and the entrypoint comment, which now names the cost of the unquoted expansion rather than only its purpose.

**New CI coverage.** `output: json` is the only path that reads the report back out rather than re-running the linter, so it is what exercises the temp file; the action workflow now has a step for it.

## Not done: `USER nobody`

The issue conditions this on "after confirming the entrypoint and the linter only read the workspace and write to `TMPDIR`". They do — the schema cache treats an unwritable directory as "a slower next run" and moves on. But the blocker is elsewhere, and it is decisive:

- GitHub's [Dockerfile support for GitHub Actions](https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions) says outright: *"Do not use the `USER` instruction in your `Dockerfile`, because you won't be able to access the `GITHUB_WORKSPACE` directory."*
- `$GITHUB_OUTPUT` is a file the runner process creates on the host and mounts in, owned by the uid the runner runs as (1001 on hosted runners) and not group- or world-writable. Any other uid gets `EACCES` appending to it — [actions/runner-images#10915](https://github.com/actions/runner-images/issues/10915) is exactly this, still open.
- The entrypoint appends its counts there under `set -euo pipefail`. So `USER` would turn **a clean lint into a failed step for every consumer**, not just here.

Shipping it would have broken the action, so I have recorded the reasoning in the Dockerfile where someone would go to add the line, rather than leaving the next person to rediscover it. If you want the privilege drop anyway, the workable shape is `su-exec` inside the entrypoint — root marshals arguments and writes `$GITHUB_OUTPUT`, the linter itself runs unprivileged. Say the word and I will do it as a follow-up; I left it out because it regresses self-hosted runners whose checkout is not world-readable.

## Why the pin is fuzzy, not exact

Two premises in the issue's second bullet do not hold here, and the pin is shaped around that:

- **"consumers pin by digest"** — they do not. `action.yml` is `image: Dockerfile`, so this image is **rebuilt on every consumer's runner on every run**. A pin that stops resolving fails their workflow, not ours.
- **"let the existing dependency automation bump them"** — dependabot cannot. Its `gomod` and `github-actions` ecosystems read `go.mod` and workflow `uses:` lines; nothing reads apk constraints. (Adding the `docker` ecosystem would not help and would actively hurt: it would try to bump the `ghcr.io/minuk-dev/otelcol-config-lint:1.0.0` pin that `make release-pin` owns and the release workflow validates.)

Alpine's repository carries only the current revision of a package, so `bash=5.2.37-r0` stops resolving the day 3.22 rebuilds bash for a CVE — and nothing here bumps it back. `bash~5.2.37` fixes the upstream version, which within one Alpine stable branch never moves, and lets the security rebuild through. It still fails loudly if the version itself ever changes, which is the tripwire the bullet was after.

`ca-certificates` is deliberately left unpinned: its version is the date the bundle was cut, so a pin of either shape freezes the trust store at a fixed set of roots and breaks the build outright the day a new bundle lands.

## Verification

- The entrypoint was exercised locally against a stub linter: outputs correct, report printed on the `json` path, no temp file left behind, and the concurrency table above.
- No Go code changed; `go test ./...` passes and `make lint` reports the same 50 pre-existing goconst issues as `main`.
- **Docker was not available locally**, so I could not build the image or check the apk constraint syntax myself. CI has now done both: the `action` job builds this Dockerfile and runs the action nine ways, including the new `output: json` step, and it passes. Every check is green.
- The `lint` check failed once on the first run and passed on rerun. It was not this branch: `golangci-lint config verify` timed out fetching `golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json`, so the linter died before reading any code — and this PR changes no Go. That job depends on a network fetch to validate `.golangci.yaml`, so it can redden any PR on a bad day; happy to send a separate change disabling that verify step if you want it gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z
