### PR TITLE
fix(action): keep the description under the Marketplace limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,9 @@
 name: otelcol-config-lint
+# GitHub Marketplace rejects a description of 125 characters or more, so this
+# says only what the linter is for; the README carries the rest.
 description: >-
-  Lint OpenTelemetry Collector config files against a specific collector
-  release, with findings as inline pull-request annotations.
+  Lint OpenTelemetry Collector configs against a specific collector release,
+  with findings as pull-request annotations.
 author: minuk-dev
 
 branding:


### PR DESCRIPTION
## What

`action.yml`'s `description` was 129 characters. GitHub Marketplace rejects a listing whose description is 125 characters or more:

> Description must be less than 125 characters.

## Change

```diff
-  Lint OpenTelemetry Collector config files against a specific collector
-  release, with findings as inline pull-request annotations.
+  Lint OpenTelemetry Collector configs against a specific collector release,
+  with findings as pull-request annotations.
```

117 characters after folding. `config files` becomes `configs` and `inline` goes; the release the config is checked against is the claim worth keeping, and the README still spells out that the annotations are inline. A comment above the field records the limit so the next edit does not walk back over it.

## Checks

- Folded value measured at 117 characters, so it clears the limit with room to spare.
- No test or workflow asserts the description, and `.github/workflows/action.yaml` exercises the action end to end as committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J6QwG8TzNs447uz16BC5z