### PR TITLE
refactor(cmd): stop exporting options no caller can fill in

### DIFF
--- a/cmd/schemagen/main.go
+++ b/cmd/schemagen/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	cmd := schemagen.NewCommand(nil)
+	cmd := schemagen.NewCommand()
 	cmd.SetArgs(os.Args[1:])
 	cmd.SetIn(os.Stdin)
 	cmd.SetOut(os.Stdout)

--- a/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
+++ b/pkg/cmd/otelcol-config-lint/otelcol-config-lint.go
@@ -53,7 +53,9 @@ func ExitCode(err error) int {
 type GlobalCmdOptions = cmdutil.GlobalOptions
 
 // NewCommand builds the root command. A nil opts is allowed, in which case a
-// zero value is used.
+// zero value is used, which is what the binary passes: opts is there for an
+// embedder that wants the command to read a filesystem of its own, and every
+// other input is a flag or an argument.
 func NewCommand(opts *GlobalCmdOptions) *cobra.Command {
 	if opts == nil {
 		//nolint:exhaustruct // the flags fill themselves in, and a nil Fs is the real filesystem

--- a/pkg/cmd/schemagen/harvest.go
+++ b/pkg/cmd/schemagen/harvest.go
@@ -35,7 +35,7 @@ const metadataFile = "metadata.yaml"
 var errModuleMissing = errors.New("module could not be resolved")
 
 // build reads one distribution out of the modules its manifest names.
-func (o *Options) build(man *manifest) (*schema.Schema, error) {
+func (o *options) build(man *manifest) (*schema.Schema, error) {
 	mods, err := o.resolveModules(man)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/schemagen/module.go
+++ b/pkg/cmd/schemagen/module.go
@@ -61,7 +61,7 @@ func (s *moduleSet) lookup(module string) (resolvedModule, bool) {
 // that GOPROXY, GOPRIVATE, GONOSUMDB, netrc and any credential helper already
 // configured for this machine apply unchanged. A private component resolves
 // exactly as it does for the build that consumes it.
-func (o *Options) resolveModules(man *manifest) (*moduleSet, error) {
+func (o *options) resolveModules(man *manifest) (*moduleSet, error) {
 	work, err := o.workspace(man)
 	if err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ func (o *Options) resolveModules(man *manifest) (*moduleSet, error) {
 // workspace writes the synthetic module the go command resolves in: the
 // manifest's components as requirements, its replacements as replacements, and
 // a file importing every component so tidy keeps them all.
-func (o *Options) workspace(man *manifest) (string, error) {
+func (o *options) workspace(man *manifest) (string, error) {
 	dir := filepath.Join(o.cacheDir, "workspace", man.Dist.Name)
 
 	err := os.MkdirAll(dir, dirPerm)
@@ -188,7 +188,7 @@ func (o *Options) workspace(man *manifest) (string, error) {
 // goCommand runs the go tool in the workspace and returns its stdout. The
 // environment is inherited: whatever GOPROXY, GOPRIVATE or credentials this
 // machine builds with are what a private module needs.
-func (o *Options) goCommand(dir string, args ...string) (string, error) {
+func (o *options) goCommand(dir string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), o.timeout)
 	defer cancel()
 

--- a/pkg/cmd/schemagen/retain.go
+++ b/pkg/cmd/schemagen/retain.go
@@ -24,7 +24,7 @@ import (
 // Pruning bounds what the registry serves and what a checkout costs, not the
 // history of the repository holding it; the files stay in every commit that had
 // them.
-func (o *Options) prune() error {
+func (o *options) prune() error {
 	if o.retain <= 0 {
 		return nil
 	}
@@ -52,7 +52,7 @@ func (o *Options) prune() error {
 
 // pruneDistribution removes the schema files of one distribution's dropped
 // releases, in every format they were written in.
-func (o *Options) pruneDistribution(dir string) error {
+func (o *options) pruneDistribution(dir string) error {
 	dropped := drop(versionsIn(dir), o.retain, o.retainEvery)
 
 	for _, v := range dropped {

--- a/pkg/cmd/schemagen/schemagen.go
+++ b/pkg/cmd/schemagen/schemagen.go
@@ -102,9 +102,15 @@ func ExitCode(err error) int {
 // downloads a few hundred modules, so it is generous.
 const commandTimeout = 10 * time.Minute
 
-// Options holds everything the command was asked to do. The fields are filled
-// in by RegisterFlags and then by Prepare, in that order.
-type Options struct {
+// options holds everything the command was asked to do. The fields are filled
+// in by registerFlags and then by prepare, in that order.
+//
+// It is unexported, and so is every field: each one is either a flag, which
+// registerFlags overwrites with its default the moment it is declared, or
+// state the run resolves for itself. There is nothing an embedder could set
+// that the command would honour, which is why NewCommand takes no options and
+// this type is the package's own.
+type options struct {
 	// flags
 	builders    []string
 	outFile     string
@@ -125,12 +131,11 @@ type Options struct {
 	diffs []*schema.Diff
 }
 
-// NewCommand builds the schemagen command. A nil opts is allowed, in which case
-// a zero value is used.
-func NewCommand(opts *Options) *cobra.Command {
-	if opts == nil {
-		opts = &Options{} //nolint:exhaustruct // every field is filled in by RegisterFlags and Prepare
-	}
+// NewCommand builds the schemagen command. It is configured through its flags
+// alone: schemagen is a build-time tool driven from the command line, so the
+// options it fills in are its own.
+func NewCommand() *cobra.Command {
+	opts := &options{} //nolint:exhaustruct // every field is filled in by registerFlags and prepare
 
 	// The root carries no work of its own: every mode is a subcommand, so a
 	// bare invocation prints the help that lists them.
@@ -172,7 +177,7 @@ func noArgs(cmd *cobra.Command, args []string) error {
 
 // newGenerateCommand builds "generate", which reads the manifests and writes
 // the schemas. It is where every flag describing an output lives.
-func newGenerateCommand(opts *Options) *cobra.Command {
+func newGenerateCommand(opts *options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate [flags]",
 		Short: "Build component schemas from the upstream collector sources",
@@ -182,16 +187,16 @@ func newGenerateCommand(opts *Options) *cobra.Command {
 		Args:         noArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := opts.Prepare(cmd)
+			err := opts.prepare(cmd)
 			if err != nil {
 				return err
 			}
 
-			return opts.Run(cmd)
+			return opts.run(cmd)
 		},
 	}
 
-	opts.RegisterFlags(cmd)
+	opts.registerFlags(cmd)
 
 	return cmd
 }
@@ -203,7 +208,7 @@ func newGenerateCommand(opts *Options) *cobra.Command {
 // different question: it takes only --builder, and none of the flags saying
 // where a schema goes, in what format, or how much of a registry to keep mean
 // anything to it.
-func newPrintVersionCommand(opts *Options) *cobra.Command {
+func newPrintVersionCommand(opts *options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "print-version [flags]",
 		Short: "Print the release each manifest resolves to",
@@ -212,12 +217,12 @@ func newPrintVersionCommand(opts *Options) *cobra.Command {
 		Args:         noArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := opts.Prepare(cmd)
+			err := opts.prepare(cmd)
 			if err != nil {
 				return err
 			}
 
-			return opts.PrintVersions(cmd)
+			return opts.printVersions(cmd)
 		},
 	}
 
@@ -226,8 +231,8 @@ func newPrintVersionCommand(opts *Options) *cobra.Command {
 	return cmd
 }
 
-// RegisterFlags declares every flag the generator takes.
-func (o *Options) RegisterFlags(cmd *cobra.Command) {
+// registerFlags declares every flag the generator takes.
+func (o *options) registerFlags(cmd *cobra.Command) {
 	o.registerBuilderFlag(cmd)
 
 	flags := cmd.Flags()
@@ -251,9 +256,9 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 	flags.DurationVar(&o.timeout, "timeout", commandTimeout, "timeout for one go command")
 }
 
-// Prepare wires up what the run needs beyond the flags: where the schema is
+// prepare wires up what the run needs beyond the flags: where the schema is
 // written and where progress is reported.
-func (o *Options) Prepare(cmd *cobra.Command) error {
+func (o *options) prepare(cmd *cobra.Command) error {
 	o.out = cmd.OutOrStdout()
 	o.progress = cmd.ErrOrStderr()
 
@@ -264,12 +269,12 @@ func (o *Options) Prepare(cmd *cobra.Command) error {
 	return nil
 }
 
-// Run generates a schema for every distribution it was given a manifest for.
-// Prepare is expected to have run first; a caller that composed the options
-// itself gets the defaults instead of a half-built run.
-func (o *Options) Run(cmd *cobra.Command) error {
+// run generates a schema for every distribution it was given a manifest for.
+// prepare is expected to have run first; the options built directly in a test
+// get the defaults instead of a half-built run writing to a nil stream.
+func (o *options) run(cmd *cobra.Command) error {
 	if o.out == nil || o.progress == nil {
-		err := o.Prepare(cmd)
+		err := o.prepare(cmd)
 		if err != nil {
 			return err
 		}
@@ -332,10 +337,9 @@ func (o *Options) Run(cmd *cobra.Command) error {
 	return nil
 }
 
-// PrintVersions writes the release each manifest resolves to and returns.
+// printVersions writes the release each manifest resolves to and returns.
 //
-// Prepare is expected to have run first; a caller that composed the options
-// itself gets the defaults instead of a half-built run.
+// prepare is expected to have run first, the way run expects it.
 //
 // It exists so that a caller filling a registry can ask what a manifest would
 // be filed under without generating it, which is not something that can be
@@ -350,9 +354,9 @@ func (o *Options) Run(cmd *cobra.Command) error {
 // file it under the name it already had.
 //
 // Only the manifest is read, so this answers without resolving a module graph.
-func (o *Options) PrintVersions(cmd *cobra.Command) error {
+func (o *options) printVersions(cmd *cobra.Command) error {
 	if o.out == nil || o.progress == nil {
-		err := o.Prepare(cmd)
+		err := o.prepare(cmd)
 		if err != nil {
 			return err
 		}
@@ -384,7 +388,7 @@ func (o *Options) PrintVersions(cmd *cobra.Command) error {
 // registerBuilderFlag declares the one input every mode takes: which manifests
 // to read. It is registered on its own because print-version takes this and
 // nothing else.
-func (o *Options) registerBuilderFlag(cmd *cobra.Command) {
+func (o *options) registerBuilderFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&o.builders, "builder", nil,
 		"OCB builder manifest describing a distribution, as \"[name=]path\";\n"+
 			"name overrides what the registry files it under; repeat for several")
@@ -397,7 +401,7 @@ func (o *Options) registerBuilderFlag(cmd *cobra.Command) {
 // is left holding, which is the whole point of rebuilding it by listing the
 // directory rather than editing it. The availability index follows the index,
 // so both describe the same releases.
-func (o *Options) publishRegistry() error {
+func (o *options) publishRegistry() error {
 	if o.registryDir == "" {
 		return nil
 	}
@@ -418,7 +422,7 @@ func (o *Options) publishRegistry() error {
 // checkDestination settles where the schemas are written. A run either writes
 // one distribution, to a file or to stdout, or fills a registry with as many as
 // it was given manifests; asking for both says two different things.
-func (o *Options) checkDestination(manifests []string) error {
+func (o *options) checkDestination(manifests []string) error {
 	switch {
 	case o.registryDir != "" && o.outFile != "" && o.outFile != stdoutMarker:
 		return ErrTwoOutputs
@@ -443,7 +447,7 @@ func (o *Options) checkDestination(manifests []string) error {
 }
 
 // generate reads one manifest and writes the distribution it describes.
-func (o *Options) generate(builder string, formats []schema.Format) error {
+func (o *options) generate(builder string, formats []schema.Format) error {
 	name, path := splitBuilder(builder)
 
 	man, err := readManifest(path, name)
@@ -472,7 +476,7 @@ func (o *Options) generate(builder string, formats []schema.Format) error {
 // parseFormats resolves --formats. An unknown name is refused rather than
 // written: Schema.Write treats anything that is not JSON as YAML, so a typo
 // would otherwise put YAML under a file name the registry never reads back.
-func (o *Options) parseFormats() ([]schema.Format, error) {
+func (o *options) parseFormats() ([]schema.Format, error) {
 	names := splitList(o.formats)
 	if len(names) == 0 {
 		return nil, ErrNoFormats
@@ -494,7 +498,7 @@ func (o *Options) parseFormats() ([]schema.Format, error) {
 
 // logf reports progress, on the error stream: the schema is what this command
 // outputs, and "--out -" is meant to be piped.
-func (o *Options) logf(format string, args ...any) {
+func (o *options) logf(format string, args ...any) {
 	_, _ = fmt.Fprintf(o.progress, format, args...)
 }
 

--- a/pkg/cmd/schemagen/schemagen_internal_test.go
+++ b/pkg/cmd/schemagen/schemagen_internal_test.go
@@ -1,0 +1,26 @@
+package schemagen
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunWithoutPrepare covers building the options directly, which only this
+// package can do: the run falls back to the defaults instead of writing to a
+// nil stream.
+func TestRunWithoutPrepare(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+
+	//nolint:exhaustruct // the point is what an unprepared run does
+	opts := &options{}
+	cmd := &cobra.Command{Use: "schemagen"}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.ErrorIs(t, opts.run(cmd), ErrNoManifests)
+}

--- a/pkg/cmd/schemagen/schemagen_test.go
+++ b/pkg/cmd/schemagen/schemagen_test.go
@@ -34,7 +34,7 @@ func runCommand(t *testing.T, args ...string) (int, string, string) {
 
 	var stdout, stderr bytes.Buffer
 
-	cmd := schemagen.NewCommand(nil)
+	cmd := schemagen.NewCommand()
 	cmd.SetArgs(args)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
@@ -119,21 +119,6 @@ func TestUnknownFormat(t *testing.T) {
 	entries, err := os.ReadDir(out)
 	require.NoError(t, err)
 	assert.Empty(t, entries, "a refused format still wrote to the registry")
-}
-
-// TestRunWithoutPrepare covers composing the options directly: the run falls
-// back to the defaults instead of writing to a nil stream.
-func TestRunWithoutPrepare(t *testing.T) {
-	t.Parallel()
-
-	var stdout, stderr bytes.Buffer
-
-	opts := &schemagen.Options{}
-	cmd := schemagen.NewCommand(opts)
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
-
-	require.ErrorIs(t, opts.Run(cmd), schemagen.ErrNoManifests)
 }
 
 // TestIncompleteManifest covers the manifest checks, and what a run that

--- a/pkg/cmd/schemagen/summary.go
+++ b/pkg/cmd/schemagen/summary.go
@@ -16,7 +16,7 @@ import (
 // registry served up to now even when a release is regenerated in place. A
 // distribution with nothing to compare against still gets an entry, saying how
 // large its first schema is.
-func (o *Options) summarise(cat *schema.Schema) {
+func (o *options) summarise(cat *schema.Schema) {
 	if o.summaryFile == "" || o.registryDir == "" {
 		return
 	}
@@ -62,7 +62,7 @@ func previousIn(dir, version string) *schema.Schema {
 // a reviewer reading "no component changes" learns something, and a caller
 // pasting the file into a pull request body should not have to handle a missing
 // one.
-func (o *Options) writeSummary() error {
+func (o *options) writeSummary() error {
 	if o.summaryFile == "" {
 		return nil
 	}

--- a/pkg/cmd/schemagen/write.go
+++ b/pkg/cmd/schemagen/write.go
@@ -25,7 +25,7 @@ const stdoutMarker = "-"
 // writeFile writes one distribution's schema where the command line asked for
 // it, which is where a single run's output belongs: the registry layout below
 // is derived from the manifest, so it can only name one place.
-func (o *Options) writeFile(cat *schema.Schema, formats []schema.Format) error {
+func (o *options) writeFile(cat *schema.Schema, formats []schema.Format) error {
 	if o.outFile == stdoutMarker || o.outFile == "" {
 		return writeTo(o.out, cat, formatFor(o.outFile, formats))
 	}
@@ -53,7 +53,7 @@ func formatFor(path string, formats []schema.Format) schema.Format {
 // writeRegistry files one distribution's schema under
 // "<registry>/<distribution>/<version>.<format>", which is the layout the
 // registry is read back in.
-func (o *Options) writeRegistry(cat *schema.Schema, formats []schema.Format) error {
+func (o *options) writeRegistry(cat *schema.Schema, formats []schema.Format) error {
 	dir := filepath.Join(o.registryDir, cat.Distribution)
 
 	err := os.MkdirAll(dir, dirPerm)
@@ -79,7 +79,7 @@ func (o *Options) writeRegistry(cat *schema.Schema, formats []schema.Format) err
 // is published beside it describes the same releases. It is rebuilt by listing
 // the registry directory, not from the manifests generated in this run, so
 // regenerating one distribution leaves the others listed.
-func (o *Options) writeIndex() (*schema.Index, error) {
+func (o *options) writeIndex() (*schema.Index, error) {
 	entries, err := os.ReadDir(o.registryDir)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", o.registryDir, err)
@@ -127,7 +127,7 @@ func (o *Options) writeIndex() (*schema.Index, error) {
 // It is rebuilt from the schemas the registry is left holding, for the same
 // reason the index is: a run that regenerated one distribution must not
 // republish the others from what this run happens to have in hand.
-func (o *Options) writeComponents(idx *schema.Index) error {
+func (o *options) writeComponents(idx *schema.Index) error {
 	comps := &schema.Components{Distributions: map[string]schema.ComponentSpans{}}
 
 	for _, dist := range idx.Names() {
@@ -162,7 +162,7 @@ func (o *Options) writeComponents(idx *schema.Index) error {
 
 // spansIn works out which of a distribution's releases ship each component
 // type, by reading every schema the registry holds for it.
-func (o *Options) spansIn(dist string, versions []string) (schema.ComponentSpans, error) {
+func (o *options) spansIn(dist string, versions []string) (schema.ComponentSpans, error) {
 	// kind -> type -> the releases shipping it.
 	present := map[config.Kind]map[string]map[string]bool{}
 

--- a/pkg/cmdutil/options.go
+++ b/pkg/cmdutil/options.go
@@ -21,6 +21,11 @@ import (
 // own resolved state in its own package, and folds in only the blocks it is
 // about; this is the part all of them honour, so the file is read once however
 // the commands are nested.
+//
+// Fs is the one field an embedder sets, and the only one that could be: the
+// rest are flags, which RegisterFlags overwrites with their defaults the
+// moment it declares them, or state Prepare resolves. An embedder that wants
+// a different settings file passes --config the way the command line does.
 type GlobalOptions struct {
 	// Fs is the filesystem the settings file, the config files and any local
 	// schema location are read from. A nil Fs means the real one, which is


### PR DESCRIPTION
Closes #18.

## What the issue asked

`Options` exported with every field unexported, so `NewCommand(nil)` was the
only call an importer could actually write. Two ways out: export the fields, or
drop the parameter. The choice depends on whether the command is meant to be
consumed as a library.

Since the issue was filed, #92 split the lint command's options up: each
subcommand keeps its own unexported options, and what the root takes is now
`GlobalCmdOptions` (`= cmdutil.GlobalOptions`), whose `Fs` **is** exported and
does get set — `otelcol-config-lint_test.go:506` passes a memory filesystem
through it. That half has effectively taken the first way out.

`pkg/cmd/schemagen` did not move, and is where the in-between state still lives.

## What this does

**schemagen — the second way out.** It is a build-time tool, driven from the
command line and wired up by `cmd/schemagen/main.go` and the workflows; nothing
imports it as a library. So:

- `NewCommand()` takes no parameter and builds its own options
- `Options` → `options`, and `RegisterFlags`/`Prepare`/`Run`/`PrintVersions`
  become unexported methods on it

Every field was either a flag — which `registerFlags` overwrites with its
default the moment it declares it, so a pre-set value would be silently
discarded — or state `prepare` resolves. There was nothing an embedder could
have set that the command would honour.

**The root command keeps its parameter**, because `Fs` is a real knob and not a
flag target. Both doc comments now say which fields an embedder can set and
why the rest cannot, so the asymmetry reads as a decision rather than an
oversight.

## Test

`TestRunWithoutPrepare` composed the options directly, which only the package
itself can do now, so it moves to `schemagen_internal_test.go` — the
`*_internal_test.go` convention `pkg/schema` and `pkg/rule` already use. It
still pins the same behaviour: an unprepared run falls back to the defaults
instead of writing to a nil stream.

## Checks

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass
- `make lint` reports the same 50 pre-existing `goconst` findings as `main`
  (`pkg/settings/jsonschema.go`, `pkg/version/version_test.go`) and nothing new;
  worth a look separately, since `main` does not lint clean locally

No behaviour change: same flags, same output, same exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8PPcw5wivngiJkbpQuXo7