### PR TITLE
docs: give each rule its own page and cut the README to a reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ config.yaml:6:3: error: unknown receiver type "prometheusreceiver" in collector 
 config.yaml:11:14: error: "timeout" must be a duration such as 5s, 200ms or 1m30s [invalid-value]
 config.yaml:17:3: warning: exporter "otlp" is deprecated [deprecated-component]
     hint: renamed to "otlp_grpc" upstream; the old name still resolves for now
-config.yaml:22:3: error: unknown exporter type "logging" in collector v0.157.0 [unknown-component]
-    hint: "logging" exists in v0.110.0 but not in v0.157.0
 config.yaml:29:30: error: service.extensions references "pprof" which is not declared under extensions [undefined-reference]
     hint: declared extensions: health_check
 config.yaml:34:5: error: processor "memory_limiter" sets neither limit_mib nor limit_percentage: 'limit_mib' or 'limit_percentage' must be greater than zero [memory-limiter-config]
@@ -22,15 +20,19 @@ config.yaml:34:5: error: processor "memory_limiter" sets neither limit_mib nor l
     docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
 ```
 
-A rule that reports what the collector requires or recommends carries a `docs:`
-link to the upstream page that says so, so the claim can be checked rather than
-taken on trust. It is in the JSON output as `docs`, and in the GitHub
-annotations.
-
 No collector binary and no Go toolchain are needed at lint time. The component
-schemas are fetched from the published registry, so a new collector release
+schemas are fetched from a published registry, so a new collector release
 becomes lintable as soon as its schema is committed — no linter upgrade. Point
 `--schema-location` at a directory to run without network access.
+
+## Documentation
+
+| | |
+| --- | --- |
+| [Rules](docs/rules/README.md) | all 35 rules, one page each: what they report and why |
+| [Settings file](docs/configuration.md) | `.otelcol-config-lint.yaml`, rule selection, the deployment environment |
+| [Schemas](docs/schemas.md) | the registry, caching, and generating a schema for your own distribution |
+| [Working on the linter](docs/contributing.md) | layout, development, adding a rule |
 
 ## Install
 
@@ -65,18 +67,17 @@ Findings land as inline pull-request annotations, because the action defaults to
 is invalid, and reports a usage error — a rule that does not exist, an unreadable
 settings file — distinctly, with exit code 2.
 
-Every input is the `run` flag of the same name, so the flag table below is the
-whole reference: `files` (default `.`, whitespace-separated and so unable to
+Every input is the `run` flag of the same name, so the [flag table](#flags) is
+the whole reference: `files` (default `.`, whitespace-separated and so unable to
 carry a path with a space in it, globs allowed), `collector-version`,
 `distribution`, `schema-location` (one per line to search several in order),
 `strict`, `ignore-missing-schemas`, `min-severity`, `fail-on`, `default`,
 `enable`, `disable`, `severity`, `exclude`, `output` (default `github`),
 `config`, `no-config`, `summary` (default `true`), `verbose` and
 `exit-on-error`. `--concurrency`, `--no-color`, `--no-cache` and
-`--insecure-schema-location` are left out: a runner gains nothing from the
-first two, a fresh container has no cache to read, and a workflow that reads
-its schemas over plain HTTP is one whose findings anyone on the path can
-choose.
+`--insecure-schema-location` are left out: a runner gains nothing from the first
+two, a fresh container has no cache to read, and a workflow that reads its
+schemas over plain HTTP is one whose findings anyone on the path can choose.
 
 The counts come back as outputs — `exit-code`, `valid`, `invalid`, `errors`,
 `skipped`, `warnings` and `infos` — so a later step can decide what to do with
@@ -94,13 +95,13 @@ them:
 
 `@v0` follows the newest v0 release, and runs exactly that release's linter: the
 action wraps `ghcr.io/minuk-dev/otelcol-config-lint:<release>`, pinned at a tag
-and never `latest`, so a step is two small image pulls rather than a Go
-toolchain and a compile. The major tag is whatever the release's own major is —
-the release workflow moves it — so it becomes `@v1` when 1.0.0 ships, and until
-then `@v1` resolves to nothing. Pin a full tag such as `@v0.1.1` to hold a
-workflow to one revision. The schemas are a separate registry that tracks its
-own main, so pin `schema-location` as well — at a vendored directory, or at a
-tagged URL — for a run that cannot change underneath a workflow.
+and never `latest`, so a step is two small image pulls rather than a Go toolchain
+and a compile. The major tag is whatever the release's own major is — the release
+workflow moves it — so it becomes `@v1` when 1.0.0 ships, and until then `@v1`
+resolves to nothing. Pin a full tag such as `@v0.1.1` to hold a workflow to one
+revision. The schemas are a separate registry that tracks its own main, so pin
+`schema-location` as well — at a vendored directory, or at a tagged URL — for a
+run that cannot change underneath a workflow.
 
 ## Usage
 
@@ -120,11 +121,23 @@ otelcol-config-lint version
 | `config-schema` | the JSON Schema for the settings file, for an editor to check one against |
 | `version` | print the linter version (also available as `--version`) |
 
-The flags below belong to `run`:
+```sh
+otelcol-config-lint run config.yaml                               # lint one file
+otelcol-config-lint run --summary ./configs                       # walk a directory
+cat config.yaml | otelcol-config-lint run -                       # read stdin
+otelcol-config-lint run --output json ./configs > report.json     # machine-readable
+otelcol-config-lint run --output github ./configs                 # PR annotations
+otelcol-config-lint run --collector-version v0.110.0 config.yaml  # target an older release
+otelcol-config-lint run --distribution core config.yaml           # target plain otelcol
+otelcol-config-lint run --default none -E invalid-value ./configs # run one rule and nothing else
+otelcol-config-lint run -c ci.yaml ./configs                      # a settings file of its own
+```
 
-Every flag mirrors a key of the settings file, and each row below names the key
-it mirrors. The file is what a repository commits; a flag is how one run departs
-from it.
+### Flags
+
+These belong to `run`. Every one mirrors a key of the [settings
+file](docs/configuration.md), named in the middle column: the file is what a
+repository commits, a flag is how one run departs from it.
 
 | Flag | Settings key | Meaning |
 | --- | --- | --- |
@@ -154,34 +167,21 @@ from it.
 | `--verbose` | `output.verbose` | also report the files that passed, and say which settings file was read |
 | `--no-color` | `output.color` (inverted) | disable coloured output |
 
-`--enable`, `--disable`, `--severity`, `--exclude` and `--schema-location` take
-a comma-separated list, and may also be repeated.
+`--enable`, `--disable`, `--severity`, `--exclude` and `--schema-location` take a
+comma-separated list, and may also be repeated.
 
-Exit codes: `0` everything passed, `1` at least one file failed, `2` the command
-could not run. A `--collector-version` the registry has no schema for is that
-last case: the run ends naming the nearest release available, because checking
-the config against a release nobody asked for and exiting `0` says nothing that
-CI can read. Pass `--allow-nearest-fallback` to check against it anyway, for a
+### Exit codes
+
+`0` everything passed, `1` at least one file failed, `2` the command could not
+run. A `--collector-version` the registry has no schema for is that last case:
+the run ends naming the nearest release available, because checking the config
+against a release nobody asked for and exiting `0` says nothing that CI can
+read. Pass `--allow-nearest-fallback` to check against it anyway, for a
 repository deliberately tracking ahead of the registry.
 
-```sh
-otelcol-config-lint run config.yaml                               # lint one file
-otelcol-config-lint run --summary ./configs                       # walk a directory
-cat config.yaml | otelcol-config-lint run -                       # read stdin
-otelcol-config-lint run --output json ./configs > report.json     # machine-readable
-otelcol-config-lint run --output github ./configs                 # PR annotations
-otelcol-config-lint run --collector-version v0.110.0 config.yaml  # target an older release
-otelcol-config-lint run --distribution core config.yaml           # target plain otelcol
-otelcol-config-lint run --default none -E invalid-value ./configs # run one rule and nothing else
-otelcol-config-lint run -c ci.yaml ./configs                      # a settings file of its own
-```
+## Settings file
 
-### Settings file
-
-Commit the policy instead of repeating flags. The file is laid out the way
-golangci-lint's is: **what to check** under `run`, **which rules** under
-`rules`, **what counts as a failure** under `issues`, and **how it is printed**
-under `output`.
+Commit the policy instead of repeating flags:
 
 ```yaml
 version: "1"
@@ -190,883 +190,83 @@ run:
   collectorVersion: v0.157.0
   distribution: contrib
   strict: true
-  concurrency: 8
-  exclude:
-    - "*.tmpl.yaml"
-  schemaLocations:
-    - ./schemas       # this project's own schemas first
-    - default         # then the published registry
 
 rules:
-  default: all        # or "none", to run only what enable names
-  enable: []
   disable:
     - missing-batch
   severity:
     missing-memory-limiter: warning
-  settings: {}        # each rule's own block, keyed by rule name
 
 issues:
   minSeverity: warning
   failOn: error
-  exitOnError: false
-
-output:
-  format: text
-  summary: true
-  verbose: false
-  color: true
 ```
 
-Every block is optional, as is every key in it: what a file does not state keeps
-its default. A key the linter does not know is an error rather than a line that
-quietly does nothing.
-
-#### Where the file is found
-
-`.otelcol-config-lint.yaml` — or `.otelcol-config-lint.yml` — is looked for in
-the working directory and then in each parent, stopping at the directory holding
-`.git`, so one file at the repository root governs a run started from any
-subdirectory. `--config` names another file, and an explicitly named file that
-does not exist is an error. `--no-config` runs on the flags alone. `--verbose`
-prints which file was read.
-
-Explicit flags win over the file, with one exception: the rule lists merge, so
-`-D` adds to `rules.disable` rather than replacing it.
-
-#### Choosing the rules
-
-`rules.default` is the set to start from — `all`, which is every rule and what a
-file that says nothing gets, or `none`, which runs only what `enable` names.
-`disable` then takes rules out, and `severity` sets the level a rule reports at.
-Naming a rule in both `enable` and `disable` is an error rather than a silent win
-for one of them.
-
-```yaml
-rules:
-  default: none
-  enable: [unknown-component, invalid-value, undefined-reference]
-```
-
-`otelcol-config-lint list rules` prints what the policy resolves to: a rule that
-will not run is listed at severity `off`.
-
-#### Per-rule settings
-
-`rules.settings` is where a rule's own knobs go, keyed by rule name, the way
-golangci-lint's `linters.settings` works:
-
-```yaml
-rules:
-  settings:
-    some-rule:
-      threshold: 10
-```
-
-No built-in rule reads a block yet — the schema is here so one can be added
-without every settings file having to change shape. Until a rule declares that
-it takes settings, writing a block for it is reported as an error: a knob nobody
-reads is worse than a knob that is missing.
-
-#### Checking the settings file in an editor
-
-`otelcol-config-lint.schema.json` is a JSON Schema for the file, so an editor
-underlines a misspelled key, a severity that is not a level, and a rule name
-that does not exist — the rule list in it is generated from the rules the linter
-carries, and CI fails on a copy that has fallen behind.
-
-Name it from the file itself, which every YAML language server reads:
-
-```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/minuk-dev/otelcol-config-lint/main/otelcol-config-lint.schema.json
-```
-
-Or map it once, in VS Code's `settings.json`:
-
-```json
-{
-  "yaml.schemas": {
-    "https://raw.githubusercontent.com/minuk-dev/otelcol-config-lint/main/otelcol-config-lint.schema.json": [
-      ".otelcol-config-lint.yaml",
-      ".otelcol-config-lint.yml"
-    ]
-  }
-}
-```
-
-`otelcol-config-lint config-schema` prints the same document, so a project that
-vendors it gets the list of rules the binary it pins actually runs:
-
-```sh
-otelcol-config-lint config-schema > otelcol-config-lint.schema.json
-```
-
-#### The flat form
-
-The keys the first release put at the top level — `collectorVersion`,
-`distribution`, `schemaLocations`, `strict`, `ignoreMissingSchemas`, `summary`,
-`minSeverity`, `failOn`, `disable`, `severity`, `exclude` and `kubernetes` — are
-still read, and folded into the blocks above. A run that finds one says which
-keys to move. `output: json` is not one of them: a bare format name is still the
-shorthand for `output: {format: json}`.
-
-#### The deployment environment
-
-`memory-limiter-sizing` compares a `memory_limiter` against the container it
-runs in, which the config file cannot state. The `run.kubernetes` block
-supplies it.
-
-It is resolved **per file**, because a run is not one deployment: an agent
-DaemonSet at `256Mi` and a gateway Deployment at `4Gi` sit in the same directory
-and are checked in the same run.
-
-```yaml
-run:
-  kubernetes:
-    enabled: true
-    memoryRequest: 512Mi        # the defaults, for any file no override matches
-    memoryLimit: 512Mi
-    overrides:
-      - paths: ["configs/agent-*.yaml"]
-        memoryRequest: 256Mi
-        memoryLimit: 256Mi
-      - paths: ["configs/gateway/*.yaml"]
-        memoryRequest: 4Gi
-        memoryLimit: 4Gi
-      - paths: ["configs/legacy/*.yaml"]
-        enabled: false          # opt a subtree back out
-```
-
-- Overrides are matched in list order and the **first match wins**. A matching
-  override replaces the defaults; it does not merge with them.
-- `paths` are globs matched against both the whole path and the base name,
-  exactly as `--exclude` is, so the two behave identically — including which
-  patterns do not work: there is no `**`.
-- `enabled` defaults to true when either memory number is written, since a
-  block stating what the container has is a block about a container.
-- Sizes are Kubernetes quantities: `512Mi`, `1Gi`, `2G`, or a bare byte count.
-  Anything else is an error rather than a silently different number.
-- A file that matches no override and has no defaults to fall back on simply
-  skips `memory-limiter-sizing`. That is per file: the rest of the run is
-  unaffected. `--verbose` prints what each file resolved to.
-- Config read from stdin is reported as `stdin`, which no glob is meant to
-  match, so it gets the defaults.
-
-`--kubernetes`, `--memory-request` and `--memory-limit` are the single-file
-convenience: they set the defaults and, like every flag, win over the file.
-There is deliberately no flag form of the overrides.
+`.otelcol-config-lint.yaml` is looked for in the working directory and then in
+each parent, stopping at the repository root. See
+[docs/configuration.md](docs/configuration.md) for the whole file: where it is
+found, how rules are selected, the JSON Schema an editor checks it against, and
+the `run.kubernetes` block that tells `memory-limiter-sizing` what container a
+config runs in.
 
 ## What it checks
 
-`otelcol-config-lint list rules` prints the current set with default severities.
+35 rules, listed by `otelcol-config-lint list rules` and documented one page
+each under [docs/rules/](docs/rules/README.md).
 
-**Structure** — `unknown-top-level-key`, `service-required`,
-`unknown-service-key`, `invalid-pipeline-key`, `empty-pipeline`,
-`unknown-pipeline-key`, `duplicate-key`, `wrong-node-type`.
+- **[Structure](docs/rules/README.md#structure)** — the config the collector
+  refuses to load, or loads while silently ignoring half of.
+  `unknown-top-level-key`, `service-required`, `unknown-service-key`,
+  `invalid-pipeline-key`, `empty-pipeline`, `unknown-pipeline-key`,
+  `duplicate-key`, `wrong-node-type`.
+- **[Wiring](docs/rules/README.md#wiring)** — whether what is declared and what
+  is referenced add up. `undefined-reference`,
+  `undefined-extension-reference`, `unused-component`, `duplicate-reference`,
+  `connector-wiring`.
+- **[Release and distribution
+  compatibility](docs/rules/README.md#release-and-distribution-compatibility)** —
+  `unknown-component` (with "exists in v0.110.0 but not in v0.157.0", or "not in
+  the core distribution; it ships in contrib, k8s"), `signal-support`,
+  `component-stability`, `deprecated-component`.
+- **[Settings](docs/rules/README.md#settings)** — `unknown-field`,
+  `required-field`, `invalid-value`, `deprecated-field`, read from field schemas
+  covering 92–96% of components. What cannot be resolved is left open rather
+  than reported, so partial coverage never produces false positives.
+- **[Practice](docs/rules/README.md#practice)** — configs that load and run, and
+  then behave in a way nobody asked for. `processor-order`,
+  `missing-memory-limiter`, `missing-batch`, `memory-limiter-config`,
+  `memory-limiter-sizing`, `batch-size-bounds`, `no-persistent-queue`,
+  `debug-exporter-verbosity`.
+- **[The collector's own
+  telemetry](docs/rules/README.md#the-collectors-own-telemetry)** —
+  `deprecated-telemetry-key`, `telemetry-metrics-disabled`. Both report a
+  silence rather than a failure.
+- **[Security](docs/rules/README.md#security)** — `insecure-tls`,
+  `receiver-binds-all-interfaces`, `debug-extension-exposed`,
+  `hardcoded-secret`.
 
-**Wiring** — `undefined-reference`, `undefined-extension-reference` (an
-extension a component's own settings name — an exporter's
-`sending_queue.storage`, an `auth.authenticator` — that nothing declares, or
-that is declared and then left out of `service.extensions`, which the collector
-refuses to start on; the field schema is what says which settings hold one, so
-a setting upstream adds is checked as soon as its schema lands),
-`unused-component`, `duplicate-reference`,
-`connector-wiring` (a connector must export from one pipeline and receive into
-another, and must not close a loop).
-
-**Release and distribution compatibility** — `unknown-component` (with "exists
-in v0.110.0 but not in v0.157.0" when a component was removed, or "not in the
-core distribution; it ships in contrib, k8s" when the binary simply does not
-carry it), `signal-support` (a receiver
-that only does traces used in a metrics pipeline), `component-stability`,
-`deprecated-component`.
-
-**Settings** — `unknown-field`, `required-field`, `invalid-value`,
-`deprecated-field`. Field schemas are read from each component's `Config` struct
-and enriched with the `config.schema.yaml` upstream publishes, covering 92-96%
-of components on every release. What cannot be resolved — a third-party config
-such as Prometheus's own — is left open rather than reported, so partial
-coverage never produces false positives. `${env:...}` expansions are left
-alone.
-
-**Practice** — `processor-order` (`memory_limiter` first, enrichment before
-sampling, `batch` last), `missing-memory-limiter`,
-`missing-batch`, `memory-limiter-config`, `memory-limiter-sizing`,
-`batch-size-bounds`, `no-persistent-queue`, `debug-exporter-verbosity`.
-
-**The collector's own telemetry** — `deprecated-telemetry-key`,
-`telemetry-metrics-disabled`. `service.telemetry` is the one block that is about
-the run rather than about the data, and both rules report a silence rather than
-a failure. `service.telemetry.metrics.address` is ignored from v0.123.0 onward:
-a collector upgraded across that release starts, and serves its metrics wherever
-its `readers` say, while the scrape target the config names stays empty. The
-rule holds its tongue when `--collector-version` is older, because there the key
-still works. `metrics.level: none` is a legitimate setting with an unadvertised
-cost — the metrics it turns off are the ones that say the collector is dropping
-data, the queue sizes and `otelcol_exporter_send_failed_*` among them.
-
-**Security** — `insecure-tls`, `receiver-binds-all-interfaces`,
-`debug-extension-exposed`, `hardcoded-secret`.
-
-Every rule reads the config the collector will read, not the one on the page.
-YAML anchors, aliases and `<<` merge keys are resolved when the file is parsed,
-the way confmap resolves them through yaml.v3 before the collector sees a single
-setting — so a component whose settings come from a shared base is checked
-against what it will actually run with, and `<<` is never reported as a setting,
-because it is not one. A key a component writes itself still wins over the one
-its merge supplies, which is the merge key's purpose, so `duplicate-key` reads
-the document as written and stays quiet about the override. Findings keep the
-line they were written on: a setting a merge supplies is reported against the
-line in the anchor, which is the line to edit.
-
-Every practice, telemetry and security rule cites the upstream page it rests on
-— the `memorylimiterprocessor`, `batchprocessor`, `exporterhelper`,
-`debugexporter`, `tailsamplingprocessor` and `probabilisticsamplerprocessor`
-READMEs, `configtls`, the internal telemetry page, upstream's security best
-practices, and the Kubernetes resource docs for the container's request and
-limit.
-
-`processor-order` is about where a processor stands rather than what it is set
-to. Two of its clauses are the ends of the chain: `memory_limiter` first, so
-backpressure is applied before any work is done, and `batch` last, so the
-processors ahead of it see individual items. The third is the middle, where the
-two orders are equally valid YAML and only one of them works.
-
-```yaml
-processors: [memory_limiter, tail_sampling, k8sattributes, batch]
-#                            ^^^^^^^^^^^^^ decides before the pod and namespace are on the span
-```
-
-`k8sattributes`, `resourcedetection` and `resource` add the attributes a
-sampling policy is written against — as do `k8s_attributes` and
-`resource_detection`, the names upstream renamed the first two to, which both
-count — so a policy matching one of them from behind
-`tail_sampling` or `probabilistic_sampler` matches nothing at all — no error, no
-crash, just the spans it was meant to keep going missing. `tail_sampling`'s own
-README states the other half of it: the processor reassembles spans into new
-batches, so anything reading the request context has to have run already.
-`attributes` is deliberately left out of the group, because it redacts as often
-as it enriches and stripping fields from what a sampler kept is the right order
-to do that in.
-
-`memory_limiter` is the one processor this linter tells people to add, and two
-of its constraints cannot be written as a field schema:
-`check_interval` must be greater than zero and yet defaults to `0s`, so leaving
-it out is an error rather than a choice, and `limit_mib`/`limit_percentage` are
-a one-of. `memory-limiter-config` checks what upstream's own `Validate()`
-checks, quoting its wording, and matches on the component type so
-`memory_limiter/aggressive` is covered too.
-
-`memory-limiter-sizing` is the other half, and it needs a number the config
-cannot carry: the container's memory limit. A limiter that passes every check
-above is still decoration if `limit_mib` sits at or above the container limit,
-because the kernel kills the collector before the limiter ever engages. It runs
-only for files the [`kubernetes` block](#the-deployment-environment) describes,
-so a run that configures nothing sees nothing new.
-
-`batch-size-bounds` is the same idea for the `batch` processor, whose
-`Validate()` relates two fields a field schema only ever sees one at a time:
-`send_batch_size` is the count that triggers a send, `send_batch_max_size` is a
-hard cap, and a cap below the trigger is refused at startup. The names read
-backwards from the semantics, so capping at something reasonable-looking like
-`1000` while leaving `send_batch_size` at its default of `8192` is exactly the
-shape that fails — and since nobody wrote the 8192, the finding says it is the
-default rather than quoting it back as if they had. It also reports a negative
-`timeout` and a key repeated in `metadata_keys`, which are compared
-case-insensitively, so `tenant` and `Tenant` are one key. Both sizes are
-`uint32` upstream, a range the published field schemas flatten to `int`, so a
-negative or over-large count is reported here too — it fails to load rather than
-to validate, and saying so beats hinting at a fix that still will not start.
-
-`missing-batch` reports a pipeline that batches nothing on its way out, and
-there are now two ways not to be one. `exporterhelper` batches inside the
-sending queue, under `sending_queue.batch`, which sits behind the queue and the
-retry logic rather than in front of them; the `batch` processor
-[drops the data in a batch that fails to send](https://github.com/open-telemetry/opentelemetry-collector/issues/12443),
-and the queue batcher does not. That is why the hint leads with the exporter
-setting and names the processor as what also works. The processor is not
-deprecated — upstream has explicitly not decided that — so a pipeline that uses
-it is a pipeline that batches, and nothing here says to take it out.
-
-```yaml
-exporters:
-  otlphttp:
-    endpoint: http://backend:4318
-    sending_queue:
-      batch:                   # off by default; writing the block turns it on
-        flush_timeout: 200ms
-```
-
-A pipeline whose exporters all do that gets no finding: it batches, and a
-`batch` processor added on top would be a second layer with a flush timing of
-its own. Where only some of them do, the pipeline is under-batched on the legs
-that do not, so the finding names the exporter and sits on the line that wires
-it in — that exporter's settings are where the fix is written. A connector in
-the exporter slot is not a leg out of the collector and is not counted; it feeds
-another pipeline, which has exporters of its own. An exporter whose queue is built from
-an expansion counts as unknown rather than as not batching, for the same reason
-the field rules leave what they cannot resolve alone. A merge key is not one of
-those: it is resolved when the file is parsed, the way the collector resolves
-it, so what an anchor supplies is read like anything written in place.
-
-What the document writes decides whether there is a finding; what the field
-schema describes decides only which fix the hint may name. The queue batcher is
-off until something turns it on, so a config that writes no
-`sending_queue.batch` is not batching there whatever the schema knows about the
-type — which is why an exporter it describes no settings for, `nop` and
-`datadog` among them, is reported like any other rather than passed over in
-silence.
-
-The hint is the half that follows the schema, and it asks for
-`sending_queue.batch` itself rather than for the queue holding it. The batcher
-is younger than the queue: on a release from before it moved in, every exporter
-has a `sending_queue` and none of them has a `batch` under it, and a hint naming
-one there would be advising a setting the collector rejects on startup —
-`unknown-field`, reading the same schema, would say so in the same run. So
-where the field is not there to write — an exporter with no `sending_queue` on
-the targeted release, `debug` on `v0.157` among them; any exporter on a release
-that predates the batcher; anything the schema does not describe, `nop` and
-`datadog` among them — the hint names the processor instead, because a fix the
-release has no setting for is no fix. Which exporters those are is the schema's
-answer and moves with the release, which is the point of asking it. Where one finding covers several exporters
-at once it names the queue batcher only if all of them accept it; where they
-disagree it names the processor and says that only some of them can take a
-`sending_queue.batch`, since the reason it gives otherwise would be false of
-half of them.
-
-`no-persistent-queue` is the one opinionated rule, and it reports at `info` for
-that reason. The sending queue is on by default and lives in memory, so a
-deploy, an OOM kill or a node drain takes everything still in it — and nothing
-in the config says so, because an exporter with a `storage` extension and one
-without look identical until the restart.
-
-```yaml
-exporters:
-  otlp:
-    endpoint: backend:4317
-    sending_queue:
-      storage: file_storage    # without this, a restart drops the queue
-```
-
-Persistence takes three steps — a storage extension declared, listed in
-`service.extensions`, and named here — which is why the finding names all three
-and why `undefined-extension-reference` above is worth having alongside it. The
-The rule stays quiet on `sending_queue.enabled: false`, on an exporter no
-pipeline references, and on exporters whose field schema describes their
-settings and has no queue among them, which is what keeps `debug` out of it.
-Where the schema resolved nothing for a component — the `datadog` exporter and
-`nop` share that — a queue the config writes is the only evidence there is, and
-it is taken at face value.
-
-It reports once per exporter, not once per config: the fix is written per
-exporter, each queue names its own storage, and a finding without a position
-cannot say which of eight exporters to edit. It is also the rule most likely to
-be unwanted — a sidecar next to an application that can re-send, or an agent
-whose source keeps its own buffer, is right not to want a writable volume. There
-is deliberately no default-disabled rule concept for it: `info` is already below
-`--min-severity warning`, which is a normal way to run, and `disable:
-[no-persistent-queue]` in the settings file turns it off for good. A second
-mechanism that means roughly the same thing would only be another place to look.
-
-`debug-exporter-verbosity` catches the exporter somebody added to find out why
-an export was failing and never took out again. It prints what it is given to
-the collector's own log, and at `verbosity: detailed` that is every field of
-every span, data point and record in the pipeline — the collector spends its
-time formatting log lines, and the log backend receives a second copy of all the
-telemetry the collector was meant to be forwarding.
-
-```yaml
-exporters:
-  debug:
-    verbosity: detailed    # a line per record, not per batch
-service:
-  pipelines:
-    traces:
-      exporters: [otlp, debug]    # and it ships to production like this
-```
-
-That is the `warning`. Below it, at `info`, is one quiet note for a `debug`
-exporter at any verbosity: `basic` costs a line per batch rather than per
-record, which is cheap enough not to be a warning, but it is still a diagnostic
-tool left running, and upstream keeps no stable output format, so nothing
-downstream should be parsing it either. Both clauses match on the type, so
-`debug/verbose` counts, and both report per pipeline that references the
-exporter — that is what the message names and where the reader takes it out of.
-An exporter no pipeline references prints nothing and is `unused-component`'s to
-report; the `logging` exporter that came before it is `deprecated-component`'s.
-`warning` rather than `error` is deliberate: a deliberate debug run is
-legitimate and should not fail a CI job, and `--severity
-debug-exporter-verbosity=error` is there for anyone who wants it fatal.
-
-`receiver-binds-all-interfaces` is the one upstream's [config best
-practices](https://opentelemetry.io/docs/security/config-best-practices/) lead
-with, and the most common way a collector ends up reachable from more of the
-network than anyone meant:
-
-```yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317   # every interface, not just the one you meant
-```
-
-The collector changed its own default to `localhost` in `v0.110.0` for exactly
-this reason. The example configs the ecosystem copies from did not — the ones on
-opentelemetry.io say outright that they use the unspecified address "as a
-convenience" — and those get pasted into production. Every spelling of it is
-matched: `0.0.0.0`, `[::]`, a bare `:4317`, and `:::4317`, which is what netstat
-prints for an IPv6 listener and which Go refuses outright, so a collector handed
-one does not start at all.
-
-Only endpoints something *listens* on are read, and the split is by kind:
-receivers and extensions bind, while an exporter's or a connector's `endpoint`
-names somewhere to send to. `0.0.0.0` there is also wrong, but it is a different
-mistake with a different fix, and a bind-address hint on a line about a backend
-would be worse than silence. Within a component the walk is by key name rather
-than by a table of where each type keeps its address, since `otlp` writes one per
-protocol and most others write one at the top; each is reported separately,
-because each is its own line to edit. Two key names are read, not one: the
-stanza-based log receivers call it `listen_address` — `tcplog`, `udplog`, and
-`syslog` under each of its `tcp` and `udp` blocks — and reading only `endpoint`
-would leave every one of them unreported. A receiver no pipeline names and an
-extension `service.extensions` leaves out are both skipped — neither is ever
-instantiated, so neither binds anything — as is an endpoint nobody wrote, which
-takes the component's own default. `${env:MY_POD_IP}:4317` is the fix, so it is
-not a finding; `0.0.0.0:${env:PORT}` still is, since the address says plainly
-who can reach it and only the port is left open.
-
-The hint carries the fix rather than only the objection: bind `127.0.0.1` when
-every client is local, and in Kubernetes write `${env:MY_POD_IP}`, taking the pod
-IP from the downward API. It reports at `warning`, not `error` — a gateway behind
-a service mesh with its own network policy binds every interface deliberately.
-`health_check` and `healthcheckv2` are left out for the same reason
-`debug-extension-exposed` leaves them out, below, and `pprof` and `zpages` are
-that rule's to report.
-
-`debug-extension-exposed` rests on upstream's [security guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md),
-which is direct about avoiding "exposing health or telemetry data outside the
-Collector by default", and the debugging extensions are the ones that do it.
-`pprof` serves heap profiles, goroutine dumps and the collector's command line;
-`zpages` serves live traces and pipeline internals.
-This is narrower than the general bind-address check above, and separate from it
-because the consequence differs in kind: a `0.0.0.0` OTLP receiver accepts data
-it should not, while a `0.0.0.0` pprof endpoint *hands out* process internals.
-
-```yaml
-extensions:
-  pprof:
-    endpoint: 0.0.0.0:1777     # warning: heap profiles, on every interface
-  zpages:
-    endpoint: 10.0.4.7:55679   # info: deliberate, but that network can read it
-```
-
-The two cases are reported apart because they have different fixes. An
-unspecified address — `0.0.0.0`, `[::]`, a bare `:1777` — is reachable from
-every interface the host has and reports at `warning`; a specific non-loopback
-address was chosen by someone and reports at `info`, saying only that the
-network it sits on can read the collector's internals. Both are matched on
-component type, so `zpages/internal` is covered.
-
-`health_check` and `healthcheckv2` are deliberately left out. A Kubernetes
-liveness probe comes from the kubelet, off the container's loopback interface,
-so a health check bound to `0.0.0.0` is what a correct deployment looks like —
-and a rule that fires on every correct config is a rule people disable, which
-would take `pprof` down with it.
-
-The rule only reports extensions `service.extensions` actually lists, since
-that is the only thing that starts one — a declaration left out of it binds no
-port, and `unused-component` is what has something to say about it. An endpoint
-nobody wrote is left alone too: it takes the extension's own default, which has
-been `localhost` for both since upstream made `UseLocalHostAsDefaultHost` the
-default in `v0.110`. So is a hostname other than `localhost`, since what a name
-resolves to is a property of the network rather than of the file, and an
-address supplied by `${env:...}`. An expansion standing in for only the *port*
-is still reported — `0.0.0.0:${env:PPROF_PORT}` says plainly who can reach it —
-and an endpoint a `<<` merge supplies is read like one written in place, since
-merges are resolved when the file is parsed, so sharing one debugging block
-between extensions does not hide it.
-
-`hardcoded-secret` is the one rule about the file rather than the collector.
-Configs live in git, and exporter credentials are written in the same file as
-everything else:
-
-```yaml
-exporters:
-  otlp:
-    endpoint: backend:4317
-    headers:
-      authorization: Bearer ${env:OTLP_TOKEN}   # not the literal token
-```
-
-Upstream's guidance is to keep sensitive values in a secret store or on an
-encrypted filesystem and pull them in with an expansion, and CI is the last
-moment before the value reaches a remote. The rule walks every declared
-component — wired or not, since a credential in the repository has already been
-handed over — and reports a scalar whose key names a credential (`password`,
-`token`, `api_key`, `secret`, `credential`, `private_key`, `key_pem`,
-`access_key`, `passphrase`, matched as a case-insensitive substring, so
-`sasl_password` is covered) and whose value is written out in full. A list is
-matched by the key that named it, so `api_keys: [AKIA…]` is reported too, and
-under `headers:` so are `authorization` and any value opening with `Bearer` or
-`Basic`.
-
-**It never prints the value**, only the path: copying the secret into the CI log
-is the one thing this rule must not do. False positives are the risk it carries,
-so it gives up findings freely. `${env:...}` and `${file:...}` are the fix and
-say so; empty values and placeholders (`changeme`, `<your-token>`, `REPLACE_ME`,
-`none`) are a config with no credential in it yet, behind an auth scheme as much
-as on their own; a boolean is a switch rather than a credential, whatever the
-setting is called; and a key naming *where* a credential lives rather than
-holding one — `private_key_file`, `token_url`, `cert_pem` — is a correctly
-configured component, so keys ending in `_file`, `_path`, `_url`, `_uri` and
-`_name` are excluded before anything else. It reports at `warning`, because a
-local config with a dummy credential is legitimate and this rule will meet
-plenty of them.
+Every rule reads the config the collector will read: YAML anchors, aliases and
+`<<` merge keys are resolved when the file is parsed, and findings keep the line
+they were written on. A rule that reports what the collector requires or
+recommends carries a `docs:` link to the upstream page that says so, so the
+claim can be checked rather than taken on trust — it is in the JSON output as
+`docs`, and in the GitHub annotations.
 
 ## Schemas
 
-Schemas are published at
+Component schemas are published at
 [minuk-dev/otelcol-config-schemas](https://github.com/minuk-dev/otelcol-config-schemas),
-one file per collector release per distribution, in both YAML (the readable
-form, meant to be reviewed in pull requests) and JSON. They live in a repository
-of their own because a registry grows without bound while a run reads one file
-from it; keeping them here would charge every clone for schemas it never opens. They are
-generated from the `metadata.yaml` that every upstream component ships, across
-**both core and contrib**, split into one schema per distribution:
-`contrib` (323 components for v0.157.0, the default), `core` (32), `k8s` (83)
-and `otlp` (5).
+one file per collector release per distribution, generated from the
+`metadata.yaml` upstream ships. They are read over HTTPS by default and cached
+between runs; `--schema-location ../otelcol-config-schemas` runs against a
+checkout instead, with no network access at all.
 
-```yaml
-components:
-  receiver:
-    otlp:
-      type: otlp
-      signals: [traces, metrics, logs, profiles]
-      stability:
-        traces: stable
-        metrics: stable
-        logs: stable
-        profiles: alpha
-      module: go.opentelemetry.io/collector/receiver/otlpreceiver
-```
+A weekly job **in that repository** generates the schemas for each new collector
+release and opens a pull request there. `cmd/schemagen` in this repository is
+what it runs, and is also how a private distribution gets a schema of its own —
+see [docs/schemas.md](docs/schemas.md).
 
-They are read over HTTPS by default, so nothing needs installing or cloning. To
-pin a copy, or to run without network access, point at a checkout:
+## Contributing
 
-```sh
-otelcol-config-lint run --schema-location ../otelcol-config-schemas config.yaml
-```
-
-A location is a registry directory or URL (one holding `index.json`, laid out
-as `<distribution>/<version>.<ext>`, optionally with the `components.json`
-described [below](#which-releases-have-a-component)), a
-`{{.Version}}`/`{{.Distribution}}` template naming a single file, or `default`
-for the published registry. Repeat the flag to search several in order, so a
-private distribution's schema can take precedence over the public ones, or so a
-vendored copy answers before the network is tried.
-
-A remote location must be `https://`. The schema is what every rule reasons
-from — which components exist, which settings they take — so anyone able to
-rewrite one in flight decides what the linter reports; a plain `http://`
-location is refused unless `--insecure-schema-location` says otherwise, which
-is there for a registry served on localhost. One download is capped at 32 MiB,
-so a registry that is hostile or merely broken cannot stream the linter out of
-memory.
-
-### Which releases have a component
-
-An unknown component is worth explaining — `"logging" exists in v0.110.0 but
-not in v0.157.0` says something a "did you mean" cannot — but the question is
-about every release at once, and a schema describes one. Answering it by
-reading them is a multi-megabyte download per release, tens of them, to produce
-a single line of hint, and against a rate limit that counts requests it is the
-shape most likely to be throttled.
-
-So the registry publishes `components.json` beside the index: the releases each
-component type is shipped in, per distribution, as one document read in one
-request. It is only read by a run that actually meets an unknown component, and
-it is written as spans (`from`, and `to` once the component is gone), so a new
-release does not rewrite the entry of everything it left alone.
-
-A registry publishing none is still read the old way, one schema per release —
-without limit for a directory on disk, and no further back than the twelve
-newest releases over the network, which are the ones a hint is usually about. A
-walk that lost half its releases to a throttled registry reports nothing rather
-than naming whichever release happened to answer: a hint that is quietly wrong
-is worse than no hint at all.
-
-### Caching
-
-A schema describes one release of one distribution, so what it says under a
-version does not change. Fetched schemas are therefore kept between runs, under
-`$XDG_CACHE_HOME/otelcol-config-lint` (the platform's own cache directory when
-the environment names none), and a second run reads them from there without
-asking the registry. The index, which grows a line per release, is offered back
-with its ETag instead, so an up-to-date run pays a `304` rather than the file.
-
-`--no-cache` reads nothing and keeps nothing. The registry tracks its own main,
-so a schema can be corrected under a version this machine has already read;
-that is when to reach for it. Deleting the directory has the same effect once.
-
-A throttled or briefly failing registry is asked again — three attempts, waiting
-as long as a `Retry-After` asks for and backing off from half a second
-otherwise — so one `429` does not fail a lint. A `404` is not retried: it means
-the registry does not carry that version, which waiting will not change.
-
-### Adding a release
-
-A distribution is described by the same [OCB builder
-manifest](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder)
-that builds it, so the schema lists exactly the components the binary carries.
-Upstream ships one per distribution in
-[`opentelemetry-collector-releases`](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions):
-
-```sh
-# ../opentelemetry-collector-releases checked out at the release to generate
-make schemas                                    # writes to ../otelcol-config-schemas
-make schemas RELEASES=/path/to/opentelemetry-collector-releases \
-             SCHEMAS=/path/to/otelcol-config-schemas
-```
-
-Or name a manifest directly, which is how a private distribution is covered.
-A single run writes one schema, so `--out` names the file (or `-`, the default,
-for stdout); `--registry` is what fills a directory with the
-`<distribution>/<version>.<ext>` layout and its `index.json`:
-
-```sh
-go run ./cmd/schemagen generate --builder ./builder.yaml --out ./my-collector.yaml
-go run ./cmd/schemagen generate --builder acme=./builder.yaml --registry ./schemas
-```
-
-`cmd/schemagen` downloads every module the manifest names, plus everything they
-require, and writes `<distribution>/<version>.yaml` and `.json` into the schema
-repository, along with the `index.json` listing them. The index also records
-the extension each distribution's schemas should be fetched with, so reading
-one over the network costs a single request instead of probing `.yaml`, `.yml`
-and `.json` in turn; a distribution whose releases do not agree on one form
-names none, and is probed as before. `components.json` is written beside it,
-from the schemas the registry is left holding, so that
-[an unknown component can be placed](#which-releases-have-a-component) without
-downloading the registry; a distribution whose releases could not all be read is
-left out of it rather than described from half of them. The download goes
-through the `go` command, so `GOPROXY`, `GOPRIVATE` and whatever credentials
-this machine builds with apply unchanged: a **private component resolves exactly as
-it does for the build that consumes it**, and a `replaces:` entry pointing at a
-checkout is read from there. A component that ships no `metadata.yaml` is still
-recorded, from what the manifest says, so a config naming it is not reported as
-unknown.
-
-In the registry the file name comes from the manifest -- `dist.otelcol_version`
-(or `dist.version`) and `dist.name` -- so `--builder <name>=<path>` overrides
-the name where the registry spells a distribution differently from upstream, as
-it does for `otelcol`, which is filed as `core`.
-
-Component renames are carried through: upstream is moving types to snake_case,
-so from v0.157.0 the OTLP gRPC exporter is `otlp_grpc` with `otlp` kept as a
-deprecated alias. Both resolve, and using the old name reports
-`deprecated-component`.
-
-### Keeping the registry current
-
-Nobody has to remember. The [`schemas`](.github/workflows/schemas.yaml) workflow
-runs weekly, reads upstream's release tags, and for each one the registry does
-not have yet generates the schemas and opens a pull request against
-`otelcol-config-schemas`, one per release. A release with no schema stops the
-run — `--collector-version v0.158.0` is a usage error naming the newest release
-the registry does have — so the registry has to keep up on its own. Dispatch the workflow with a version to
-generate one by hand, present or not.
-
-The generated diff is several megabytes of YAML, so the pull request leads with
-what actually changed. `--summary` writes it: the components the release adds,
-drops and renames, and the ones that crossed the beta line, which is what
-`component-stability` reports on and so what changes the findings an unchanged
-config gets.
-
-```sh
-go run ./cmd/schemagen generate --builder acme=./builder.yaml --registry ./schemas \
-  --summary -
-```
-
-```
-### contrib: `v0.157.0` → `v0.158.0`
-
-4 added, 1 renamed, 2 across the beta line; 327 components in total.
-
-**Added**
-
-- receiver `faro`
-…
-```
-
-A registry grows without bound — one file per release per distribution, in two
-formats — so `--retain n` keeps only the newest `n` releases of each
-distribution, and `--retain-every n` holds on to every `n`th minor for good, so
-a config pinned to a round release keeps resolving after its neighbours are
-dropped. Neither is on by default; the scheduled workflow sets them, a local
-`make schemas` keeps everything. Pruning bounds what the registry serves and
-what a checkout costs, not the history of the repository holding it.
-
-### Field schemas
-
-`metadata.yaml` describes components but not their settings, so those are read
-from the modules themselves: every component's `Config` struct, and the
-`config.schema.yaml` upstream publishes alongside it, which contributes
-descriptions and enums the Go source cannot:
-
-```yaml
-fields:
-  type: map
-  children:
-    timeout: {type: duration, doc: how long to wait before sending a batch}
-    send_batch_size: {type: int}
-```
-
-References between those schemas are followed across modules, so a component's
-shared settings — `sending_queue`, `retry_on_failure`, TLS, gRPC client options
-— are expanded in full. What cannot be resolved stays open rather than being
-reported, so partial coverage never produces false positives.
-
-A setting that decodes into a `component.ID` is marked, since nothing in the
-value says so — a storage id and a directory path are both strings:
-
-```yaml
-sending_queue:
-  type: map
-  children:
-    storage: {type: string, extensionRef: storage}
-```
-
-That marker is what `undefined-extension-reference` reads, so which settings
-name an extension is derived from the sources rather than maintained as a list
-in the linter. The role — `storage`, `auth`, or a plain `extension` for a key
-the generator has no name for — is only what the diagnostic calls it. Schemas
-generated before the marker existed keep working: the rule still knows
-`sending_queue.storage` and `auth.authenticator` on its own, and that fallback
-falls away as the registry is regenerated.
-
-## Layout
-
-```
-cmd/otelcol-config-lint/      the linter entry point
-cmd/schemagen/                the schema generator entry point
-pkg/cmd/otelcol-config-lint/  the cobra command: flags, settings files, reporting
-pkg/cmd/schemagen/            the generator: harvests upstream metadata into schemas
-pkg/scanner/                  expands the given paths into the files to lint
-pkg/sets/                     a set built on a map, in the shape of k8s.io/apimachinery
-pkg/config/                   YAML parsing that keeps positions, so findings have line numbers
-pkg/schema/                   schema types, version resolution and location lookup
-pkg/rule/                     what a rule is: the interface, the context and the shared readers
-pkg/rule/<rule-name>/         one rule and its tests, one package each
-pkg/rule/ruletest/            the fixtures a rule's tests are written against
-pkg/ruleset/                  the registry: every rule collected into one set
-pkg/lint/                     the engine and the output formatters
-pkg/diag/                     diagnostics, severities and positions
-pkg/quantity/                 Kubernetes memory quantities, parsed and printed back
-pkg/version/                  the linter's own version, stamped at build time
-testdata/rules/               one invalid config per rule, with the run that shows it
-action.yml                    the GitHub Action; Dockerfile wraps the released image it runs
-build/docker/Dockerfile       the distroless linter image releases publish
-```
-
-## Adding a rule
-
-A rule is a package. `pkg/rule` defines what one is -- the `Rule` interface, the
-`Context` a check reads, the `Finding` it reports -- along with the YAML readers
-and phrasing helpers every rule shares. `pkg/ruleset` is the only place that
-knows about all of them, which is what keeps a rule free to import the
-vocabulary it is written in.
-
-So a new rule is one directory and one line:
-
-```go
-// pkg/rule/mynewrule/rule.go
-package mynewrule
-
-// New builds the rule.
-func New() rule.Rule {
-	return myNewRule{rule.NewBase("my-new-rule",
-		"one line saying what this reports", diag.Warning)}
-}
-
-type myNewRule struct{ rule.Base }
-
-func (r myNewRule) Check(ctx *rule.Context) {
-	for _, p := range ctx.File.Service.Pipelines {
-		ctx.Report(rule.Finding{
-			Node: p.KeyNode, Path: "service.pipelines." + p.Key,
-			Message: "pipeline " + rule.Quote(p.Key) + " is doing the thing",
-			Hint:    "stop doing the thing",
-		})
-	}
-}
-```
-
-Then add `mynewrule.New()` to the list in `pkg/ruleset/ruleset.go`, and write
-`pkg/rule/mynewrule/rule_test.go` against `pkg/rule/ruletest`, which carries the
-stand-in schema and the clean config every rule's tests start from:
-
-```go
-found, err := ruletest.Run(mynewrule.New(), src)
-```
-
-A test that is about two rules meeting -- one reporting where the other stays
-quiet -- belongs in `pkg/ruleset` instead, which is where the whole set is run
-at once.
-
-Last, the rule needs a config in `testdata/rules`: `my-new-rule.yaml`, which
-breaks it, with a comment naming the rule on the line that breaks it, and
-`my-new-rule.settings.yaml`, which says which rules the run has on in the shape
-golangci-lint uses:
-
-```yaml
-rules:
-  enable: [my-new-rule]  # must report on my-new-rule.yaml
-  disable: []            # switched off for this run, and must stay quiet
-  settings: {}           # per-rule options, keyed by rule name
-```
-
-The tests refuse a rule with no fixture, so this is where a rule is shown
-working through the real command line, the published schemas and the severity
-gate rather than against the stand-in schema. `testdata/rules/README.md` has the
-rest of the schema, including how a fixture selects its own collector release or
-states the container it runs in.
-
-## Development
-
-```sh
-make test            # go test -race with coverage
-make lint            # golangci-lint
-make build           # ./bin/otelcol-config-lint
-make build-snapshot  # every release target, the way CI builds them
-make schemas         # regenerate the schemas into ../otelcol-config-schemas
-```
-
-Nothing injects the version. The Go toolchain records the module version and
-the repository state in every binary it builds, and `pkg/version` reads that
-back, so a tagged build reports its tag because it was built from that tag:
-
-| built from | `otelcol-config-lint version` |
-| --- | --- |
-| a tag | `v1.2.3`, or `v1.2.3+dirty` from a modified tree |
-| `go install ...@v1.2.3` | `v1.2.3` |
-| a commit between tags | `b7dbdd5`, or `b7dbdd5-dirty` |
-| no repository, or `go run` | `devel` |
-
-CI runs the tests with coverage reported on the pull request, builds every
-release target, lints this repository's own example configs, exercises the
-action against `testdata/`, and publishes binaries and container images from
-tags. A weekly job generates the schemas for each new collector release and
-opens a pull request against the schema registry.
-
-Releasing is bump then tag, because the action's image is pinned at the release
-it ships in and a tag cannot reference an image built from itself:
-
-```sh
-make release-pin RELEASE=v1.2.3
-git commit -am 'chore(release): pin the action at v1.2.3'
-git tag v1.2.3 && git push origin main v1.2.3
-```
-
-The release workflow refuses a tag whose pin names another release, and moves
-`v1` onto the release once it has published.
+[docs/contributing.md](docs/contributing.md) has the repository layout, the
+`make` targets, how releases are cut, and what adding a rule takes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,187 @@
+# Settings file
+
+Commit the policy instead of repeating flags. The file is laid out the way
+golangci-lint's is: **what to check** under `run`, **which rules** under
+`rules`, **what counts as a failure** under `issues`, and **how it is printed**
+under `output`.
+
+```yaml
+version: "1"
+
+run:
+  collectorVersion: v0.157.0
+  distribution: contrib
+  strict: true
+  concurrency: 8
+  exclude:
+    - "*.tmpl.yaml"
+  schemaLocations:
+    - ./schemas       # this project's own schemas first
+    - default         # then the published registry
+
+rules:
+  default: all        # or "none", to run only what enable names
+  enable: []
+  disable:
+    - missing-batch
+  severity:
+    missing-memory-limiter: warning
+  settings: {}        # each rule's own block, keyed by rule name
+
+issues:
+  minSeverity: warning
+  failOn: error
+  exitOnError: false
+
+output:
+  format: text
+  summary: true
+  verbose: false
+  color: true
+```
+
+Every block is optional, as is every key in it: what a file does not state keeps
+its default. A key the linter does not know is an error rather than a line that
+quietly does nothing.
+
+Each key mirrors a `run` flag of the same meaning — the [flag
+table](../README.md#usage) names the pairs. The file is what a repository
+commits; a flag is how one run departs from it.
+
+## Where the file is found
+
+`.otelcol-config-lint.yaml` — or `.otelcol-config-lint.yml` — is looked for in
+the working directory and then in each parent, stopping at the directory holding
+`.git`, so one file at the repository root governs a run started from any
+subdirectory.
+
+- `--config` names another file. An explicitly named file that does not exist is
+  an error.
+- `--no-config` runs on the flags alone.
+- `--verbose` prints which file was read.
+
+Explicit flags win over the file, with one exception: the rule lists merge, so
+`-D` adds to `rules.disable` rather than replacing it.
+
+## Choosing the rules
+
+`rules.default` is the set to start from — `all`, which is every rule and what a
+file that says nothing gets, or `none`, which runs only what `enable` names.
+`disable` then takes rules out, and `severity` sets the level a rule reports at.
+
+```yaml
+rules:
+  default: none
+  enable: [unknown-component, invalid-value, undefined-reference]
+```
+
+Naming a rule in both `enable` and `disable` is an error rather than a silent
+win for one of them. `otelcol-config-lint list rules` prints what the policy
+resolves to: a rule that will not run is listed at severity `off`.
+
+See [the rule reference](rules/README.md) for what each one does.
+
+## Per-rule settings
+
+`rules.settings` is where a rule's own knobs go, keyed by rule name, the way
+golangci-lint's `linters.settings` works:
+
+```yaml
+rules:
+  settings:
+    some-rule:
+      threshold: 10
+```
+
+No built-in rule reads a block yet — the schema is here so one can be added
+without every settings file having to change shape. Until a rule declares that
+it takes settings, writing a block for it is reported as an error: a knob nobody
+reads is worse than a knob that is missing.
+
+## Checking the settings file in an editor
+
+`otelcol-config-lint.schema.json` is a JSON Schema for the file, so an editor
+underlines a misspelled key, a severity that is not a level, and a rule name
+that does not exist. The rule list in it is generated from the rules the linter
+carries, and CI fails on a copy that has fallen behind.
+
+Name it from the file itself, which every YAML language server reads:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/minuk-dev/otelcol-config-lint/main/otelcol-config-lint.schema.json
+```
+
+Or map it once, in VS Code's `settings.json`:
+
+```json
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/minuk-dev/otelcol-config-lint/main/otelcol-config-lint.schema.json": [
+      ".otelcol-config-lint.yaml",
+      ".otelcol-config-lint.yml"
+    ]
+  }
+}
+```
+
+`otelcol-config-lint config-schema` prints the same document, so a project that
+vendors it gets the list of rules the binary it pins actually runs:
+
+```sh
+otelcol-config-lint config-schema > otelcol-config-lint.schema.json
+```
+
+## The deployment environment
+
+[`memory-limiter-sizing`](rules/memory-limiter-sizing.md) compares a
+`memory_limiter` against the container it runs in, which the config file cannot
+state. The `run.kubernetes` block supplies it.
+
+It is resolved **per file**, because a run is not one deployment: an agent
+DaemonSet at `256Mi` and a gateway Deployment at `4Gi` sit in the same directory
+and are checked in the same run.
+
+```yaml
+run:
+  kubernetes:
+    enabled: true
+    memoryRequest: 512Mi        # the defaults, for any file no override matches
+    memoryLimit: 512Mi
+    overrides:
+      - paths: ["configs/agent-*.yaml"]
+        memoryRequest: 256Mi
+        memoryLimit: 256Mi
+      - paths: ["configs/gateway/*.yaml"]
+        memoryRequest: 4Gi
+        memoryLimit: 4Gi
+      - paths: ["configs/legacy/*.yaml"]
+        enabled: false          # opt a subtree back out
+```
+
+- Overrides are matched in list order and the **first match wins**. A matching
+  override replaces the defaults; it does not merge with them.
+- `paths` are globs matched against both the whole path and the base name,
+  exactly as `--exclude` is, so the two behave identically — including which
+  patterns do not work: there is no `**`.
+- `enabled` defaults to true when either memory number is written, since a block
+  stating what the container has is a block about a container.
+- Sizes are Kubernetes quantities: `512Mi`, `1Gi`, `2G`, or a bare byte count.
+  Anything else is an error rather than a silently different number.
+- A file that matches no override and has no defaults to fall back on simply
+  skips `memory-limiter-sizing`. That is per file: the rest of the run is
+  unaffected. `--verbose` prints what each file resolved to.
+- Config read from stdin is reported as `stdin`, which no glob is meant to
+  match, so it gets the defaults.
+
+`--kubernetes`, `--memory-request` and `--memory-limit` are the single-file
+convenience: they set the defaults and, like every flag, win over the file.
+There is deliberately no flag form of the overrides.
+
+## The flat form
+
+The keys the first release put at the top level — `collectorVersion`,
+`distribution`, `schemaLocations`, `strict`, `ignoreMissingSchemas`, `summary`,
+`minSeverity`, `failOn`, `disable`, `severity`, `exclude` and `kubernetes` — are
+still read, and folded into the blocks above. A run that finds one says which
+keys to move. `output: json` is not one of them: a bare format name is still the
+shorthand for `output: {format: json}`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,142 @@
+# Working on the linter
+
+## Layout
+
+```
+cmd/otelcol-config-lint/      the linter entry point
+cmd/schemagen/                the schema generator entry point
+pkg/cmd/otelcol-config-lint/  the cobra command: flags, settings files, reporting
+pkg/cmd/schemagen/            the generator: harvests upstream metadata into schemas
+pkg/scanner/                  expands the given paths into the files to lint
+pkg/sets/                     a set built on a map, in the shape of k8s.io/apimachinery
+pkg/config/                   YAML parsing that keeps positions, so findings have line numbers
+pkg/schema/                   schema types, version resolution and location lookup
+pkg/rule/                     what a rule is: the interface, the context and the shared readers
+pkg/rule/<rule-name>/         one rule and its tests, one package each
+pkg/rule/ruletest/            the fixtures a rule's tests are written against
+pkg/ruleset/                  the registry: every rule collected into one set
+pkg/lint/                     the engine and the output formatters
+pkg/diag/                     diagnostics, severities and positions
+pkg/quantity/                 Kubernetes memory quantities, parsed and printed back
+pkg/version/                  the linter's own version, stamped at build time
+docs/rules/                   one page per rule
+testdata/rules/               one invalid config per rule, with the run that shows it
+action.yml                    the GitHub Action; Dockerfile wraps the released image it runs
+build/docker/Dockerfile       the distroless linter image releases publish
+```
+
+## Development
+
+```sh
+make test            # go test -race with coverage
+make lint            # golangci-lint
+make build           # ./bin/otelcol-config-lint
+make build-snapshot  # every release target, the way CI builds them
+make schemas         # regenerate the schemas into ../otelcol-config-schemas
+```
+
+Nothing injects the version. The Go toolchain records the module version and the
+repository state in every binary it builds, and `pkg/version` reads that back,
+so a tagged build reports its tag because it was built from that tag:
+
+| built from | `otelcol-config-lint version` |
+| --- | --- |
+| a tag | `v1.2.3`, or `v1.2.3+dirty` from a modified tree |
+| `go install ...@v1.2.3` | `v1.2.3` |
+| a commit between tags | `b7dbdd5`, or `b7dbdd5-dirty` |
+| no repository, or `go run` | `devel` |
+
+### CI
+
+This repository's own CI runs the tests with coverage reported on the pull
+request, builds every release target, lints the example configs in `testdata/`,
+exercises the action against them, checks that
+`otelcol-config-lint.schema.json` has not fallen behind the rules the linter
+carries, and publishes binaries and container images from tags.
+
+The weekly job that generates schemas for each new collector release lives in
+the [schema registry](https://github.com/minuk-dev/otelcol-config-schemas), not
+here — see [Keeping the registry
+current](schemas.md#keeping-the-registry-current).
+
+### Releasing
+
+Bump then tag, because the action's image is pinned at the release it ships in
+and a tag cannot reference an image built from itself:
+
+```sh
+make release-pin RELEASE=v1.2.3
+git commit -am 'chore(release): pin the action at v1.2.3'
+git tag v1.2.3 && git push origin main v1.2.3
+```
+
+The release workflow refuses a tag whose pin names another release, and moves
+`v1` onto the release once it has published.
+
+## Adding a rule
+
+A rule is a package. `pkg/rule` defines what one is — the `Rule` interface, the
+`Context` a check reads, the `Finding` it reports — along with the YAML readers
+and phrasing helpers every rule shares. `pkg/ruleset` is the only place that
+knows about all of them, which is what keeps a rule free to import the
+vocabulary it is written in.
+
+So a new rule is one directory and one line:
+
+```go
+// pkg/rule/mynewrule/rule.go
+package mynewrule
+
+// New builds the rule.
+func New() rule.Rule {
+	return myNewRule{rule.NewBase("my-new-rule",
+		"one line saying what this reports", diag.Warning)}
+}
+
+type myNewRule struct{ rule.Base }
+
+func (r myNewRule) Check(ctx *rule.Context) {
+	for _, p := range ctx.File.Service.Pipelines {
+		ctx.Report(rule.Finding{
+			Node: p.KeyNode, Path: "service.pipelines." + p.Key,
+			Message: "pipeline " + rule.Quote(p.Key) + " is doing the thing",
+			Hint:    "stop doing the thing",
+		})
+	}
+}
+```
+
+Then add `mynewrule.New()` to the list in `pkg/ruleset/ruleset.go`, and write
+`pkg/rule/mynewrule/rule_test.go` against `pkg/rule/ruletest`, which carries the
+stand-in schema and the clean config every rule's tests start from:
+
+```go
+found, err := ruletest.Run(mynewrule.New(), src)
+```
+
+A test that is about two rules meeting — one reporting where the other stays
+quiet — belongs in `pkg/ruleset` instead, which is where the whole set is run at
+once.
+
+Then the rule needs a config in `testdata/rules`: `my-new-rule.yaml`, which
+breaks it, with a comment naming the rule on the line that breaks it, and
+`my-new-rule.settings.yaml`, which says which rules the run has on in the shape
+golangci-lint uses:
+
+```yaml
+rules:
+  enable: [my-new-rule]  # must report on my-new-rule.yaml
+  disable: []            # switched off for this run, and must stay quiet
+  settings: {}           # per-rule options, keyed by rule name
+```
+
+The tests refuse a rule with no fixture, so this is where a rule is shown
+working through the real command line, the published schemas and the severity
+gate rather than against the stand-in schema.
+[`testdata/rules/README.md`](../testdata/rules/README.md) has the rest of the
+schema, including how a fixture selects its own collector release or states the
+container it runs in.
+
+Last, add `docs/rules/my-new-rule.md` and a row in
+[`docs/rules/README.md`](rules/README.md), following the shape the other pages
+use: what it reports, a config that trips it, and what it stays quiet about.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,120 @@
+# Rules
+
+One page per rule: what it reports, a config that trips it, and why the rule
+exists. `otelcol-config-lint list rules` prints the same set with the severities
+a run resolves them to.
+
+Every rule can be switched off or re-levelled from the [settings
+file](../configuration.md#choosing-the-rules):
+
+```yaml
+rules:
+  disable: [missing-batch]
+  severity:
+    missing-memory-limiter: warning
+```
+
+## Structure
+
+The config the collector will refuse to load, or will load and silently ignore
+half of.
+
+| Rule | Default | Reports |
+| --- | --- | --- |
+| [`unknown-top-level-key`](unknown-top-level-key.md) | `error` | a root key other than the component sections and `service` |
+| [`service-required`](service-required.md) | `error` | no `service` block, or no pipelines in it |
+| [`unknown-service-key`](unknown-service-key.md) | `error` | a key inside `service` the collector does not read |
+| [`invalid-pipeline-key`](invalid-pipeline-key.md) | `error` | a pipeline named after no signal |
+| [`empty-pipeline`](empty-pipeline.md) | `error` | a pipeline with no receivers or no exporters |
+| [`unknown-pipeline-key`](unknown-pipeline-key.md) | `error` | a pipeline slot other than the three |
+| [`duplicate-key`](duplicate-key.md) | `error` | a mapping key written twice, discarding the first value |
+| [`wrong-node-type`](wrong-node-type.md) | `error` | a section or slot written in the wrong YAML shape |
+
+## Wiring
+
+Whether what the config declares and what it references add up.
+
+| Rule | Default | Reports |
+| --- | --- | --- |
+| [`undefined-reference`](undefined-reference.md) | `error` | the `service` block naming a component nothing declares |
+| [`undefined-extension-reference`](undefined-extension-reference.md) | `error` | an extension a component's own settings name, that nothing declares or starts |
+| [`unused-component`](unused-component.md) | `warning` | a declaration no pipeline reaches |
+| [`duplicate-reference`](duplicate-reference.md) | `warning` | the same component listed twice in one slot |
+| [`connector-wiring`](connector-wiring.md) | `error` | a connector wired to one side only, or closing a loop |
+
+## Release and distribution compatibility
+
+The half of the linter that needs to know which collector you run.
+
+| Rule | Default | Reports |
+| --- | --- | --- |
+| [`unknown-component`](unknown-component.md) | `error` | a component type the targeted release does not ship |
+| [`signal-support`](signal-support.md) | `error` | a component in a pipeline whose signal it does not carry |
+| [`component-stability`](component-stability.md) | `info` | a component below beta stability |
+| [`deprecated-component`](deprecated-component.md) | `warning` | a component upstream has deprecated or stopped maintaining |
+
+## Settings
+
+Read from each component's field schema. See [Field
+schemas](../schemas.md#field-schemas) for where those come from and what they
+cannot answer.
+
+| Rule | Default | Reports |
+| --- | --- | --- |
+| [`unknown-field`](unknown-field.md) | `warning` | a setting the component does not accept |
+| [`required-field`](required-field.md) | `error` | a setting the component cannot start without |
+| [`invalid-value`](invalid-value.md) | `error` | a value of the wrong type, or outside the allowed set |
+| [`deprecated-field`](deprecated-field.md) | `warning` | a setting upstream has replaced |
+
+## Practice
+
+Configs the collector loads and runs, and then behaves in a way nobody asked
+for. Every rule here cites the upstream page it rests on.
+
+| Rule | Default | Reports |
+| --- | --- | --- |
+| [`processor-order`](processor-order.md) | `warning` | a processor in the one place it does not work |
+| [`missing-memory-limiter`](missing-memory-limiter.md) | `info` | a pipeline with nothing bounding memory use |
+| [`missing-batch`](missing-batch.md) | `info` | a pipeline that batches nothing on its way out |
+| [`memory-limiter-config`](memory-limiter-config.md) | `error` | a `memory_limiter` the collector refuses to start |
+| [`memory-limiter-sizing`](memory-limiter-sizing.md) | `warning` | a `memory_limiter` that does not fit its container |
+| [`batch-size-bounds`](batch-size-bounds.md) | `error` | a `batch` processor the collector refuses to start |
+| [`no-persistent-queue`](no-persistent-queue.md) | `info` | a sending queue a restart empties |
+| [`debug-exporter-verbosity`](debug-exporter-verbosity.md) | `warning` | a `debug` exporter left in a production pipeline |
+
+## The collector's own telemetry
+
+`service.telemetry` is the one block about the run rather than about the data,
+and both rules report a silence rather than a failure.
+
+| Rule | Default | Reports |
+| --- | --- | --- |
+| [`deprecated-telemetry-key`](deprecated-telemetry-key.md) | `warning` | a `service.telemetry` key the collector stopped reading |
+| [`telemetry-metrics-disabled`](telemetry-metrics-disabled.md) | `info` | the collector's own metrics turned off |
+
+## Security
+
+| Rule | Default | Reports |
+| --- | --- | --- |
+| [`insecure-tls`](insecure-tls.md) | `warning` | TLS verification switched off |
+| [`receiver-binds-all-interfaces`](receiver-binds-all-interfaces.md) | `warning` | a listener on every interface the host has |
+| [`debug-extension-exposed`](debug-extension-exposed.md) | `warning` | `pprof` or `zpages` reachable from off the host |
+| [`hardcoded-secret`](hardcoded-secret.md) | `warning` | a credential written into the config |
+
+## What every rule has in common
+
+- **The config the collector will read.** YAML anchors, aliases and `<<` merge
+  keys are resolved when the file is parsed, the way confmap resolves them
+  before the collector sees a setting. A component whose settings come from a
+  shared base is checked against what it will run with, `<<` is never reported
+  as a setting, and a key written in place still wins over the one a merge
+  supplies. Findings keep the line they were written on, so a setting an anchor
+  supplies is reported at the anchor — the line to edit.
+- **Expansions are left alone.** `${env:...}` and `${file:...}` are resolved at
+  startup, not here, so a rule that cannot see the value stays quiet rather than
+  guessing. The exception is where the written half is already the finding:
+  `0.0.0.0:${env:PORT}` says plainly who can reach it.
+- **A `docs:` link where there is one to give.** Practice, telemetry and
+  security rules carry the upstream page that states the recommendation, so the
+  claim can be checked instead of taken on trust. It is in the JSON output as
+  `docs`, and in the GitHub annotations.

--- a/docs/rules/batch-size-bounds.md
+++ b/docs/rules/batch-size-bounds.md
@@ -1,0 +1,51 @@
+# batch-size-bounds
+
+**Default severity:** `error` · **Group:** [Practice](README.md#practice)
+
+A `batch` processor the collector will refuse to start. The processor's
+`Validate()` relates two fields that a field schema only ever sees one at a
+time, so [`invalid-value`](invalid-value.md) cannot catch this.
+
+## What it reports
+
+| Config | Why |
+| --- | --- |
+| `send_batch_max_size` below `send_batch_size` | a cap below the trigger is refused at startup |
+| a negative `timeout` | refused at startup |
+| a key repeated in `metadata_keys` | compared case-insensitively, so `tenant` and `Tenant` are one key |
+| a batch size outside `uint32` | fails to load rather than to validate |
+
+## Example
+
+```yaml
+processors:
+  batch:
+    send_batch_size: 10000
+    send_batch_max_size: 1000      # the cap is below the size a batch is sent at
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:14:26: error: processor "batch" sets send_batch_max_size to 1000 and send_batch_size to 10000: send_batch_max_size must be greater or equal to send_batch_size [batch-size-bounds]
+    hint: raise send_batch_max_size to 10000 or more, or leave it out so batches are not split at all
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
+```
+
+The names read backwards from the semantics: `send_batch_size` is the count that
+*triggers* a send, `send_batch_max_size` is a hard cap. So capping at something
+reasonable-looking like `1000` while leaving `send_batch_size` at its default of
+`8192` is exactly the shape that fails — and since nobody wrote the 8192, the
+finding says it is the default rather than quoting it back as if they had.
+
+Both sizes are `uint32` upstream, a range the published field schemas flatten to
+`int`, so a negative or over-large count is reported here too: it fails to load
+rather than to validate, and saying so beats hinting at a fix that still will
+not start.
+
+## Docs
+
+- [`batchprocessor`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md)
+
+## See also
+
+- [`../../testdata/rules/batch-size-bounds.yaml`](../../testdata/rules/batch-size-bounds.yaml)

--- a/docs/rules/component-stability.md
+++ b/docs/rules/component-stability.md
@@ -1,0 +1,50 @@
+# component-stability
+
+**Default severity:** `info` · **Group:** [Release compatibility](README.md#release-and-distribution-compatibility)
+
+Components below beta stability can change or break without notice. Upstream
+records a stability level per component per signal, and this rule reads it back.
+
+## What it reports
+
+One finding per component, for the first signal it is wired into that has a
+level worth mentioning:
+
+| Level | Severity | Message |
+| --- | --- | --- |
+| development | `warning` | `... is in development and may change without notice` |
+| alpha | `info` | `... is alpha; its configuration can change between releases` |
+| beta and above | — | nothing |
+
+Extensions have no signal, so they are reported without the `for traces` clause.
+The other end — deprecated and unmaintained — belongs to
+[`deprecated-component`](deprecated-component.md).
+
+## Example
+
+```yaml
+extensions:
+  remotetap:                       # in development
+    endpoint: localhost:12001
+service:
+  extensions: [remotetap]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:19:3: warning: extension "remotetap" is in development and may change without notice [component-stability]
+```
+
+## Notes
+
+- Only components a pipeline actually uses are reported. A declaration nothing
+  wires up is [`unused-component`](unused-component.md)'s.
+- Stability is per signal: a receiver can be stable for traces and alpha for
+  profiles, and what you get told is the level for the pipeline you put it in.
+- This is the rule most affected by upgrading `--collector-version`, since a
+  component crossing the beta line changes the findings an unchanged config
+  gets. `schemagen --summary` calls those out for exactly that reason.
+
+## See also
+
+- [`../../testdata/rules/component-stability.yaml`](../../testdata/rules/component-stability.yaml)

--- a/docs/rules/connector-wiring.md
+++ b/docs/rules/connector-wiring.md
@@ -1,0 +1,52 @@
+# connector-wiring
+
+**Default severity:** `error` · **Group:** [Wiring](README.md#wiring)
+
+A connector joins two pipelines: it is an exporter in the one that feeds it and
+a receiver in the one that consumes what it produces. Wired to one side only, it
+either gets no input or has its output dropped.
+
+## What it reports
+
+| Config | Finding |
+| --- | --- |
+| used as a receiver, never as an exporter | `... so it gets no input` |
+| used as an exporter, never as a receiver | `... so its output is dropped` |
+| both sides of the *same* pipeline | `... which forms a loop` |
+
+## Example
+
+```yaml
+connectors:
+  span_metrics:                    # nothing exports into it, so it produces nothing
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp_grpc]       # span_metrics is not here
+    metrics:
+      receivers: [span_metrics]
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:19:3: error: connector "span_metrics" is used as a receiver but never as an exporter, so it gets no input [connector-wiring]
+    hint: list it under exporters in the pipeline that should feed it
+```
+
+Nothing fails at startup. The metrics pipeline runs, and produces nothing, for
+as long as nobody looks.
+
+## Notes
+
+- A connector referenced from neither side is left to
+  [`unused-component`](unused-component.md).
+- Connectors are directional per signal, which
+  [`signal-support`](signal-support.md) checks: the exporter side consumes the
+  pipeline's signal, the receiver side produces it, and a connector can support
+  a signal on one side and not the other.
+
+## See also
+
+- [`../../testdata/rules/connector-wiring.yaml`](../../testdata/rules/connector-wiring.yaml)

--- a/docs/rules/debug-exporter-verbosity.md
+++ b/docs/rules/debug-exporter-verbosity.md
@@ -1,0 +1,62 @@
+# debug-exporter-verbosity
+
+**Default severity:** `warning` · **Group:** [Practice](README.md#practice)
+
+The exporter somebody added to find out why an export was failing, and never
+took out again. It writes what it is given to the collector's own log, and at
+`verbosity: detailed` that is every field of every span, data point and record
+in the pipeline — the collector spends its time formatting log lines, and the
+log backend receives a second copy of all the telemetry the collector was meant
+to be forwarding.
+
+## What it reports
+
+| Config | Severity |
+| --- | --- |
+| a `debug` exporter at `verbosity: detailed` | `warning` |
+| a `debug` exporter at any other verbosity | `info` |
+
+One finding per pipeline reference, not both. `basic` costs a line per batch
+rather than per record, which is cheap enough not to be a warning — but it is still a diagnostic tool left running, and upstream
+keeps no stable output format, so nothing downstream should be parsing it
+either.
+
+Both clauses match on the component type, so `debug/verbose` counts, and both
+report **per pipeline** that references the exporter: that is what the message
+names, and where the reader takes it out of.
+
+## Example
+
+```yaml
+exporters:
+  debug:
+    verbosity: detailed            # a line per record, not per batch
+service:
+  pipelines:
+    traces:
+      exporters: [otlp, debug]     # and it ships to production like this
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:22:19: warning: exporter "debug" runs at verbosity: detailed in pipeline "traces", logging every record it receives [debug-exporter-verbosity]
+    hint: set verbosity: basic, or remove the exporter from service.pipelines.traces.exporters; sampling_initial and sampling_thereafter bound the rate if it has to stay at detailed
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md
+```
+
+## Notes
+
+- An exporter no pipeline references prints nothing and is
+  [`unused-component`](unused-component.md)'s to report; the `logging` exporter
+  that came before it is [`deprecated-component`](deprecated-component.md)'s.
+- `warning` rather than `error` is deliberate: a deliberate debug run is
+  legitimate and should not fail a CI job. `--severity
+  debug-exporter-verbosity=error` is there for anyone who wants it fatal.
+
+## Docs
+
+- [`debugexporter`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md)
+
+## See also
+
+- [`../../testdata/rules/debug-exporter-verbosity.yaml`](../../testdata/rules/debug-exporter-verbosity.yaml)

--- a/docs/rules/debug-extension-exposed.md
+++ b/docs/rules/debug-extension-exposed.md
@@ -1,0 +1,73 @@
+# debug-extension-exposed
+
+**Default severity:** `warning` · **Group:** [Security](README.md#security)
+
+`pprof` serves heap profiles, goroutine dumps and the collector's command line;
+`zpages` serves live traces and pipeline internals. Upstream's [security
+guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md)
+is direct about avoiding "exposing health or telemetry data outside the
+Collector by default", and these are the extensions that do it.
+
+This is narrower than
+[`receiver-binds-all-interfaces`](receiver-binds-all-interfaces.md), and
+separate from it because the consequence differs in kind: a `0.0.0.0` OTLP
+receiver accepts data it should not, while a `0.0.0.0` pprof endpoint *hands
+out* process internals.
+
+## What it reports
+
+```yaml
+extensions:
+  pprof:
+    endpoint: 0.0.0.0:1777         # warning: heap profiles, on every interface
+  zpages:
+    endpoint: 10.0.4.7:55679       # info: deliberate, but that network can read it
+```
+
+| Address | Severity |
+| --- | --- |
+| unspecified — `0.0.0.0`, `[::]`, a bare `:1777` | `warning` |
+| a specific non-loopback address | `info` |
+
+The two are reported apart because they have different fixes. The second was
+chosen by someone, and the finding says only that the network it sits on can
+read the collector's internals. Both match on component type, so
+`zpages/internal` is covered.
+
+## Example
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:20:15: warning: extension "zpages" binds "0.0.0.0:55679", serving live traces and the collector's pipeline internals on every interface of the host [debug-extension-exposed]
+    hint: bind it to localhost, and reach it through a port-forward when you need it; upstream's advice is not to expose telemetry or debugging data outside the collector by default
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md
+```
+
+## What it stays quiet about
+
+- **`health_check` and `healthcheckv2`, deliberately.** A Kubernetes liveness
+  probe comes from the kubelet, off the container's loopback interface, so a
+  health check bound to `0.0.0.0` is what a correct deployment looks like — and
+  a rule that fires on every correct config is a rule people disable, which
+  would take `pprof` down with it.
+- An extension `service.extensions` does not list. That is the only thing that
+  starts one; a declaration left out of it binds no port, and
+  [`unused-component`](unused-component.md) has something to say about it.
+- An endpoint nobody wrote: it takes the extension's own default, which has been
+  `localhost` for both since upstream made `UseLocalHostAsDefaultHost` the
+  default in v0.110.
+- A hostname other than `localhost`, since what a name resolves to is a property
+  of the network rather than of the file, and an address supplied by
+  `${env:...}`. An expansion standing in for only the *port* is still reported —
+  `0.0.0.0:${env:PPROF_PORT}` says plainly who can reach it.
+
+An endpoint a `<<` merge supplies is read like one written in place, so sharing
+one debugging block between extensions does not hide it.
+
+## Docs
+
+- [Security best practices](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md)
+
+## See also
+
+- [`../../testdata/rules/debug-extension-exposed.yaml`](../../testdata/rules/debug-extension-exposed.yaml)

--- a/docs/rules/deprecated-component.md
+++ b/docs/rules/deprecated-component.md
@@ -1,0 +1,45 @@
+# deprecated-component
+
+**Default severity:** `warning` · **Group:** [Release compatibility](README.md#release-and-distribution-compatibility)
+
+A component upstream has marked deprecated or unmaintained. It still works, for
+now; the point of the finding is that the migration is cheaper before removal
+than after.
+
+## What it reports
+
+Two sources, in order:
+
+1. an explicit deprecation note in the schema, which is quoted as the hint —
+   this is where a rename lands;
+2. a `deprecated` or `unmaintained` stability level on any signal, with
+   `plan a migration; it may be removed in a future release`.
+
+## Example
+
+```yaml
+exporters:
+  otlp:                            # renamed to "otlp_grpc" upstream
+    endpoint: backend:4317
+```
+
+```console
+$ otelcol-config-lint run --collector-version v0.157.0 config.yaml
+config.yaml:14:3: warning: exporter "otlp" is deprecated [deprecated-component]
+    hint: renamed to "otlp_grpc" upstream; the old name still resolves for now
+```
+
+Upstream is moving component types to snake_case, so from v0.157.0 the OTLP gRPC
+exporter is `otlp_grpc` and `otlp` is a deprecated alias. Both resolve, so
+[`unknown-component`](unknown-component.md) stays quiet and this rule is what
+says the old name is on its way out.
+
+## Notes
+
+Only components a pipeline uses are reported; a declaration nothing wires up is
+[`unused-component`](unused-component.md)'s. The `logging` exporter — removed
+rather than deprecated — is [`unknown-component`](unknown-component.md)'s.
+
+## See also
+
+- [`../../testdata/rules/deprecated-component.yaml`](../../testdata/rules/deprecated-component.yaml)

--- a/docs/rules/deprecated-field.md
+++ b/docs/rules/deprecated-field.md
@@ -1,0 +1,40 @@
+# deprecated-field
+
+**Default severity:** `warning` · **Group:** [Settings](README.md#settings)
+
+A setting upstream has replaced. It is still read, and the replacement is
+usually where the new options live.
+
+## What it reports
+
+Every setting the [field schema](../schemas.md#field-schemas) marks deprecated,
+with upstream's own note about what replaces it as the hint.
+
+## Example
+
+```yaml
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    compression: gzip              # replaced by "compression_type"
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:19:5: warning: setting "compression" is deprecated [deprecated-field]
+    hint: use "compression_type", which also names the compression level
+```
+
+## Notes
+
+This is the settings-level counterpart of
+[`deprecated-component`](deprecated-component.md). What counts as deprecated is
+whatever the schema for the targeted release records, so pointing
+`--collector-version` at an older release quietly and correctly stops reporting
+a setting that was fine there.
+
+## See also
+
+- [`../../testdata/rules/deprecated-field.yaml`](../../testdata/rules/deprecated-field.yaml)
+  — checked against a small schema in `testdata/rules/schemas`, since no
+  released schema carries a deprecated setting yet.

--- a/docs/rules/deprecated-telemetry-key.md
+++ b/docs/rules/deprecated-telemetry-key.md
@@ -1,0 +1,41 @@
+# deprecated-telemetry-key
+
+**Default severity:** `warning` · **Group:** [The collector's own telemetry](README.md#the-collectors-own-telemetry)
+
+A `service.telemetry` key the collector no longer reads. The config is not
+refused — it is obeyed somewhere else, which is what makes it worth a finding.
+
+## What it reports
+
+`service.telemetry.metrics.address`, which is ignored from collector **v0.123.0**
+onward. A collector upgraded across that release starts, and serves its metrics
+wherever its `readers` say, while the scrape target the config names stays
+empty.
+
+The rule holds its tongue when `--collector-version` is older, because there the
+key still works, and when no schema resolved, because there is no release to
+judge against.
+
+## Example
+
+```yaml
+service:
+  telemetry:
+    metrics:
+      address: localhost:8888      # ignored from v0.123.0; a pull reader replaces it
+```
+
+```console
+$ otelcol-config-lint run --collector-version v0.157.0 config.yaml
+config.yaml:24:7: warning: setting "address" in service.telemetry.metrics is ignored from collector v0.123.0 onward [deprecated-telemetry-key]
+    hint: its host and port move into a pull reader: readers: [{pull: {exporter: {prometheus: {host: localhost, port: 8888}}}}]; as written, the collector serves its metrics where the readers say and not here
+    docs: https://opentelemetry.io/docs/collector/internal-telemetry/
+```
+
+## Docs
+
+- [Internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/)
+
+## See also
+
+- [`../../testdata/rules/deprecated-telemetry-key.yaml`](../../testdata/rules/deprecated-telemetry-key.yaml)

--- a/docs/rules/duplicate-key.md
+++ b/docs/rules/duplicate-key.md
@@ -1,0 +1,46 @@
+# duplicate-key
+
+**Default severity:** `error` · **Group:** [Structure](README.md#structure)
+
+The same mapping key written twice. YAML keeps the last value and discards the
+first, without complaining.
+
+## What it reports
+
+A repeated key anywhere in the document, at the position of the second
+declaration.
+
+## Example
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+  otlp:                          # the declaration above is silently discarded
+    protocols:
+      http:
+        endpoint: localhost:4318
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:7:3: error: duplicate key "otlp"; the earlier value is discarded [duplicate-key]
+```
+
+The collector starts, listens on 4318 only, and nothing in its log mentions the
+gRPC endpoint that was asked for.
+
+## Notes
+
+A `<<` merge key is not a duplicate. Merges are resolved when the file is
+parsed, the way the collector resolves them, and a key written in place is
+*meant* to win over the one its merge supplies — so a document overriding an
+anchor's setting reads as written and gets no finding.
+
+## See also
+
+- [`duplicate-reference`](duplicate-reference.md) for the same component listed
+  twice in one pipeline slot, which is a list rather than a mapping.
+- [`../../testdata/rules/duplicate-key.yaml`](../../testdata/rules/duplicate-key.yaml)

--- a/docs/rules/duplicate-reference.md
+++ b/docs/rules/duplicate-reference.md
@@ -1,0 +1,36 @@
+# duplicate-reference
+
+**Default severity:** `warning` · **Group:** [Wiring](README.md#wiring)
+
+The same component listed twice in one pipeline slot. The collector deduplicates
+it, so the second entry does nothing.
+
+## What it reports
+
+The second and any later occurrence of a component id within one slot of one
+pipeline. Listing the same component in two different pipelines is normal and
+never reported.
+
+## Example
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp, otlp]      # the second entry adds nothing
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:21:25: warning: "otlp" is listed twice in traces.receivers [duplicate-reference]
+```
+
+It is usually a merge gone wrong, or a processor somebody meant to name once
+with a different suffix — `batch` and `batch/large` are two components, `batch`
+and `batch` are one.
+
+## See also
+
+- [`../../testdata/rules/duplicate-reference.yaml`](../../testdata/rules/duplicate-reference.yaml)

--- a/docs/rules/empty-pipeline.md
+++ b/docs/rules/empty-pipeline.md
@@ -1,0 +1,34 @@
+# empty-pipeline
+
+**Default severity:** `error` · **Group:** [Structure](README.md#structure)
+
+Every pipeline needs at least one receiver and one exporter. Processors are
+optional; the two ends are not.
+
+## What it reports
+
+One finding per missing end, on the slot where it is missing — a pipeline with
+neither gets two.
+
+## Example
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+service:
+  pipelines:
+    traces:            # no exporters: what this receives goes nowhere
+      receivers: [otlp]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:9:5: error: pipeline "traces" has no exporters [empty-pipeline]
+```
+
+## See also
+
+- [`../../testdata/rules/empty-pipeline.yaml`](../../testdata/rules/empty-pipeline.yaml)

--- a/docs/rules/hardcoded-secret.md
+++ b/docs/rules/hardcoded-secret.md
@@ -1,0 +1,71 @@
+# hardcoded-secret
+
+**Default severity:** `warning` · **Group:** [Security](README.md#security)
+
+The one rule about the file rather than the collector. Configs live in git, and
+exporter credentials are written in the same file as everything else. CI is the
+last moment before the value reaches a remote.
+
+## What it reports
+
+The rule walks **every declared component** — wired or not, since a credential
+in the repository has already been handed over — and reports a scalar whose key
+names a credential and whose value is written out in full.
+
+The key names, matched as a case-insensitive substring so `sasl_password` is
+covered: `password`, `token`, `api_key`, `secret`, `credential`, `private_key`,
+`key_pem`, `access_key`, `passphrase`. A list is matched by the key that named
+it, so `api_keys: [AKIA…]` is reported too, and under `headers:` so are
+`authorization` and any value opening with `Bearer` or `Basic`.
+
+**It never prints the value**, only the path. Copying the secret into the CI log
+is the one thing this rule must not do.
+
+## Example
+
+```yaml
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    headers:
+      authorization: Bearer a3f1c99d4b7e2085f6c1
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:18:22: warning: "headers.authorization" is a credential written into the config for exporter "otlp_grpc" [hardcoded-secret]
+    hint: move it to a secret store and reference it here as an expansion such as ${env:OTLP_TOKEN}, which the collector resolves at startup
+    docs: https://opentelemetry.io/docs/security/config-best-practices/
+```
+
+The fix upstream recommends — keep sensitive values in a secret store or on an
+encrypted filesystem, and pull them in with an expansion:
+
+```yaml
+      authorization: Bearer ${env:OTLP_TOKEN}    # not the literal token
+```
+
+## What it stays quiet about
+
+False positives are the risk this rule carries, so it gives up findings freely:
+
+- `${env:...}` and `${file:...}` — those are the fix, and say so;
+- empty values and placeholders (`changeme`, `<your-token>`, `REPLACE_ME`,
+  `none`), which are a config with no credential in it yet, behind an auth
+  scheme as much as on their own;
+- a boolean, which is a switch rather than a credential whatever the setting is
+  called;
+- a key naming *where* a credential lives rather than holding one —
+  `private_key_file`, `token_url`, `cert_pem`. Keys ending in `_file`, `_path`,
+  `_url`, `_uri` and `_name` are excluded before anything else.
+
+It reports at `warning`, because a local config with a dummy credential is
+legitimate and this rule will meet plenty of them.
+
+## Docs
+
+- [Config best practices](https://opentelemetry.io/docs/security/config-best-practices/)
+
+## See also
+
+- [`../../testdata/rules/hardcoded-secret.yaml`](../../testdata/rules/hardcoded-secret.yaml)

--- a/docs/rules/insecure-tls.md
+++ b/docs/rules/insecure-tls.md
@@ -1,0 +1,43 @@
+# insecure-tls
+
+**Default severity:** `warning` · **Group:** [Security](README.md#security)
+
+TLS verification switched off on a component that talks over the network. The
+connection is neither encrypted nor authenticated, and anyone on the path can
+read it or stand in for the other end.
+
+## What it reports
+
+`insecure: true` or `insecure_skip_verify: true`, at **any depth** inside a
+declared component — exporters bury these under sub-blocks such as auth or queue
+settings, so the walk goes all the way down. Only a literal boolean `true`
+counts.
+
+## Example
+
+```yaml
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    tls:
+      insecure: true               # neither encrypted nor verified
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:17:17: warning: "tls.insecure" disables TLS verification for exporter "otlp_grpc" [insecure-tls]
+    hint: supply ca_file/cert_file instead of skipping verification outside local testing
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md
+```
+
+`warning` rather than `error`: a local test collector talking to a local backend
+over plaintext is a normal thing to write. `--severity insecure-tls=error` makes
+it fatal where it should be.
+
+## Docs
+
+- [`configtls`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
+
+## See also
+
+- [`../../testdata/rules/insecure-tls.yaml`](../../testdata/rules/insecure-tls.yaml)

--- a/docs/rules/invalid-pipeline-key.md
+++ b/docs/rules/invalid-pipeline-key.md
@@ -1,0 +1,37 @@
+# invalid-pipeline-key
+
+**Default severity:** `error` · **Group:** [Structure](README.md#structure)
+
+A pipeline key is `<signal>` or `<signal>/<name>`, where the signal is one the
+collector carries: `traces`, `metrics`, `logs` or `profiles`.
+
+## What it reports
+
+A pipeline whose key names no known signal — `tracez`, `trace`, `metric/1`. The
+name after the slash is free-form and never reported.
+
+## Example
+
+```yaml
+service:
+  pipelines:
+    tracez:            # not a signal
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:20:5: error: pipeline "tracez" does not name a known signal [invalid-pipeline-key]
+    hint: pipeline keys look like traces, metrics/internal or logs/2; did you mean "traces"?
+```
+
+## Notes
+
+[`signal-support`](signal-support.md) stands down for a pipeline this rule
+reports: without a signal there is nothing to check a component against.
+
+## See also
+
+- [`../../testdata/rules/invalid-pipeline-key.yaml`](../../testdata/rules/invalid-pipeline-key.yaml)

--- a/docs/rules/invalid-value.md
+++ b/docs/rules/invalid-value.md
@@ -1,0 +1,41 @@
+# invalid-value
+
+**Default severity:** `error` · **Group:** [Settings](README.md#settings)
+
+A setting whose value has the wrong type, or is outside the set the component
+accepts.
+
+## What it reports
+
+Every value the [field schema](../schemas.md#field-schemas) types that the
+config writes as something else — a duration without a unit, a string where a
+list belongs, an enum value that is not one of the enum's — saying what it must
+be instead.
+
+## Example
+
+```yaml
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    timeout: 5                     # a duration needs a unit, so this is not 5 seconds
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:16:14: error: "timeout" must be a duration such as 5s, 200ms or 1m30s [invalid-value]
+```
+
+The bare `5` is the one worth having the rule for. It parses, and it is not five
+seconds.
+
+## Notes
+
+Enums come from the `config.schema.yaml` upstream publishes, which the Go source
+alone cannot supply — see [Field schemas](../schemas.md#field-schemas).
+Expansions are left alone: `${env:TIMEOUT}` is resolved at startup, and the
+linter has no value to judge.
+
+## See also
+
+- [`../../testdata/rules/invalid-value.yaml`](../../testdata/rules/invalid-value.yaml)

--- a/docs/rules/memory-limiter-config.md
+++ b/docs/rules/memory-limiter-config.md
@@ -1,0 +1,61 @@
+# memory-limiter-config
+
+**Default severity:** `error` · **Group:** [Practice](README.md#practice)
+
+A `memory_limiter` the collector will refuse to start. Two of its constraints
+cannot be written as a field schema, so [`invalid-value`](invalid-value.md)
+cannot see them:
+
+- `check_interval` must be greater than zero, and yet defaults to `0s` — so
+  leaving it out is an error rather than a choice;
+- `limit_mib` and `limit_percentage` are a one-of, and writing neither is
+  refused.
+
+This rule checks what upstream's own `Validate()` checks, quoting its wording,
+and matches on the component type so `memory_limiter/aggressive` is covered too.
+
+## What it reports
+
+Every clause quotes upstream's own wording, so the message says what the
+collector will say.
+
+| Config | Severity |
+| --- | --- |
+| no `check_interval`, or one at or below `0s` | `error` |
+| neither `limit_mib` nor `limit_percentage` | `error` |
+| `spike_limit_mib` at or above `limit_mib` (and the same for the percentage pair) | `error` |
+| a percentage above 100, which is not a share of anything | `error` |
+| a `check_interval` far from the recommended `1s` | `info` |
+
+A value only the collector can resolve — an expansion — is left alone rather
+than guessed at.
+
+## Example
+
+```yaml
+processors:
+  memory_limiter:
+    check_interval: 0s             # the interval must be greater than zero
+    limit_mib: 512
+    spike_limit_mib: 128
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:9:21: error: processor "memory_limiter" sets check_interval to 0s: 'check_interval' must be greater than zero [memory-limiter-config]
+    hint: set check_interval: 1s, the value upstream recommends
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
+```
+
+## Docs
+
+- [`memorylimiterprocessor`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md)
+  — states `check_interval`'s `0s` default and its recommended value,
+  `spike_limit_mib`'s 20% default, and the ~50MiB the process runs above
+  `limit_mib`.
+
+## See also
+
+- [`memory-limiter-sizing`](memory-limiter-sizing.md) — the half that needs to
+  know the container.
+- [`../../testdata/rules/memory-limiter-config.yaml`](../../testdata/rules/memory-limiter-config.yaml)

--- a/docs/rules/memory-limiter-sizing.md
+++ b/docs/rules/memory-limiter-sizing.md
@@ -1,0 +1,67 @@
+# memory-limiter-sizing
+
+**Default severity:** `warning` · **Group:** [Practice](README.md#practice)
+
+A `memory_limiter` whose limits do not fit the container it runs in. A limiter
+that passes every other check is still decoration if `limit_mib` sits at or
+above the container's memory limit: the kernel kills the collector before the
+limiter ever engages.
+
+This needs a number the config cannot carry, so it runs **only for files the
+[`kubernetes` block](../configuration.md#the-deployment-environment)
+describes**. A run that configures nothing sees nothing new.
+
+## What it reports
+
+The hard limit is `limit_mib`, or `limit_percentage` resolved against the
+container's memory limit. Only the most serious clause applies, so a limit that
+is over the container's is not also reported as being over 80% of it.
+
+| Config | Severity |
+| --- | --- |
+| the hard limit is at or above the container memory limit | `error` |
+| less than ~50MiB is left over it — the process runs about that far above what the limiter counts | `warning` |
+| the hard limit is above 80% of the container memory limit | `warning` |
+| `limit_percentage` with no container memory limit to be a percentage of | `warning` |
+| the limiter may use more than the container's memory *request* | `info` |
+
+## Example
+
+```yaml
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512                 # 512Mi enforced in a 256Mi container
+    spike_limit_mib: 128
+```
+
+```console
+$ otelcol-config-lint run --memory-request 256Mi --memory-limit 256Mi config.yaml
+config.yaml:13:16: error: processor "memory_limiter" enforces 512Mi, at or above the container memory limit of 256Mi; the kernel kills the collector before the limiter engages [memory-limiter-sizing]
+    hint: keep the hard limit near 80% of the container memory limit, and set GOMEMLIMIT to about 80% of the hard limit so the collector collects garbage before the limiter has to refuse data
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
+config.yaml:13:16: info: processor "memory_limiter" may use 512Mi, above the container memory request of 256Mi [memory-limiter-sizing]
+    hint: the pod is Burstable and is evicted first under node pressure; collectors usually set the memory request equal to the limit
+    docs: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+```
+
+## Telling the linter about the container
+
+A run is not one deployment — an agent DaemonSet at `256Mi` and a gateway
+Deployment at `4Gi` sit in the same directory — so the container is resolved
+**per file**. See [The deployment
+environment](../configuration.md#the-deployment-environment) for the `overrides`
+list; `--kubernetes`, `--memory-request` and `--memory-limit` are the
+single-file convenience.
+
+A file that matches no override and has no defaults to fall back on simply skips
+this rule. That is per file: the rest of the run is unaffected.
+
+## Docs
+
+- [`memorylimiterprocessor`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md)
+- [Kubernetes: managing container resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+
+## See also
+
+- [`../../testdata/rules/memory-limiter-sizing.yaml`](../../testdata/rules/memory-limiter-sizing.yaml)

--- a/docs/rules/missing-batch.md
+++ b/docs/rules/missing-batch.md
@@ -1,0 +1,96 @@
+# missing-batch
+
+**Default severity:** `info` · **Group:** [Practice](README.md#practice)
+
+A pipeline that batches nothing on its way out. Every record becomes its own
+export request, which costs throughput at the collector and request volume at
+the backend.
+
+## Two ways to batch
+
+There are now two, and either satisfies the rule:
+
+```yaml
+exporters:
+  otlphttp:
+    endpoint: http://backend:4318
+    sending_queue:
+      batch:                       # off by default; writing the block turns it on
+        flush_timeout: 200ms
+```
+
+`exporterhelper` batches inside the sending queue, behind the queue and the
+retry logic rather than in front of them. The `batch` processor
+[drops the data in a batch that fails to send](https://github.com/open-telemetry/opentelemetry-collector/issues/12443);
+the queue batcher does not. That is why the hint leads with the exporter setting
+and names the processor as what also works. The processor is not deprecated —
+upstream has explicitly not decided that — so a pipeline using it is a pipeline
+that batches, and nothing here says to take it out.
+
+## What it reports
+
+- **The whole pipeline**, when it has no `batch` processor and none of its
+  exporters batches in `sending_queue`.
+- **One exporter**, when only some of them do. The pipeline is under-batched on
+  the legs that do not, so the finding names the exporter and sits on the line
+  that wires it in — that exporter's settings are where the fix is written.
+
+A connector in the exporter slot is not a leg out of the collector and is not
+counted; it feeds another pipeline, which has exporters of its own.
+
+## Example
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter]   # nothing batches, so a record is an export
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:21:19: info: pipeline "traces" has no batch processor, and none of its exporters batches in sending_queue [missing-batch]
+    hint: configure sending_queue.batch on the exporters, which batches behind the retry queue; the batch processor also works but drops data that fails to send
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md
+```
+
+## Which fix the hint names
+
+What the document writes decides whether there is a finding; what the field
+schema describes decides only which fix the hint may name.
+
+The queue batcher is off until something turns it on, so a config that writes no
+`sending_queue.batch` is not batching there whatever the schema knows about the
+type — which is why an exporter the schema describes no settings for, `nop` and
+`datadog` among them, is reported like any other rather than passed over.
+
+The hint is the half that follows the schema. The batcher is younger than the
+queue: on a release from before it moved in, every exporter has a `sending_queue`
+and none of them has a `batch` under it, and a hint naming one there would be
+advising a setting the collector rejects on startup —
+[`unknown-field`](unknown-field.md), reading the same schema, would say so in
+the same run. So where the field is not there to write, the hint names the
+processor instead:
+
+- an exporter with no `sending_queue` on the targeted release (`debug` on
+  v0.157 among them);
+- any exporter on a release that predates the batcher;
+- anything the schema does not describe.
+
+Where one finding covers several exporters it names the queue batcher only if
+all of them accept it; where they disagree it names the processor and says only
+some can take a `sending_queue.batch`.
+
+An exporter whose queue is built from an expansion counts as unknown rather than
+as not batching. A merge key is not one of those: it is resolved when the file
+is parsed, so what an anchor supplies is read like anything written in place.
+
+## Docs
+
+- [`exporterhelper`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
+
+## See also
+
+- [`../../testdata/rules/missing-batch.yaml`](../../testdata/rules/missing-batch.yaml)

--- a/docs/rules/missing-memory-limiter.md
+++ b/docs/rules/missing-memory-limiter.md
@@ -1,0 +1,47 @@
+# missing-memory-limiter
+
+**Default severity:** `info` · **Group:** [Practice](README.md#practice)
+
+A pipeline with no `memory_limiter` has nothing bounding what the collector
+holds. Under load the OOM killer is the limit, and it takes the whole process
+with everything queued in it.
+
+## What it reports
+
+One finding per pipeline that lists no `memory_limiter` processor, on the
+`processors` slot — or on the pipeline key where there is no slot to point at. A
+pipeline with no receivers is skipped, since it takes in nothing to hold.
+
+## Example
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]          # under load, the OOM killer is the limit
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:18:19: info: pipeline "traces" has no memory_limiter processor [missing-memory-limiter]
+    hint: add memory_limiter as the first processor to bound the collector's memory use
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
+```
+
+`memory_limiter` is the one processor this linter tells people to add, which is
+why three further rules are about getting it right once it is there:
+[`processor-order`](processor-order.md) puts it first,
+[`memory-limiter-config`](memory-limiter-config.md) checks what upstream's own
+`Validate()` checks, and
+[`memory-limiter-sizing`](memory-limiter-sizing.md) checks it against the
+container.
+
+## Docs
+
+- [`memorylimiterprocessor`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md)
+
+## See also
+
+- [`../../testdata/rules/missing-memory-limiter.yaml`](../../testdata/rules/missing-memory-limiter.yaml)

--- a/docs/rules/no-persistent-queue.md
+++ b/docs/rules/no-persistent-queue.md
@@ -1,0 +1,76 @@
+# no-persistent-queue
+
+**Default severity:** `info` · **Group:** [Practice](README.md#practice)
+
+A sending queue held in memory, which a restart drops along with everything in
+it. The queue is on by default, so a deploy, an OOM kill or a node drain takes
+whatever is still in it — and nothing in the config says so, because an exporter
+with a `storage` extension and one without look identical until the restart.
+
+## What it reports
+
+One finding **per exporter**, not per config: the fix is written per exporter,
+each queue names its own storage, and a finding without a position cannot say
+which of eight exporters to edit.
+
+It stays quiet on:
+
+- `sending_queue.enabled: false`;
+- an exporter no pipeline references — [`unused-component`](unused-component.md)
+  has that one;
+- exporters whose field schema describes their settings and has no queue among
+  them, which is what keeps `debug` out of it.
+
+Where the schema resolved nothing for a component — the `datadog` exporter and
+`nop` share that — a queue the config writes is the only evidence there is, and
+it is taken at face value.
+
+## Example
+
+```yaml
+exporters:
+  otlp_grpc:                       # the default sending_queue is in memory
+    endpoint: backend:4317
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:15:3: info: exporter "otlp_grpc" takes the default sending_queue, which is held in memory; a restart drops whatever is still queued [no-persistent-queue]
+    hint: persistence takes three steps: declare a storage extension such as file_storage, list it in service.extensions so the collector starts it, and name it here as sending_queue.storage
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md
+```
+
+The fix:
+
+```yaml
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage        # without this, a restart drops the queue
+```
+
+Persistence takes three steps — a storage extension declared, listed in
+`service.extensions`, and named here — which is why the hint names all three and
+why [`undefined-extension-reference`](undefined-extension-reference.md) is worth
+having alongside it.
+
+## Turning it off
+
+This is the one opinionated rule, and it reports at `info` for that reason. It
+is also the rule most likely to be unwanted: a sidecar next to an application
+that can re-send, or an agent whose source keeps its own buffer, is right not to
+want a writable volume.
+
+`info` is already below `--min-severity warning`, which is a normal way to run,
+and `disable: [no-persistent-queue]` in the settings file turns it off for good.
+There is deliberately no default-disabled rule concept for it — a second
+mechanism meaning roughly the same thing would only be another place to look.
+
+## Docs
+
+- [`exporterhelper`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
+
+## See also
+
+- [`../../testdata/rules/no-persistent-queue.yaml`](../../testdata/rules/no-persistent-queue.yaml)

--- a/docs/rules/processor-order.md
+++ b/docs/rules/processor-order.md
@@ -1,0 +1,75 @@
+# processor-order
+
+**Default severity:** `warning` · **Group:** [Practice](README.md#practice)
+
+Processors run in the order they are listed, and some of them have exactly one
+place they work. This rule is about where a processor stands rather than what it
+is set to: the config loads, the collector runs, and what comes out the far end
+is not what the author asked for.
+
+## What it reports
+
+Three clauses — the two ends of the chain, and the middle.
+
+| Clause | Severity | Why |
+| --- | --- | --- |
+| `memory_limiter` is not first | `warning` | backpressure has to be applied before any work is done |
+| `batch` is not last | `info` | processors behind it see whole batches rather than individual items |
+| enrichment runs after sampling | `warning` | the sampler decides before the attributes its policies match are there |
+
+All three match on component *type*, so `memory_limiter/aggressive` and
+`tail_sampling/errors` are covered.
+
+## The middle clause
+
+This is the one that is not obvious from reading the file:
+
+```yaml
+processors: [memory_limiter, tail_sampling, k8sattributes, batch]
+#                            ^^^^^^^^^^^^^ decides before the pod and namespace are on the span
+```
+
+`k8sattributes`, `resourcedetection` and `resource` add the attributes a
+sampling policy is written against — as do `k8s_attributes` and
+`resource_detection`, the names upstream renamed the first two to, which both
+count. A policy matching one of them from behind `tail_sampling` or
+`probabilistic_sampler` matches nothing at all: no error, no crash, just the
+spans it was meant to keep going missing.
+
+`tail_sampling`'s own README states the other half of it — the processor
+reassembles spans into new batches, so anything reading the request context has
+to have run already.
+
+`attributes` is deliberately left out of the enrichment group. It redacts as
+often as it enriches, and stripping fields from what a sampler kept is the right
+order to do that in, so including it would report a correct config as often as a
+wrong one.
+
+## Example
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch, memory_limiter]     # the limiter runs after the batch it protects
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:23:27: warning: memory_limiter is processor 2 in pipeline "traces"; it must be first [processor-order]
+    hint: move "memory_limiter" to the front of service.pipelines.traces.processors
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
+```
+
+## Docs
+
+- [`memorylimiterprocessor`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md)
+- [`batchprocessor`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md)
+- [`tailsamplingprocessor`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/tailsamplingprocessor/README.md)
+- [`probabilisticsamplerprocessor`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/probabilisticsamplerprocessor/README.md)
+
+## See also
+
+- [`../../testdata/rules/processor-order.yaml`](../../testdata/rules/processor-order.yaml)

--- a/docs/rules/receiver-binds-all-interfaces.md
+++ b/docs/rules/receiver-binds-all-interfaces.md
@@ -1,0 +1,74 @@
+# receiver-binds-all-interfaces
+
+**Default severity:** `warning` · **Group:** [Security](README.md#security)
+
+A component listening on every network interface the host has. This is the one
+upstream's [config best
+practices](https://opentelemetry.io/docs/security/config-best-practices/) lead
+with, and the most common way a collector ends up reachable from more of the
+network than anyone meant.
+
+## What it reports
+
+An endpoint something *listens* on, bound to an unspecified address. Every
+spelling is matched: `0.0.0.0`, `[::]`, a bare `:4317`, and `:::4317` — which is
+what netstat prints for an IPv6 listener and which Go refuses outright, so a
+collector handed one does not start at all.
+
+The split is by kind: **receivers and extensions bind**, while an exporter's or
+a connector's `endpoint` names somewhere to send *to*. `0.0.0.0` there is also
+wrong, but it is a different mistake with a different fix, and a bind-address
+hint on a line about a backend would be worse than silence.
+
+Two key names are read, not one: the stanza-based log receivers call it
+`listen_address` — `tcplog`, `udplog`, and `syslog` under each of its `tcp` and
+`udp` blocks — and reading only `endpoint` would leave every one of them
+unreported. Within a component the walk is by key name rather than by a table of
+where each type keeps its address, since `otlp` writes one per protocol and most
+others write one at the top; each is reported separately, because each is its
+own line to edit.
+
+## Example
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317     # every interface, not just the one you meant
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:6:19: warning: "protocols.grpc.endpoint" binds "0.0.0.0:4317", every interface the host has, for receiver "otlp" [receiver-binds-all-interfaces]
+    hint: bind the interface you meant, e.g. 127.0.0.1:4317 when every client is local; in Kubernetes write ${env:MY_POD_IP}:4317, the pod IP the downward API supplies
+    docs: https://opentelemetry.io/docs/security/config-best-practices/
+```
+
+The collector changed its own default to `localhost` in v0.110.0 for exactly
+this reason. The example configs the ecosystem copies from did not — the ones on
+opentelemetry.io say outright that they use the unspecified address "as a
+convenience" — and those get pasted into production.
+
+## What it stays quiet about
+
+- A receiver no pipeline names, and an extension `service.extensions` leaves
+  out: neither is ever instantiated, so neither binds anything.
+- An endpoint nobody wrote, which takes the component's own default.
+- `${env:MY_POD_IP}:4317` — that is the fix. But `0.0.0.0:${env:PORT}` is still
+  reported: the address says plainly who can reach it, and only the port is left
+  open.
+- `health_check` and `healthcheckv2`, for the reason
+  [`debug-extension-exposed`](debug-extension-exposed.md) leaves them out.
+  `pprof` and `zpages` are that rule's to report.
+
+`warning`, not `error`: a gateway behind a service mesh with its own network
+policy binds every interface deliberately.
+
+## Docs
+
+- [Config best practices](https://opentelemetry.io/docs/security/config-best-practices/)
+
+## See also
+
+- [`../../testdata/rules/receiver-binds-all-interfaces.yaml`](../../testdata/rules/receiver-binds-all-interfaces.yaml)

--- a/docs/rules/required-field.md
+++ b/docs/rules/required-field.md
@@ -1,0 +1,33 @@
+# required-field
+
+**Default severity:** `error` · **Group:** [Settings](README.md#settings)
+
+A setting the component cannot start without.
+
+## What it reports
+
+Every setting the [field schema](../schemas.md#field-schemas) marks required
+that the config does not write, reported on the component it belongs to.
+
+## Example
+
+```yaml
+receivers:
+  otlp:                            # needs "protocols"; with none it enables nothing
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:3:8: error: missing required setting "protocols" for receivers.otlp [required-field]
+```
+
+## Notes
+
+Required-ness is what the schema records, so a component the schema does not
+describe contributes nothing here — the same coverage rule as
+[`unknown-field`](unknown-field.md), and for the same reason: silence beats a
+false positive.
+
+## See also
+
+- [`../../testdata/rules/required-field.yaml`](../../testdata/rules/required-field.yaml)

--- a/docs/rules/service-required.md
+++ b/docs/rules/service-required.md
@@ -1,0 +1,49 @@
+# service-required
+
+**Default severity:** `error` · **Group:** [Structure](README.md#structure)
+
+A config must declare a `service` block with at least one pipeline. Components
+are declared, not started: nothing the `service` block does not wire up is ever
+instantiated.
+
+## What it reports
+
+Three positions, one at a time:
+
+| Config | Finding |
+| --- | --- |
+| no `service` block | `config has no service block, so nothing will run` |
+| `service` with no `pipelines` | `service has no pipelines, so no telemetry will be processed` |
+| `pipelines` written and empty | `service.pipelines is empty, so no telemetry will be processed` |
+
+## Example
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+# no service block, so the collector starts nothing at all
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:1:1: error: config has no service block, so nothing will run [service-required]
+    hint: add a service.pipelines section wiring the declared components together
+```
+
+## Notes
+
+It is the rule that keeps the others quiet. Without a `service` block every
+declared component is unused and every extension unstarted, so
+[`unused-component`](unused-component.md) and
+[`undefined-extension-reference`](undefined-extension-reference.md) stand down
+and let this one finding speak for the file.
+
+## See also
+
+- [`../../testdata/rules/service-required.yaml`](../../testdata/rules/service-required.yaml)

--- a/docs/rules/signal-support.md
+++ b/docs/rules/signal-support.md
@@ -1,0 +1,45 @@
+# signal-support
+
+**Default severity:** `error` · **Group:** [Release compatibility](README.md#release-and-distribution-compatibility)
+
+A component wired into a pipeline whose signal it does not carry — a
+traces-only receiver in a metrics pipeline. The collector refuses to start.
+
+## What it reports
+
+Every reference in every pipeline whose component does not support that
+pipeline's signal, with the signals it does support as the hint. Connectors are
+read directionally: the exporter side has to consume the pipeline's signal, the
+receiver side has to produce it.
+
+## Example
+
+```yaml
+receivers:
+  jaeger:
+service:
+  pipelines:
+    metrics:
+      receivers: [jaeger]          # the jaeger receiver carries traces only
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:18:19: error: receiver "jaeger" does not support metrics in pipeline "metrics" [signal-support]
+    hint: it supports: traces
+```
+
+## Notes
+
+Which signals a component supports comes from the release
+[schema](../schemas.md), so this rule stands down when none resolved. It also
+stands down where another rule has the better finding: a pipeline
+[`invalid-pipeline-key`](invalid-pipeline-key.md) reports has no signal to check
+against, an [`undefined-reference`](undefined-reference.md) has no declaration,
+and an [`unknown-component`](unknown-component.md) has no schema entry.
+
+## See also
+
+- [`../../testdata/rules/signal-support.yaml`](../../testdata/rules/signal-support.yaml)

--- a/docs/rules/telemetry-metrics-disabled.md
+++ b/docs/rules/telemetry-metrics-disabled.md
@@ -1,0 +1,42 @@
+# telemetry-metrics-disabled
+
+**Default severity:** `info` · **Group:** [The collector's own telemetry](README.md#the-collectors-own-telemetry)
+
+`service.telemetry.metrics.level: none` is a legitimate setting with an
+unadvertised cost: the metrics it turns off are the ones that say the collector
+is dropping data.
+
+## What it reports
+
+A `level` of `none`, compared case-insensitively the way configtelemetry's own
+decoder folds it, so `None` is the same level. A value only the collector can
+resolve — an expansion, or one a merge key supplies — is read as not disabled:
+a finding quoting a level nobody wrote would be a guess.
+
+## Example
+
+```yaml
+service:
+  telemetry:
+    metrics:
+      level: none                  # nothing is reported about the collector itself
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:23:14: info: service.telemetry.metrics.level is "none", so the collector reports no metrics about itself [telemetry-metrics-disabled]
+    hint: there are reasons to run without them, but they are the metrics that say the collector is dropping data -- otelcol_exporter_send_failed_* and the queue sizes among them; "basic" is the level that keeps those
+    docs: https://opentelemetry.io/docs/collector/internal-telemetry/
+```
+
+The cost is that `otelcol_exporter_send_failed_*` and the queue sizes are not
+emitted either, so a pipeline in trouble looks exactly like a healthy one.
+`basic` is the level that keeps those.
+
+## Docs
+
+- [Internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/)
+
+## See also
+
+- [`../../testdata/rules/telemetry-metrics-disabled.yaml`](../../testdata/rules/telemetry-metrics-disabled.yaml)

--- a/docs/rules/undefined-extension-reference.md
+++ b/docs/rules/undefined-extension-reference.md
@@ -1,0 +1,58 @@
+# undefined-extension-reference
+
+**Default severity:** `error` · **Group:** [Wiring](README.md#wiring)
+
+An extension that a component's *own settings* name — an exporter's
+`sending_queue.storage`, an `auth.authenticator` — that nothing declares, or
+that is declared and then left out of `service.extensions`.
+
+[`undefined-reference`](undefined-reference.md) never sees these: that rule
+walks the `service` block, and these sit several levels down inside a component.
+Getting one wrong is a startup failure, and the collector's own error does not
+say which of the three places is missing the name.
+
+## What it reports
+
+Two cases, with different fixes:
+
+| Config | Finding |
+| --- | --- |
+| nothing declares the extension | `... which is not declared under extensions` |
+| declared, but not in `service.extensions` | `... which is declared but missing from service.extensions, so the collector never starts it` |
+
+## Example
+
+```yaml
+exporters:
+  otlp:
+    endpoint: backend:4317
+    sending_queue:
+      storage: file_storage        # nothing declares "file_storage"
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:17:16: error: exporter "otlp" references storage extension "file_storage" which is not declared under extensions [undefined-extension-reference]
+    hint: no extensions are declared in this config
+    docs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md
+```
+
+## Which settings hold an extension
+
+The [field schema](../schemas.md#field-schemas) says so. A setting that decodes
+into a `component.ID` is marked when the schema is generated, since nothing in
+the value itself says so — a storage id and a directory path are both strings.
+So a setting upstream adds is checked as soon as its schema lands, rather than
+waiting for a list in the linter to be updated.
+
+The role the marker carries — `storage`, `auth`, or a plain `extension` for a
+key the generator has no name for — is only what the diagnostic calls it.
+Schemas generated before the marker existed keep working: the rule knows
+`sending_queue.storage` and `auth.authenticator` on its own, and that fallback
+falls away as the registry is regenerated.
+
+## See also
+
+- [`no-persistent-queue`](no-persistent-queue.md), which asks for the storage
+  extension this rule then checks.
+- [`../../testdata/rules/undefined-extension-reference.yaml`](../../testdata/rules/undefined-extension-reference.yaml)

--- a/docs/rules/undefined-reference.md
+++ b/docs/rules/undefined-reference.md
@@ -1,0 +1,50 @@
+# undefined-reference
+
+**Default severity:** `error` · **Group:** [Wiring](README.md#wiring)
+
+The `service` block may only reference components the config declares. A name it
+cannot resolve is a startup failure.
+
+## What it reports
+
+Every name in `service.extensions` and in the three slots of every pipeline that
+has no declaration under the matching section. The hint lists what *is* declared
+there, and says so when the name is declared under a different section — a
+receiver listed among the exporters resolves to nothing, and the fix is moving
+the reference rather than adding a component.
+
+## Example
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+service:
+  pipelines:
+    traces:
+      receivers: [otlp, jaeger]        # nothing declares "jaeger"
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:21:25: error: pipeline "traces" references receiver "jaeger" which is not declared under receivers [undefined-reference]
+    hint: declared receivers: otlp
+```
+
+## Notes
+
+A connector is resolvable from a pipeline's receiver *and* exporter slot, which
+is what makes it a connector; whether it is wired to both is
+[`connector-wiring`](connector-wiring.md)'s question.
+
+## See also
+
+- [`undefined-extension-reference`](undefined-extension-reference.md) — the same
+  mistake made inside a component's own settings, where this rule never looks.
+- [`unused-component`](unused-component.md) — the other direction: declared and
+  never referenced.
+- [`../../testdata/rules/undefined-reference.yaml`](../../testdata/rules/undefined-reference.yaml)

--- a/docs/rules/unknown-component.md
+++ b/docs/rules/unknown-component.md
@@ -1,0 +1,52 @@
+# unknown-component
+
+**Default severity:** `error` · **Group:** [Release compatibility](README.md#release-and-distribution-compatibility)
+
+A component type that does not exist in the collector release being targeted.
+This is the rule the whole release-pinning idea is for: the same config is valid
+on v0.110.0 and broken on v0.157.0.
+
+## What it reports
+
+Any declared component whose type the targeted release's
+[schema](../schemas.md) does not carry. The hint is what makes the finding
+useful, and it answers whichever question applies:
+
+| Situation | Hint |
+| --- | --- |
+| declared under the wrong section | `"remotetap" is a processor; declare it under processors` |
+| the binary does not carry it | `"k8sattributes" is not in the core distribution; it ships in contrib, k8s` |
+| it existed once | `"logging" exists in v0.110.0 but not in v0.157.0` |
+| none of the above | `checked against collector v0.157.0 (contrib); did you mean "prometheus"?` |
+
+The third is answered from `components.json`, one document read in one request —
+see [Which releases have a component](../schemas.md#which-releases-have-a-component).
+
+## Example
+
+```yaml
+receivers:
+  nosuchreceiver:                  # no receiver of this type exists in the release
+```
+
+```console
+$ otelcol-config-lint run --collector-version v0.157.0 config.yaml
+config.yaml:3:3: error: unknown receiver type "nosuchreceiver" in collector v0.157.0 (contrib) [unknown-component]
+    hint: checked against collector v0.157.0 (contrib)
+```
+
+## Notes
+
+- It reports nothing when no schema could be resolved, and
+  `--ignore-missing-schemas` turns it off for a custom distribution the registry
+  does not describe.
+- The distribution matters as much as the release: `--distribution core` is 32
+  components, `contrib` is 323. A config that lints clean against contrib can
+  name a component the binary you ship does not have.
+- Renames are carried through. From v0.157.0 the OTLP gRPC exporter is
+  `otlp_grpc`, with `otlp` kept as a deprecated alias; both resolve here, and
+  the old name is [`deprecated-component`](deprecated-component.md)'s to report.
+
+## See also
+
+- [`../../testdata/rules/unknown-component.yaml`](../../testdata/rules/unknown-component.yaml)

--- a/docs/rules/unknown-field.md
+++ b/docs/rules/unknown-field.md
@@ -1,0 +1,51 @@
+# unknown-field
+
+**Default severity:** `warning` (`error` under `--strict`) · **Group:** [Settings](README.md#settings)
+
+A setting the component does not accept. The collector rejects these outright,
+so the `warning` default is about the linter's confidence rather than the
+collector's tolerance — see [Coverage](#coverage) below.
+
+## What it reports
+
+Every key a component's [field schema](../schemas.md#field-schemas) does not
+describe, at any depth, with the accepted settings and a suggestion where the
+key is close to one.
+
+`--strict` (`run.strict` in the settings file) raises it to `error`, mirroring
+kubeconform's flag.
+
+## Example
+
+```yaml
+exporters:
+  otlp_grpc:
+    endpoint: backend:4317
+    compresion: gzip               # "compression" misspelt
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:16:5: warning: unknown setting "compresion" for exporters.otlp_grpc [unknown-field]
+    hint: accepted settings: auth, authority, balancer_name, compression, endpoint, headers, keepalive, middlewares, ...; did you mean "compression"?
+```
+
+## Coverage
+
+Field schemas are read from each component's `Config` struct and enriched with
+the `config.schema.yaml` upstream publishes, covering 92–96% of components on
+every release. **What cannot be resolved is left open rather than reported**, so
+partial coverage never produces false positives — a third-party config such as
+Prometheus's own is a map the generator cannot see into, and everything under it
+passes.
+
+`${env:...}` expansions are left alone, and `--ignore-missing-schemas` turns off
+reporting for components the schema does not describe at all, which is what a
+custom distribution needs.
+
+## See also
+
+- [`required-field`](required-field.md), [`invalid-value`](invalid-value.md),
+  [`deprecated-field`](deprecated-field.md) — the other three readers of the
+  same schema.
+- [`../../testdata/rules/unknown-field.yaml`](../../testdata/rules/unknown-field.yaml)

--- a/docs/rules/unknown-pipeline-key.md
+++ b/docs/rules/unknown-pipeline-key.md
@@ -1,0 +1,35 @@
+# unknown-pipeline-key
+
+**Default severity:** `error` · **Group:** [Structure](README.md#structure)
+
+A pipeline has three slots — `receivers`, `processors`, `exporters` — and takes
+no other key.
+
+## What it reports
+
+Any fourth key inside a pipeline. `connectors` is the common one: a connector
+joins a pipeline as a receiver or an exporter, never as a slot of its own.
+
+## Example
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]
+      connectors: [span_metrics]     # a connector joins as receiver or exporter
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:24:7: error: unknown key "connectors" in pipeline "traces" [unknown-pipeline-key]
+    hint: pipelines accept receivers, processors and exporters
+```
+
+## See also
+
+- [`connector-wiring`](connector-wiring.md) for how a connector is wired
+  instead.
+- [`../../testdata/rules/unknown-pipeline-key.yaml`](../../testdata/rules/unknown-pipeline-key.yaml)

--- a/docs/rules/unknown-service-key.md
+++ b/docs/rules/unknown-service-key.md
@@ -1,0 +1,40 @@
+# unknown-service-key
+
+**Default severity:** `error` · **Group:** [Structure](README.md#structure)
+
+`service` accepts `extensions`, `pipelines` and `telemetry`, and nothing else.
+
+## What it reports
+
+Any other key inside the `service` block, with the nearest accepted key as a
+hint where one is close.
+
+## Example
+
+```yaml
+service:
+  telemetrey:          # "telemetry" misspelt
+    logs:
+      level: debug
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:19:3: error: unknown key "telemetrey" in service [unknown-service-key]
+    hint: service accepts extensions, pipelines and telemetry; did you mean "telemetry"?
+```
+
+A misspelt `telemetry` is the case this is for: the collector starts, the block
+is never read, and the debug logging somebody switched on never appears.
+
+## See also
+
+- [`unknown-top-level-key`](unknown-top-level-key.md),
+  [`unknown-pipeline-key`](unknown-pipeline-key.md) — the same check at the
+  other two levels.
+- [`../../testdata/rules/unknown-service-key.yaml`](../../testdata/rules/unknown-service-key.yaml)

--- a/docs/rules/unknown-top-level-key.md
+++ b/docs/rules/unknown-top-level-key.md
@@ -1,0 +1,41 @@
+# unknown-top-level-key
+
+**Default severity:** `error` · **Group:** [Structure](README.md#structure)
+
+A top-level key other than the component sections and `service`. The collector
+rejects the file rather than ignoring the key, so this is a config that does not
+start.
+
+## What it reports
+
+Any root key outside `receivers`, `processors`, `exporters`, `connectors`,
+`extensions` and `service`. The hint lists the six, and names the nearest one
+when the key looks like a typo.
+
+## Example
+
+```yaml
+recievers:            # "receivers" misspelt
+  otlp:
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:1:1: error: unknown top-level key "recievers" [unknown-top-level-key]
+    hint: valid top-level keys: connectors, exporters, extensions, processors, receivers, service; did you mean "receivers"?
+```
+
+The misspelling is the case worth having the rule for: the file still parses,
+the section below it still works, and the collector's own error names a key
+rather than the line that made it.
+
+## See also
+
+- [`unknown-service-key`](unknown-service-key.md) for the same mistake one level
+  down.
+- [`../../testdata/rules/unknown-top-level-key.yaml`](../../testdata/rules/unknown-top-level-key.yaml)

--- a/docs/rules/unused-component.md
+++ b/docs/rules/unused-component.md
@@ -1,0 +1,54 @@
+# unused-component
+
+**Default severity:** `warning` · **Group:** [Wiring](README.md#wiring)
+
+A declared component that nothing wires up is never instantiated: it opens no
+port, holds no connection, and its settings are never validated.
+
+## What it reports
+
+A component under any section that no pipeline references, and an extension that
+`service.extensions` does not list. The two get different wording, because an
+extension is enabled by being listed rather than by being referenced from a
+pipeline.
+
+## Example
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+  otlp/second:                     # declared, referenced by no pipeline
+    protocols:
+      http:
+        endpoint: localhost:4318
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:7:3: warning: receiver "otlp/second" is declared but referenced by no pipeline [unused-component]
+    hint: remove it, or reference it so it actually runs
+```
+
+The mistake this catches is the second half of a change that was only half made:
+a component added and never wired in, or wired out and never removed — and a
+`0.0.0.0` endpoint on a receiver nobody references reads alarming while binding
+nothing at all.
+
+## Notes
+
+- Without a `service` block every component is unused, so the rule stands down
+  and lets [`service-required`](service-required.md) say it once.
+- Several rules defer to this one rather than reporting a component that never
+  runs: [`debug-exporter-verbosity`](debug-exporter-verbosity.md),
+  [`no-persistent-queue`](no-persistent-queue.md),
+  [`receiver-binds-all-interfaces`](receiver-binds-all-interfaces.md) and
+  [`debug-extension-exposed`](debug-extension-exposed.md) all skip what is not
+  wired in. [`hardcoded-secret`](hardcoded-secret.md) is the exception: a
+  credential in the repository has already been handed over, wired or not.
+
+## See also
+
+- [`../../testdata/rules/unused-component.yaml`](../../testdata/rules/unused-component.yaml)

--- a/docs/rules/wrong-node-type.md
+++ b/docs/rules/wrong-node-type.md
@@ -1,0 +1,40 @@
+# wrong-node-type
+
+**Default severity:** `error` · **Group:** [Structure](README.md#structure)
+
+Component sections are mappings of component id to settings; `service.extensions`
+and the three pipeline slots are lists. Writing one as the other is a config the
+collector cannot decode.
+
+## What it reports
+
+| Where | Must be |
+| --- | --- |
+| `receivers`, `processors`, `exporters`, `connectors`, `extensions` | a mapping |
+| `service.extensions` | a list |
+| a pipeline's `receivers`, `processors`, `exporters` | a list |
+
+A null node — a key written with nothing under it — is not reported: that is how
+a component with no settings is declared.
+
+## Example
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers:                 # a slot is a list of component ids
+        otlp: {}
+      processors: [memory_limiter, batch]
+      exporters: [otlp_grpc]
+```
+
+```console
+$ otelcol-config-lint run config.yaml
+config.yaml:22:9: error: receivers must be a list, got a mapping [wrong-node-type]
+    hint: write it as a YAML sequence, e.g. receivers: [otlp]
+```
+
+## See also
+
+- [`../../testdata/rules/wrong-node-type.yaml`](../../testdata/rules/wrong-node-type.yaml)

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -1,0 +1,244 @@
+# Schemas
+
+Every rule that knows anything about a collector release reads it from a schema.
+Schemas are published at
+[minuk-dev/otelcol-config-schemas](https://github.com/minuk-dev/otelcol-config-schemas),
+one file per collector release per distribution, in both YAML (the readable
+form, meant to be reviewed in pull requests) and JSON.
+
+They live in a repository of their own because a registry grows without bound
+while a run reads one file from it; keeping them in the linter would charge
+every clone for schemas it never opens.
+
+They are generated from the `metadata.yaml` that every upstream component ships,
+across **both core and contrib**, split into one schema per distribution:
+`contrib` (323 components for v0.157.0, the default), `core` (32), `k8s` (83)
+and `otlp` (5).
+
+```yaml
+components:
+  receiver:
+    otlp:
+      type: otlp
+      signals: [traces, metrics, logs, profiles]
+      stability:
+        traces: stable
+        metrics: stable
+        logs: stable
+        profiles: alpha
+      module: go.opentelemetry.io/collector/receiver/otlpreceiver
+```
+
+## Where they are read from
+
+Over HTTPS by default, so nothing needs installing or cloning. To pin a copy, or
+to run without network access, point at a checkout:
+
+```sh
+otelcol-config-lint run --schema-location ../otelcol-config-schemas config.yaml
+```
+
+A location is one of:
+
+- a registry directory or URL — one holding `index.json`, laid out as
+  `<distribution>/<version>.<ext>`, optionally with the `components.json`
+  described [below](#which-releases-have-a-component);
+- a `{{.Version}}`/`{{.Distribution}}` template naming a single file;
+- `default`, for the published registry.
+
+Repeat the flag to search several in order, so a private distribution's schema
+can take precedence over the public ones, or so a vendored copy answers before
+the network is tried.
+
+A remote location must be `https://`. The schema is what every rule reasons from
+— which components exist, which settings they take — so anyone able to rewrite
+one in flight decides what the linter reports. A plain `http://` location is
+refused unless `--insecure-schema-location` says otherwise, which is there for a
+registry served on localhost. One download is capped at 32 MiB, so a registry
+that is hostile or merely broken cannot stream the linter out of memory.
+
+## Which releases have a component
+
+An unknown component is worth explaining — `"logging" exists in v0.110.0 but not
+in v0.157.0` says something a "did you mean" cannot — but the question is about
+every release at once, and a schema describes one. Answering it by reading them
+is a multi-megabyte download per release, tens of them, to produce a single line
+of hint, and against a rate limit that counts requests it is the shape most
+likely to be throttled.
+
+So the registry publishes `components.json` beside the index: the releases each
+component type is shipped in, per distribution, as one document read in one
+request. It is only read by a run that actually meets an unknown component, and
+it is written as spans (`from`, and `to` once the component is gone), so a new
+release does not rewrite the entry of everything it left alone.
+
+A registry publishing none is still read the old way, one schema per release —
+without limit for a directory on disk, and no further back than the twelve
+newest releases over the network, which are the ones a hint is usually about. A
+walk that lost half its releases to a throttled registry reports nothing rather
+than naming whichever release happened to answer: a hint that is quietly wrong
+is worse than no hint at all.
+
+## Caching
+
+A schema describes one release of one distribution, so what it says under a
+version does not change. Fetched schemas are kept between runs, under
+`$XDG_CACHE_HOME/otelcol-config-lint` (the platform's own cache directory when
+the environment names none), and a second run reads them from there without
+asking the registry. The index, which grows a line per release, is offered back
+with its ETag instead, so an up-to-date run pays a `304` rather than the file.
+
+`--no-cache` reads nothing and keeps nothing. The registry tracks its own main,
+so a schema can be corrected under a version this machine has already read; that
+is when to reach for it. Deleting the directory has the same effect once.
+
+A throttled or briefly failing registry is asked again — three attempts, waiting
+as long as a `Retry-After` asks for and backing off from half a second otherwise
+— so one `429` does not fail a lint. A `404` is not retried: it means the
+registry does not carry that version, which waiting will not change.
+
+## Keeping the registry current
+
+Nobody has to remember. The
+[`schemas` workflow](https://github.com/minuk-dev/otelcol-config-schemas/blob/main/.github/workflows/schemas.yaml)
+runs weekly **in the `otelcol-config-schemas` repository**, not in this one: it
+reads upstream's release tags, and for each one the registry does not have yet
+generates the schemas and opens a pull request there, one per release. It takes
+`cmd/schemagen` from a public checkout of this repository, which needs no
+credential, while its writes are to the registry that `GITHUB_TOKEN` already
+covers — run the other way round it would need a personal access token with
+write access to the registry, stored as a secret and rotated by hand.
+
+A release with no schema stops a lint — `--collector-version v0.158.0` is a
+usage error naming the newest release the registry does have — so the registry
+has to keep up on its own. Dispatch the workflow with a version to generate one
+by hand, present or not.
+
+The generated diff is several megabytes of YAML, so the pull request leads with
+what actually changed. `--summary` writes it: the components the release adds,
+drops and renames, and the ones that crossed the beta line, which is what
+[`component-stability`](rules/component-stability.md) reports on and so what
+changes the findings an unchanged config gets.
+
+```sh
+go run ./cmd/schemagen generate --builder acme=./builder.yaml --registry ./schemas \
+  --summary -
+```
+
+```
+### contrib: `v0.157.0` → `v0.158.0`
+
+4 added, 1 renamed, 2 across the beta line; 327 components in total.
+
+**Added**
+
+- receiver `faro`
+…
+```
+
+## Adding a release by hand
+
+A distribution is described by the same [OCB builder
+manifest](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder)
+that builds it, so the schema lists exactly the components the binary carries.
+Upstream ships one per distribution in
+[`opentelemetry-collector-releases`](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions):
+
+```sh
+# ../opentelemetry-collector-releases checked out at the release to generate
+make schemas                                    # writes to ../otelcol-config-schemas
+make schemas RELEASES=/path/to/opentelemetry-collector-releases \
+             SCHEMAS=/path/to/otelcol-config-schemas
+```
+
+Or name a manifest directly, which is how a private distribution is covered. A
+single run writes one schema, so `--out` names the file (or `-`, the default,
+for stdout); `--registry` is what fills a directory with the
+`<distribution>/<version>.<ext>` layout and its `index.json`:
+
+```sh
+go run ./cmd/schemagen generate --builder ./builder.yaml --out ./my-collector.yaml
+go run ./cmd/schemagen generate --builder acme=./builder.yaml --registry ./schemas
+```
+
+`cmd/schemagen` downloads every module the manifest names, plus everything they
+require, and writes `<distribution>/<version>.yaml` and `.json` into the schema
+repository, along with the `index.json` listing them. The index also records the
+extension each distribution's schemas should be fetched with, so reading one
+over the network costs a single request instead of probing `.yaml`, `.yml` and
+`.json` in turn; a distribution whose releases do not agree on one form names
+none, and is probed as before. `components.json` is written beside it, from the
+schemas the registry is left holding, so that [an unknown component can be
+placed](#which-releases-have-a-component) without downloading the registry; a
+distribution whose releases could not all be read is left out of it rather than
+described from half of them.
+
+The download goes through the `go` command, so `GOPROXY`, `GOPRIVATE` and
+whatever credentials this machine builds with apply unchanged: a **private
+component resolves exactly as it does for the build that consumes it**, and a
+`replaces:` entry pointing at a checkout is read from there. A component that
+ships no `metadata.yaml` is still recorded, from what the manifest says, so a
+config naming it is not reported as unknown.
+
+In the registry the file name comes from the manifest — `dist.otelcol_version`
+(or `dist.version`) and `dist.name` — so `--builder <name>=<path>` overrides the
+name where the registry spells a distribution differently from upstream, as it
+does for `otelcol`, which is filed as `core`.
+
+Component renames are carried through: upstream is moving types to snake_case,
+so from v0.157.0 the OTLP gRPC exporter is `otlp_grpc` with `otlp` kept as a
+deprecated alias. Both resolve, and using the old name reports
+[`deprecated-component`](rules/deprecated-component.md).
+
+A registry grows without bound — one file per release per distribution, in two
+formats — so `--retain n` keeps only the newest `n` releases of each
+distribution, and `--retain-every n` holds on to every `n`th minor for good, so
+a config pinned to a round release keeps resolving after its neighbours are
+dropped. Neither is on by default; the scheduled workflow sets them, a local
+`make schemas` keeps everything. Pruning bounds what the registry serves and
+what a checkout costs, not the history of the repository holding it.
+
+## Field schemas
+
+`metadata.yaml` describes components but not their settings, so those are read
+from the modules themselves: every component's `Config` struct, and the
+`config.schema.yaml` upstream publishes alongside it, which contributes
+descriptions and enums the Go source cannot:
+
+```yaml
+fields:
+  type: map
+  children:
+    timeout: {type: duration, doc: how long to wait before sending a batch}
+    send_batch_size: {type: int}
+```
+
+References between those schemas are followed across modules, so a component's
+shared settings — `sending_queue`, `retry_on_failure`, TLS, gRPC client options
+— are expanded in full. What cannot be resolved stays open rather than being
+reported, so partial coverage never produces false positives. Coverage runs at
+92–96% of components on every release.
+
+This is what [`unknown-field`](rules/unknown-field.md),
+[`required-field`](rules/required-field.md),
+[`invalid-value`](rules/invalid-value.md) and
+[`deprecated-field`](rules/deprecated-field.md) read.
+
+A setting that decodes into a `component.ID` is marked, since nothing in the
+value says so — a storage id and a directory path are both strings:
+
+```yaml
+sending_queue:
+  type: map
+  children:
+    storage: {type: string, extensionRef: storage}
+```
+
+That marker is what
+[`undefined-extension-reference`](rules/undefined-extension-reference.md) reads,
+so which settings name an extension is derived from the sources rather than
+maintained as a list in the linter. The role — `storage`, `auth`, or a plain
+`extension` for a key the generator has no name for — is only what the
+diagnostic calls it. Schemas generated before the marker existed keep working:
+the rule still knows `sending_queue.storage` and `auth.authenticator` on its
+own, and that fallback falls away as the registry is regenerated.


### PR DESCRIPTION
## Why

The README had grown to 1070 lines. Most of it was prose about individual rules
under a single "What it checks" heading — the place a reader lands first, and
the last place that detail belongs.

It also linked `.github/workflows/schemas.yaml`, which is not in this
repository, and a second passage described the weekly schema job as this
repository's CI. Fixes #77.

## What

**README: 1070 → 270 lines.** Kept as reference: install, the action, the
command and flag tables, exit codes, a short settings example, and a line per
rule group.

**`docs/rules/<name>.md`, one page per rule (35).** Each carries the default
severity, what it reports, a config that trips it with the output it actually
produces, what it stays quiet about, and the upstream page it rests on. The
examples are the `testdata/rules` fixtures run through the linter against
`testdata/schemas`, so they are what the binary prints rather than what the
prose remembers.

The long-form arguments the README carried moved rather than being cut —
`missing-batch`'s two batching paths, `no-persistent-queue`'s three steps,
`hardcoded-secret`'s exclusion list, `processor-order`'s middle clause.

**The rest splits by audience:** `docs/configuration.md` for the settings file,
`docs/schemas.md` for the registry, `docs/contributing.md` for layout, releases
and adding a rule.

## Corrections found while writing this

Three tables written from the old prose disagreed with the code, and are
corrected from it:

- `memory-limiter-config` also reports the spike-limit and over-100% percentage
  cases;
- `memory-limiter-sizing` has a third clause for the ~50MiB of headroom, and
  its hard limit does *not* include that overhead;
- `debug-exporter-verbosity` reports one finding per pipeline reference, not
  both severities at once.

## On #77

The `schemas` workflow lives in
[`otelcol-config-schemas`](https://github.com/minuk-dev/otelcol-config-schemas/blob/main/.github/workflows/schemas.yaml),
which is where it has to run: from there the linter is a public checkout
needing no credential and the writes are covered by `GITHUB_TOKEN`. Run from
here it would be the reverse — cross-repo writes needing a PAT stored as a
secret and rotated by hand. Both passages now say which repository it lives in
and link to the file.

## Verification

- `go build ./...` and `go test ./...` clean (no code changed).
- Link checker over all 40 markdown files: 0 broken relative links or anchors.
- Every rule in `list rules` has a page; every page names a registered rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)