### PR TITLE
fix(release): pin the action at a release that exists, and prove it published

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,30 @@ jobs:
           name: goreleaser-assets
           path: dist/*
 
+      # The guard before the build checks that the pin names this release. This
+      # checks the other half: that the release actually published the image the
+      # pin names. The two are not the same failure. v0.1.0 passed nothing --
+      # the guard refused the tag, goreleaser never ran, and the repository was
+      # left advertising an action whose `FROM` line pulls a tag that does not
+      # exist. Nothing downstream noticed, because .github/workflows/action.yaml
+      # rewrites the pin to a locally built image before exercising the action,
+      # so CI stayed green while every consumer's workflow failed on `manifest
+      # unknown`. A release that cannot serve its own action is not a release.
+      - name: The release has to have published the image the action is pinned to
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          pinned="$(sed -nE 's|^FROM ghcr\.io/minuk-dev/otelcol-config-lint:([^ ]+).*|\1|p' Dockerfile)"
+          image="ghcr.io/minuk-dev/otelcol-config-lint:${pinned}"
+
+          if ! docker manifest inspect "${image}" > /dev/null 2>&1; then
+            echo "::error title=release::${GITHUB_REF_NAME} published no ${image}." \
+              "The action's Dockerfile pulls that tag on every consumer's runner," \
+              "so the action is broken until it exists."
+            exit 1
+          fi
+
+          echo "${image} is published; the action resolves"
+
       # A snapshot build does not publish, so push its images by hand to keep
       # ghcr.io tracking main between releases.
       - name: Extract version
@@ -93,8 +117,11 @@ jobs:
           docker buildx imagetools create -t "${MANIFEST_TAG}" "${AMD64_IMAGE}" "${ARM64_IMAGE}"
 
   major-tag:
-    # Actions convention: `uses: minuk-dev/otelcol-config-lint@v1` has to follow
-    # the newest v1.x.y, so the major tag is moved once the release succeeded.
+    # Actions convention: `uses: minuk-dev/otelcol-config-lint@v<major>` has to
+    # follow the newest release with that major, so the tag is moved once the
+    # release succeeded. It is whatever the tag's own major is -- v0 while the
+    # releases are 0.x, and v1 from 1.0.0 on -- so the README documents the one
+    # that currently exists rather than the one it would like to.
     if: startsWith(github.ref, 'refs/tags/v')
     needs: goreleaser
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 # .github/workflows/action.yaml builds this image from source and rewrites the
 # pin to it before using the action -- the source build stays reachable, it is
 # just no longer what consumers run.
-FROM ghcr.io/minuk-dev/otelcol-config-lint:1.0.0 AS bin
+FROM ghcr.io/minuk-dev/otelcol-config-lint:0.1.1 AS bin
 
 FROM alpine:3.22
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ arm64, plus a multi-arch image on ghcr.io.
 In a workflow it is one `uses:` line — no Go toolchain, no install step:
 
 ```yaml
-- uses: minuk-dev/otelcol-config-lint@v1
+- uses: minuk-dev/otelcol-config-lint@v0
   with:
     files: ./configs
     collector-version: v0.157.0
@@ -83,7 +83,7 @@ The counts come back as outputs — `exit-code`, `valid`, `invalid`, `errors`,
 them:
 
 ```yaml
-- uses: minuk-dev/otelcol-config-lint@v1
+- uses: minuk-dev/otelcol-config-lint@v0
   id: lint
   continue-on-error: true
   with:
@@ -92,13 +92,15 @@ them:
 - run: echo "${{ steps.lint.outputs.invalid }} file(s) failed"
 ```
 
-`@v1` follows the newest v1 release, and runs exactly that release's linter: the
+`@v0` follows the newest v0 release, and runs exactly that release's linter: the
 action wraps `ghcr.io/minuk-dev/otelcol-config-lint:<release>`, pinned at a tag
 and never `latest`, so a step is two small image pulls rather than a Go
-toolchain and a compile. Pin a full tag such as `@v1.2.3` to hold a workflow to
-one revision. The schemas are a separate registry that tracks its own main, so
-pin `schema-location` as well — at a vendored directory, or at a tagged URL —
-for a run that cannot change underneath a workflow.
+toolchain and a compile. The major tag is whatever the release's own major is —
+the release workflow moves it — so it becomes `@v1` when 1.0.0 ships, and until
+then `@v1` resolves to nothing. Pin a full tag such as `@v0.1.1` to hold a
+workflow to one revision. The schemas are a separate registry that tracks its
+own main, so pin `schema-location` as well — at a vendored directory, or at a
+tagged URL — for a run that cannot change underneath a workflow.
 
 ## Usage
 


### PR DESCRIPTION
## The action is broken for every consumer, and has been since v0.1.0

`action.yml` is a docker action with `image: Dockerfile`, so GitHub builds the
root `Dockerfile` on the consumer's runner. Its first line pulls an image tag
that has never existed:

```
Dockerfile:28   FROM ghcr.io/minuk-dev/otelcol-config-lint:1.0.0 AS bin
```

ghcr carries 100 tags, **all** of them `0.0.1-SNAPSHOT-<sha>` from main builds.
`1.0.0`, `0.1.0` and `latest` all 404 (verified with an anonymous pull token
that lists the tags fine, so it is absence, not auth).

Every documented entry point fails:

| Usage | Result |
| --- | --- |
| `uses: ...@v1` | no such ref — the only tag is `v0.1.0` |
| `uses: ...@v0.1.0` | that tag's Dockerfile also pins `1.0.0` → `manifest unknown` |
| `docker run ...:latest` | 404 |

`go install ...@latest` is currently the only working install path.

## Why it happened

The [v0.1.0 release run](https://github.com/minuk-dev/otelcol-config-lint/actions/runs/32760040705)
stopped at the pin guard — the tag wanted `0.1.0`, the Dockerfile said `1.0.0`:

```
3. The action has to be pinned at the release being cut -> failure
4..11. (Set up Go … Push snapshot images)                -> skipped
major-tag job                                            -> skipped
```

The guard did its job. The problem is everything after it: goreleaser never
ran, so no images and no binaries were published, and `major-tag` never created
`v0`. The GitHub Release exists with **0 assets**, which makes the release look
cut while the container path is missing entirely.

## Why nothing caught it

`.github/workflows/action.yaml` builds the image from the PR's revision and
`sed`-rewrites the pin before exercising the action. That is correct — a pull
request predates the release it is pinned to — but it means the one fact
consumers depend on, *that the pinned tag resolves*, is never tested. The
pre-release guard only compares two strings in the repository; it cannot see
ghcr at all.

## What this changes

1. **`Dockerfile`** — pin `0.1.1`, the release this PR prepares.
2. **`release.yaml`** — the other half of the guard: after goreleaser has
   published, on a tag, `docker manifest inspect` the image the pin names. A
   release that cannot serve its own action now fails at the moment it is cut
   rather than quietly in somebody else's workflow.
3. **`README.md`** — `@v1` resolved to nothing, because `major-tag` derives the
   tag from the release's own major and 0.x publishes `v0`. Now documents `@v0`
   and says when `@v1` starts working.

## To actually fix production

Merging this only prepares main. The release still has to be cut:

```sh
git tag v0.1.1 && git push origin v0.1.1
```

That publishes `0.1.1`, `0.1.1-amd64/arm64`, moves `latest`, creates `v0`, and
uploads the binaries — and the new step verifies it before the run goes green.

Cutting `v0.1.1` rather than re-tagging `v0.1.0` leaves the published tag alone.
v0.1.0 shipped no artifact anyone could have consumed, so deleting it would also
be safe, but that is the maintainer's call, not this PR's.

## Verification

- The guard command was proven locally against the real registry: it passes on
  an existing snapshot tag and fails on `1.0.0` — the exact state that shipped.
- The pre-release guard's `sed` extracts `0.1.1` from the new Dockerfile, so a
  `v0.1.1` tag passes it.
- `release.yaml` parses; the new step lands after `Run GoReleaser` and is
  tag-only, so branch builds are unaffected.
- `go build ./...` and `go test ./...` clean (no Go changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)