### PR TITLE
fix: a schema that states no shape is not a mapping (#107), plus the two CI failures it surfaced

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,21 +33,28 @@ FROM alpine:3.22
 # and the CA bundle because schemas are fetched from the published registry
 # over HTTPS unless the workflow points schema-location somewhere local.
 #
-# bash and jq are pinned with apk's prefix operator, which fixes the upstream
-# version and leaves the -rN revision free. An exact pin is the wrong shape
-# here: action.yml says `image: Dockerfile`, so this is rebuilt on every
-# consumer's runner on every run, and Alpine's repository carries only the
-# current revision of a package. The day 3.22 rebuilds bash for a CVE, an
-# exact pin stops resolving and every workflow using this action fails on
-# `apk add` -- and no automation in this repository bumps it back: dependabot
-# reads go.mod and workflow `uses:` lines, not apk constraints. A prefix pin
-# still fails loudly if the version itself ever moves, which within one Alpine
-# stable branch it does not.
+# bash and jq are pinned with apk's prefix operator, at the minor rather than
+# the patch. An exact pin is the wrong shape here: action.yml says
+# `image: Dockerfile`, so this is rebuilt on every consumer's runner on every
+# run, and Alpine's repository carries only the current revision of a package.
+# The day 3.22 rebuilds bash for a CVE, an exact pin stops resolving and every
+# workflow using this action fails on `apk add` -- and no automation in this
+# repository bumps it back: dependabot reads go.mod and workflow `uses:` lines,
+# not apk constraints.
+#
+# The pin used to name the patch too, on the reasoning that a prefix pin "still
+# fails loudly if the version itself ever moves, which within one Alpine stable
+# branch it does not". It does. On 2026-09-02 v3.22 moved jq from 1.8.1 to
+# 1.8.2, `jq~1.8.1` stopped resolving, and the action failed on `apk add` for
+# everyone running it -- the build breaks in the consumer's workflow, not here,
+# which is the failure this pin was shaped to avoid in the first place. A
+# stable branch holds the major and minor; the patch is not a promise, so the
+# pin no longer asks for one.
 #
 # ca-certificates is deliberately left unpinned. Its version is the date the
 # bundle was cut, so a pin of either shape freezes the trust store at a set of
 # roots -- and breaks the build outright the day a new bundle lands.
-RUN apk add --no-cache 'bash~5.2.37' 'jq~1.8.1' ca-certificates
+RUN apk add --no-cache 'bash~5.2' 'jq~1.8' ca-certificates
 
 COPY --from=bin /usr/local/bin/otelcol-config-lint /usr/local/bin/otelcol-config-lint
 COPY build/docker/action-entrypoint.sh /usr/local/bin/action-entrypoint

--- a/pkg/cmd/schemagen/fields.go
+++ b/pkg/cmd/schemagen/fields.go
@@ -216,23 +216,45 @@ func (s *schemaSet) field(doc *jsonSchema, dir string, seen []string, depth int)
 		out.Children[name] = child
 	}
 
+	settleShape(out, doc)
+
+	return out
+}
+
+// settleShape decides what an object turned out to be, once its children are
+// known.
+//
+// An object with no keys of its own is two different things, and only one of
+// them is a mapping. With additionalProperties it is a map of arbitrary keys:
+// free-form, but still a mapping, so it keeps the type and stays worth
+// checking.
+//
+// Without, it states nothing at all. That is what upstream's config schema
+// renders a Go `any` as, and the resource processor's attributes[].value is one
+// -- it takes a plain string. Typing that as a map made the linter demand a
+// mapping and report `value: "log"`, which is how the processor is ordinarily
+// used, as an error. So it is left unconstrained, which is what the empty type
+// already means everywhere else: nothing is known, so nothing is checked.
+//
+// Either way the keys under it stay open, or a map whose children were never
+// expanded -- from a cycle, or a module publishing no schema -- has every key
+// below it read as unknown.
+func settleShape(out *schema.Field, doc *jsonSchema) {
 	if len(out.Children) > 0 && out.Type == "" {
 		out.Type = typeMap
 	}
 
-	// A map that accepts arbitrary keys must not have them reported as unknown.
 	if doc.AdditionalProperties != nil {
 		out.Open = true
 	}
 
-	// A map whose keys were not expanded, because of a cycle or a reference
-	// into something not published, has to stay open or every key under it
-	// reads as unknown.
 	if out.Type == typeMap && len(out.Children) == 0 {
 		out.Open = true
-	}
 
-	return out
+		if doc.AdditionalProperties == nil {
+			out.Type = ""
+		}
+	}
 }
 
 // merge folds a referenced or composed schema into the one referring to it.

--- a/pkg/cmd/schemagen/fields_internal_test.go
+++ b/pkg/cmd/schemagen/fields_internal_test.go
@@ -1,0 +1,59 @@
+package schemagen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestAnObjectStatingNothingIsUnconstrained pins the difference between the two
+// objects that carry no keys of their own.
+//
+// Upstream renders a Go `any` as a bare object, and the resource processor's
+// attributes[].value is one: it takes a plain string. Recording that as a map
+// made the linter demand a mapping and report `value: "log"` -- the ordinary way
+// to write the processor -- as an error. An object with additionalProperties is
+// a different thing: free-form, but a mapping, and still worth checking.
+func TestAnObjectStatingNothingIsUnconstrained(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		doc      string
+		wantType string
+		wantOpen bool
+	}{
+		"a Go any renders as a bare object": {
+			doc:      "type: object\n",
+			wantType: "",
+			wantOpen: true,
+		},
+		"a map of arbitrary keys is still a mapping": {
+			doc:      "type: object\nadditionalProperties:\n  type: string\n",
+			wantType: typeMap,
+			wantOpen: true,
+		},
+		"an object that lists its keys is a mapping and closed": {
+			doc:      "type: object\nproperties:\n  endpoint:\n    type: string\n",
+			wantType: typeMap,
+			wantOpen: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var doc jsonSchema
+
+			require.NoError(t, yaml.Unmarshal([]byte(tt.doc), &doc))
+
+			got := newSchemaSet().field(&doc, ".", nil, 0)
+			require.NotNil(t, got)
+
+			assert.Equal(t, tt.wantType, got.Type, "type")
+			assert.Equal(t, tt.wantOpen, got.Open, "open")
+		})
+	}
+}

--- a/pkg/rule/fieldwalker.go
+++ b/pkg/rule/fieldwalker.go
@@ -155,7 +155,7 @@ func (w FieldWalker) checkRequired(field *schema.Field, present map[string]bool,
 
 // checkType reports a type mismatch and returns whether it is safe to descend.
 func (w FieldWalker) checkType(field *schema.Field, node *yaml.Node, path string) bool {
-	if field.Type == "" {
+	if field.Type == "" || statesNoShape(field) {
 		return true
 	}
 
@@ -180,6 +180,28 @@ func (w FieldWalker) checkType(field *schema.Field, node *yaml.Node, path string
 	}
 
 	return true
+}
+
+// statesNoShape reports a schema that says nothing about the value: a map with
+// no children of its own that accepts any key.
+//
+// Two unrelated things are written that way, and the published schema cannot
+// tell them apart. One is a Go `any`, which upstream's config schema renders as
+// a bare object -- the resource processor's attributes[].value, which takes a
+// plain string, is one of those. The other is a map whose keys could not be
+// expanded, from a reference cycle or a module that publishes no schema.
+//
+// Reporting the first as "must be a mapping" fails a config that is correct,
+// which is worse than not checking the second, so neither is checked. It is the
+// same reasoning the field rules already follow: what cannot be resolved is left
+// open rather than reported, so partial coverage never produces a false
+// positive.
+//
+// Schemas generated after schemagen learned the difference state a Go `any`
+// with no type at all, which the caller already lets through. This is what
+// keeps the schemas published before that from failing valid configs.
+func statesNoShape(field *schema.Field) bool {
+	return field.Type == typeMap && field.Open && len(field.Children) == 0
 }
 
 func matchesType(field *schema.Field, node *yaml.Node) bool {

--- a/pkg/rule/fieldwalker_internal_test.go
+++ b/pkg/rule/fieldwalker_internal_test.go
@@ -68,3 +68,85 @@ func aliasChain(t *testing.T) (*yaml.Node, *yaml.Node) {
 
 	return second, cyclic
 }
+
+// TestAFieldStatingNoShapeIsNotReported covers the schema that describes a Go
+// `any` as a bare object: the resource processor's attributes[].value takes a
+// plain string, and typing it as a map made the linter report the ordinary way
+// of writing it as an error.
+//
+// The distinction is what the schema knows, not what the value is. A map that
+// lists its keys still has to be a mapping; one that lists none and accepts any
+// key is stating nothing, and nothing is what it should be checked against.
+func TestAFieldStatingNoShapeIsNotReported(t *testing.T) {
+	t.Parallel()
+
+	scalar := scalarNode(t, "log")
+
+	tests := map[string]struct {
+		field *schema.Field
+		want  bool // whether a scalar should be reported against it
+	}{
+		"an open map with no children states nothing": {
+			field: &schema.Field{Type: typeMap, Open: true},
+			want:  false,
+		},
+		"a map that lists its keys is still a mapping": {
+			field: &schema.Field{Type: typeMap, Children: map[string]*schema.Field{
+				"storage": {Type: "string"},
+			}},
+			want: true,
+		},
+		"an open map that lists keys is still a mapping": {
+			field: &schema.Field{Type: typeMap, Open: true, Children: map[string]*schema.Field{
+				"storage": {Type: "string"},
+			}},
+			want: true,
+		},
+		"no type at all was already unconstrained": {
+			field: &schema.Field{},
+			want:  false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var got []string
+
+			w := FieldWalker{
+				Ctx:        nil,
+				OnUnknown:  nil,
+				OnRequired: nil,
+				OnInvalid: func(_ *yaml.Node, path, want string) {
+					got = append(got, path+": "+want)
+				},
+				OnDeprecated: nil,
+			}
+			w.walk(tt.field, scalar, "processors.resource.attributes[0].value")
+
+			if tt.want {
+				assert.NotEmpty(t, got, "a schema that says the value is a mapping should report a scalar")
+
+				return
+			}
+
+			assert.Empty(t, got, "a schema that says nothing about the value should not report it")
+		})
+	}
+}
+
+// scalarNode returns the value node of `v: <value>`, which is how a scalar
+// reaches the walker.
+func scalarNode(t *testing.T, value string) *yaml.Node {
+	t.Helper()
+
+	var doc yaml.Node
+
+	require.NoError(t, yaml.Unmarshal([]byte("v: "+value+"\n"), &doc))
+
+	node := doc.Content[0].Content[1]
+	require.Equal(t, yaml.ScalarNode, node.Kind)
+
+	return node
+}

--- a/pkg/schema/retry_internal_test.go
+++ b/pkg/schema/retry_internal_test.go
@@ -16,6 +16,16 @@ import (
 // is what is under test, not how long it holds for.
 const testRetryDelay = time.Millisecond
 
+// Every store below fetches with its own server's client rather than the
+// package-level default. A store with no client of its own shares one
+// connection pool with every other store in the process, and these tests run
+// in parallel: a retry leaves the connection idle in that shared pool between
+// attempts, which is exactly where another server shutting down can close it
+// underneath the attempt about to reuse it. It surfaced as "transport
+// connection broken: http: CloseIdleConnections called" on a change that
+// touched neither this package nor the network. srv.Client() is per-server, so
+// nothing else can reach into its pool.
+
 // TestGetRetriesAThrottledRegistry pins that a 429 is a pause rather than the
 // end of the run. The default registry is served from GitHub, which throttles;
 // failing the whole lint on the first one would make a large run a coin toss.
@@ -36,7 +46,7 @@ func TestGetRetriesAThrottledRegistry(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := Store{AllowInsecure: true, retryDelay: testRetryDelay, NoCache: true}
+	store := Store{AllowInsecure: true, retryDelay: testRetryDelay, NoCache: true, HTTPClient: srv.Client()}
 
 	body, err := store.get(t.Context(), srv.URL, immutable)
 	require.NoError(t, err)
@@ -58,7 +68,7 @@ func TestGetGivesUpAfterTheLastAttempt(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	store := Store{AllowInsecure: true, retryDelay: testRetryDelay, NoCache: true}
+	store := Store{AllowInsecure: true, retryDelay: testRetryDelay, NoCache: true, HTTPClient: srv.Client()}
 
 	_, err := store.get(t.Context(), srv.URL, immutable)
 	require.ErrorIs(t, err, errBadStatus)
@@ -93,7 +103,7 @@ func TestGetDoesNotRetryWhatWillNotChange(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			store := Store{AllowInsecure: true, retryDelay: testRetryDelay, NoCache: true}
+			store := Store{AllowInsecure: true, retryDelay: testRetryDelay, NoCache: true, HTTPClient: srv.Client()}
 
 			_, err := store.get(t.Context(), srv.URL, immutable)
 			require.Error(t, err)
@@ -117,7 +127,7 @@ func TestGetStopsRetryingWhenTheRunIsCancelled(t *testing.T) {
 
 	// A minute of backoff, which the cancellation has to cut short for this to
 	// return at all.
-	store := Store{AllowInsecure: true, retryDelay: time.Minute, NoCache: true}
+	store := Store{AllowInsecure: true, retryDelay: time.Minute, NoCache: true, HTTPClient: srv.Client()}
 
 	_, err := store.get(ctx, srv.URL, immutable)
 	require.ErrorIs(t, err, context.Canceled)


### PR DESCRIPTION
Fixes #107, and the two CI failures that surfaced while proving it. Three
commits, each independent.

---

## 1. `invalid-value` reported a valid config as an error — #107

```yaml
processors:
  resource/log:
    attributes:
      - key: job
        value: "log"      # error: "attributes[0].value" must be a mapping
        action: upsert
```

The collector starts on that. The linter failed it, on every release checked, at
a severity that fails CI — for the ordinary way of using a processor most
configs have. Found by running the linter against a real cluster's configs.

**Why.** Upstream's `AttributeAction.Value` is `any`, which upstream's config
schema renders as a bare `object`, and `fieldType` maps `object` onto `map`. The
generator then marked the childless map `open` — the right instinct recorded in
the wrong place. `open` only stops `unknown-field` reporting the keys
*underneath*; `invalid-value` went on asserting the node itself was a mapping. A
field whose shape is **unknown** was reported as one **known to be a mapping**.

The published schema could not tell the two apart: `{type: map, open: true}`
with no children is emitted both for a Go `any` and for a map whose keys could
not be expanded. **237 fields** in the v0.157.0 contrib schema carry that shape.

**Fixed at both ends.** `schemagen` now separates them: an object with
`additionalProperties` is a map of arbitrary keys — free-form, but a mapping, so
it keeps its type; an object with neither `properties` nor `additionalProperties`
states nothing and is recorded with no type at all, which is what the empty type
already means everywhere else. The walker stops asserting a mapping for the shape
**already published**, since schemas generated before this cannot be re-typed and
a pinned `--schema-location` checkout carries the old shape for a long time.

That second half is a deliberate trade: it costs the mapping check on those 237
fields until the registry is regenerated. A missed type check is a finding nobody
gets; the behaviour it replaces is an `error` on a config that is correct. It is
also what the field rules already do everywhere else — what cannot be resolved is
left open rather than reported.

**Not relaxed.** A map that lists its keys still has to be a mapping:

```console
config.yaml:9:20: error: "sending_queue" must be a mapping [invalid-value]
config.yaml:10:14: error: "timeout" must be a duration such as 5s, 200ms or 1m30s [invalid-value]
```

Verified against the **published** schemas, which is the point — the walker half
exists precisely for schemas that cannot be regenerated:

| release | before | after |
| --- | --- | --- |
| v0.100.0 | `error` | silent |
| v0.153.0 | `error` | silent |
| v0.157.0 | `error` | silent |

---

## 2. The action stopped building for every consumer

Alpine v3.22 moved jq from 1.8.1 to 1.8.2, so `jq~1.8.1` no longer resolves and
`apk add` fails. `action.yml` is a docker action with `image: Dockerfile`, so
this is rebuilt on **every consumer's runner on every run** — the build breaks in
their workflow, not here, which is the failure the pin was shaped to avoid.

**This is not caused by this branch. It fails on `main` too**; main simply has
not rebuilt since Alpine moved (its last `action` run was 2026-09-01, green).
Every PR is blocked until it is fixed, which is why it rides along here.

The pin named the patch on the reasoning that a prefix pin *"still fails loudly
if the version itself ever moves, which within one Alpine stable branch it does
not."* It does, and it did. A stable branch holds the major and minor; the patch
is not a promise. Both now pin at the minor — `bash~5.2`, `jq~1.8` — and the
comment records what happened so the next reader does not tighten it back.

Alpine's v3.22 index currently carries `bash 5.2.37-r0` and `jq 1.8.2-r0`, so
bash was one rebuild away from the same failure.

---

## 3. `TestGetRetriesAThrottledRegistry` flaked

`transport connection broken: http: CloseIdleConnections called`, on a change
touching neither that package nor the network. A rerun went green, confirming a
flake — but it is a real one worth fixing.

A store with no client of its own fetches with the package-level default, which
is deliberately shared (one client owns one pool, and building a version index
walks every release). These tests run in parallel against httptest servers of
their own, so they all reach into that one pool — and a retry is what makes it
bite: the connection sits idle in the shared pool between attempts, where another
server shutting down can close it underneath the attempt about to reuse it.

Each retry test now fetches with `srv.Client()`, which is per-server. The same
pattern exists in the cache and store tests; those make a single request each and
have not been seen to flake, so they are left alone rather than churned on
speculation.

---

## Verification

- `go test -race ./...` passes.
- `make lint` returns to exactly the pre-existing baseline (50 `goconst`, all
  from a local golangci-lint newer than the v2.11.3 CI pins, present on untouched
  `main`) with no new findings. A `cyclop` regression this surfaced — one added
  `if` pushing `field()` from 15 to 16 branches — is fixed by extracting
  `settleShape`.
- The cluster config that surfaced #107 reports nothing where it reported two
  errors.

## Tests

- `pkg/rule/fieldwalker_internal_test.go` — a scalar against `{map, open, no
  children}` reports nothing; a map that lists its keys still reports.
- `pkg/cmd/schemagen/fields_internal_test.go` — the three object cases resolve to
  unconstrained, map+open, and map+closed.

Neither belongs in `testdata/rules/`: those fixtures are configs that *should*
report, and both assert silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)