### PR TITLE
fix(schemagen): leave a partly resolved component open, not closed over half of it

### DIFF
--- a/docs/rules/unknown-field.md
+++ b/docs/rules/unknown-field.md
@@ -39,6 +39,11 @@ partial coverage never produces false positives — a third-party config such as
 Prometheus's own is a map the generator cannot see into, and everything under it
 passes.
 
+The same holds for a component resolved only [in
+part](../schemas.md#field-schemas): where the settings that were read are known
+not to be all of them, the ones that were read are still checked and the rest
+are let through, rather than the component being closed over half of itself.
+
 `${env:...}` expansions are left alone, and `--ignore-missing-schemas` turns off
 reporting for components the schema does not describe at all, which is what a
 custom distribution needs.

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -219,6 +219,17 @@ shared settings — `sending_queue`, `retry_on_failure`, TLS, gRPC client option
 reported, so partial coverage never produces false positives. Coverage runs at
 92–96% of components on every release.
 
+That holds for a component resolved only in part, too. A `Config` that decodes
+itself — it has its own `Unmarshal(*confmap.Conf)` — and keeps a field
+mapstructure cannot fill accepts settings no tag names: the hostmetrics
+receiver declares `Scrapers` as `mapstructure:"-"` and reads the `scrapers`
+section by hand, and the receiver creator holds its `receivers` the same way.
+The settings that were resolved are still recorded and still checked; the
+mapping is left open, because presenting half of a component's settings as all
+of them is what turns a coverage gap into a false positive. Upstream began
+publishing `config.schema.yaml` widely at v0.145.0 and it states these sections
+outright, so this is what the releases before it rest on.
+
 This is what [`unknown-field`](rules/unknown-field.md),
 [`required-field`](rules/required-field.md),
 [`invalid-value`](rules/invalid-value.md) and

--- a/pkg/cmd/schemagen/fields.go
+++ b/pkg/cmd/schemagen/fields.go
@@ -433,8 +433,13 @@ func enrich(primary, secondary *schema.Field) {
 		primary.ExtensionRef = secondary.ExtensionRef
 	}
 
-	if secondary.Open {
-		primary.Open = true
+	// Openness is the one thing the secondary settles rather than only adds to.
+	// A published schema states a component's sections outright, the ones the
+	// Go sources can only decode by hand included, so where it lists a
+	// mapping's keys it is the better answer about whether that mapping is
+	// closed. A secondary that lists none says nothing either way.
+	if secondary.Open || len(secondary.Children) > 0 {
+		primary.Open = secondary.Open
 	}
 
 	for name, child := range secondary.Children {

--- a/pkg/cmd/schemagen/gosource.go
+++ b/pkg/cmd/schemagen/gosource.go
@@ -30,6 +30,11 @@ const maxAliasHops = 8
 // generator has to be told about one setting at a time.
 const componentIDType = coreModuleRoot + "/component.ID"
 
+// confmapConfType is what a config's own Unmarshal method takes when the
+// component decodes itself. It is what tells such a method apart from the many
+// other Unmarshal methods in the tree.
+const confmapConfType = coreModuleRoot + "/confmap.Conf"
+
 // goType is a type declaration found in the sources, kept with the imports of
 // the file that declared it so its own field types can be resolved.
 type goType struct {
@@ -52,14 +57,19 @@ type goIndex struct {
 	// UnmarshalText method is spelled as a word, the way the debug exporter's
 	// verbosity is "detailed" and not 2.
 	textual map[string]bool
-	fset    *token.FileSet
+	// selfDecoding holds the types that decode themselves from a confmap.
+	// Their mapstructure tags are not the whole of what they accept: a setting
+	// the method reads by hand is a setting no tag names.
+	selfDecoding map[string]bool
+	fset         *token.FileSet
 }
 
 func newGoIndex() *goIndex {
 	return &goIndex{
-		byName:  map[string]*goType{},
-		textual: map[string]bool{},
-		fset:    token.NewFileSet(),
+		byName:       map[string]*goType{},
+		textual:      map[string]bool{},
+		selfDecoding: map[string]bool{},
+		fset:         token.NewFileSet(),
 	}
 }
 
@@ -76,7 +86,7 @@ func (g *goIndex) add(importPath string, src []byte) {
 
 	for _, decl := range file.Decls {
 		if fn, isFunc := decl.(*ast.FuncDecl); isFunc {
-			g.addMethod(importPath, fn)
+			g.addMethod(importPath, imports, fn)
 
 			continue
 		}
@@ -105,16 +115,13 @@ func (g *goIndex) add(importPath string, src []byte) {
 	}
 }
 
-// addMethod records a type that decodes itself from text, which is what makes
-// it a string in a config however it is declared in Go.
-func (g *goIndex) addMethod(importPath string, method *ast.FuncDecl) {
+// addMethod records the two things a method says about the type it hangs off:
+// that it decodes itself from text, which is what makes it a string in a config
+// however it is declared in Go, and that it decodes itself from a confmap,
+// which is what makes its mapstructure tags an incomplete account of what it
+// accepts.
+func (g *goIndex) addMethod(importPath string, imports map[string]string, method *ast.FuncDecl) {
 	if method.Recv == nil || len(method.Recv.List) == 0 {
-		return
-	}
-
-	switch method.Name.Name {
-	case "UnmarshalText", "UnmarshalYAML", "UnmarshalJSON":
-	default:
 		return
 	}
 
@@ -123,7 +130,31 @@ func (g *goIndex) addMethod(importPath string, method *ast.FuncDecl) {
 		return
 	}
 
-	g.textual[importPath+"."+name] = true
+	switch method.Name.Name {
+	case "UnmarshalText", "UnmarshalYAML", "UnmarshalJSON":
+		g.textual[importPath+"."+name] = true
+	case "Unmarshal":
+		if takesConfmap(method, imports) {
+			g.selfDecoding[importPath+"."+name] = true
+		}
+	}
+}
+
+// takesConfmap reports whether a method is the confmap.Unmarshaler one, by the
+// single *confmap.Conf it takes. Plenty of other things in the tree are called
+// Unmarshal.
+func takesConfmap(method *ast.FuncDecl, imports map[string]string) bool {
+	params := method.Type.Params.List
+	if len(params) != 1 {
+		return false
+	}
+
+	pkg, name, found := strings.Cut(exprName(unwrap(params[0].Type)), ".")
+	if !found {
+		return false
+	}
+
+	return imports[pkg]+"."+name == confmapConfType
 }
 
 // fileImports maps the name a file refers to each import by onto its path.
@@ -149,36 +180,50 @@ func fileImports(file *ast.File) map[string]string {
 
 // fields builds the field schema for a config struct, following embedded and
 // referenced types through the index.
+//
+// A struct that decodes itself from a confmap and holds a field mapstructure
+// cannot fill is only partly resolved, and is left open rather than presented
+// as the complete accepted set. The hostmetrics receiver is the case that shows
+// why: its scrapers are declared `mapstructure:"-"` and read by its own
+// Unmarshal, so the tags name four settings and the config writes five. Closing
+// that over the four reports the receiver's central setting as unknown.
 func (g *goIndex) fields(key string, seen []string, depth int) *schema.Field {
 	if depth > maxFieldDepth || slices.Contains(seen, key) {
 		return nil
 	}
 
-	decl := g.deref(key)
+	decl, declaredAt := g.derefKey(key)
 	if decl == nil || decl.strukt == nil {
 		return nil
 	}
 
 	out := &schema.Field{Type: typeMap}
+	unfilled := false
 
 	for _, f := range decl.strukt.Fields.List {
-		g.addStructField(out, decl, f, append(seen, key), depth)
+		if !g.addStructField(out, decl, f, append(seen, key), depth) {
+			unfilled = true
+		}
 	}
 
 	if len(out.Children) == 0 {
 		return nil
 	}
 
+	// A squashed struct may already have opened this one; see mergeChildren.
+	out.Open = out.Open || (unfilled && g.selfDecoding[declaredAt])
+
 	return out
 }
 
-// addStructField folds one struct field into the schema being built. A squashed
-// field contributes its own children rather than a key of its own, which is how
-// the shared config structs are spliced in.
-func (g *goIndex) addStructField(out *schema.Field, decl *goType, f *ast.Field, seen []string, depth int) {
+// addStructField folds one struct field into the schema being built, and
+// reports whether mapstructure fills it. A squashed field contributes its own
+// children rather than a key of its own, which is how the shared config structs
+// are spliced in.
+func (g *goIndex) addStructField(out *schema.Field, decl *goType, f *ast.Field, seen []string, depth int) bool {
 	name, squash, ok := mapstructureName(f)
 	if !ok {
-		return
+		return false
 	}
 
 	if squash {
@@ -187,7 +232,7 @@ func (g *goIndex) addStructField(out *schema.Field, decl *goType, f *ast.Field, 
 			mergeChildren(out, nested)
 		}
 
-		return
+		return true
 	}
 
 	if out.Children == nil {
@@ -200,6 +245,8 @@ func (g *goIndex) addStructField(out *schema.Field, decl *goType, f *ast.Field, 
 	}
 
 	out.Children[name] = child
+
+	return true
 }
 
 // extensionRole says what the extension a setting names is used for. The type
@@ -286,31 +333,39 @@ func (g *goIndex) scalar(decl *goType, expr ast.Expr) string {
 // deref follows alias chains to the declaration that actually defines a type,
 // so "type QueueConfig = internal.QueueConfig" reaches the struct behind it.
 func (g *goIndex) deref(key string) *goType {
+	decl, _ := g.derefKey(key)
+
+	return decl
+}
+
+// derefKey is deref, and also reports the key the declaration it settles on is
+// stored under, which is where a method on that type was recorded.
+func (g *goIndex) derefKey(key string) (*goType, string) {
 	for range maxAliasHops {
 		decl, ok := g.byName[key]
 		if !ok {
-			return nil
+			return nil, key
 		}
 
 		if decl.strukt != nil || decl.under == nil {
-			return decl
+			return decl, key
 		}
 
 		next := g.resolve(decl, decl.under)
 		if next == "" || next == key {
-			return decl
+			return decl, key
 		}
 
 		// A chain ending at a builtin runs off the index; the last named type
 		// is what says the underlying kind, so stop on it rather than losing it.
 		if _, indexed := g.byName[next]; !indexed {
-			return decl
+			return decl, key
 		}
 
 		key = next
 	}
 
-	return nil
+	return nil, key
 }
 
 // resolve turns a type expression into the index key it is stored under.
@@ -425,6 +480,10 @@ func docText(f *ast.Field) string {
 // mergeChildren splices a squashed struct's keys into its parent, leaving any
 // the parent already declares alone.
 func mergeChildren(into, from *schema.Field) {
+	// A squashed struct contributes its openness along with its keys: settings
+	// it accepts without naming are settings the outer mapping accepts too.
+	into.Open = into.Open || from.Open
+
 	for name, child := range from.Children {
 		if into.Children == nil {
 			into.Children = map[string]*schema.Field{}

--- a/pkg/cmd/schemagen/gosource_internal_test.go
+++ b/pkg/cmd/schemagen/gosource_internal_test.go
@@ -1,0 +1,141 @@
+package schemagen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
+)
+
+// TestAPartlyResolvedConfigIsLeftOpen pins the rule the hostmetrics receiver
+// forced: a config that decodes itself from a confmap and holds a field
+// mapstructure cannot fill accepts settings its tags do not name, so the tags
+// that were read are not the complete set.
+//
+// Reading them as complete is what reported `scrapers` -- the receiver's
+// central setting, and how it has always been configured -- as unknown on every
+// release generated from the Go sources.
+func TestAPartlyResolvedConfigIsLeftOpen(t *testing.T) {
+	t.Parallel()
+
+	const unmarshalMethod = `
+func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error { return nil }
+`
+
+	tests := map[string]struct {
+		decl     string
+		method   string
+		wantOpen bool
+		wantKeys []string
+	}{
+		"a setting excluded from mapstructure and read by hand": {
+			decl: `
+type Config struct {
+	Scrapers map[string]internal.Config ` + "`mapstructure:\"-\"`" + `
+	RootPath string ` + "`mapstructure:\"root_path\"`" + `
+}`,
+			method:   unmarshalMethod,
+			wantOpen: true,
+			wantKeys: []string{"root_path"},
+		},
+		"a setting held unexported and read by hand": {
+			decl: `
+type Config struct {
+	receiverTemplates map[string]string
+	WatchObservers []string ` + "`mapstructure:\"watch_observers\"`" + `
+}`,
+			method:   unmarshalMethod,
+			wantOpen: true,
+			wantKeys: []string{"watch_observers"},
+		},
+		"a config that decodes itself but names every setting": {
+			decl: `
+type Config struct {
+	Endpoint string ` + "`mapstructure:\"endpoint\"`" + `
+}`,
+			method:   unmarshalMethod,
+			wantOpen: false,
+			wantKeys: []string{"endpoint"},
+		},
+		"a skipped field with no confmap decoding behind it": {
+			decl: `
+type Config struct {
+	logger *zap.Logger
+	Endpoint string ` + "`mapstructure:\"endpoint\"`" + `
+}`,
+			method:   "",
+			wantOpen: false,
+			wantKeys: []string{"endpoint"},
+		},
+		"an Unmarshal that is not the confmap one": {
+			decl: `
+type Config struct {
+	Scrapers map[string]internal.Config ` + "`mapstructure:\"-\"`" + `
+	Endpoint string ` + "`mapstructure:\"endpoint\"`" + `
+}`,
+			method:   "\nfunc (cfg *Config) Unmarshal(data []byte) error { return nil }\n",
+			wantOpen: false,
+			wantKeys: []string{"endpoint"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			index := newGoIndex()
+			index.add("example.com/rcv", []byte(`package rcv
+
+import "go.opentelemetry.io/collector/confmap"
+`+tt.decl+tt.method))
+
+			got := index.fields("example.com/rcv.Config", nil, 0)
+			require.NotNil(t, got)
+
+			assert.Equal(t, tt.wantOpen, got.Open, "open")
+			assert.ElementsMatch(t, tt.wantKeys, keysOf(got.Children), "children")
+		})
+	}
+}
+
+// TestOpennessSquashesOutwards covers a partly resolved struct spliced into
+// another: the outer mapping accepts what the inner one accepts, so it cannot
+// be the stricter of the two.
+func TestOpennessSquashesOutwards(t *testing.T) {
+	t.Parallel()
+
+	index := newGoIndex()
+	index.add("example.com/rcv", []byte(`package rcv
+
+import "go.opentelemetry.io/collector/confmap"
+
+type Config struct {
+	Inner `+"`mapstructure:\",squash\"`"+`
+	Endpoint string `+"`mapstructure:\"endpoint\"`"+`
+}
+
+type Inner struct {
+	hidden map[string]string
+	Timeout string `+"`mapstructure:\"timeout\"`"+`
+}
+
+func (cfg *Inner) Unmarshal(componentParser *confmap.Conf) error { return nil }
+`))
+
+	got := index.fields("example.com/rcv.Config", nil, 0)
+	require.NotNil(t, got)
+
+	assert.True(t, got.Open, "the outer mapping inherits the inner one's openness")
+	assert.ElementsMatch(t, []string{"endpoint", "timeout"}, keysOf(got.Children))
+}
+
+func keysOf(children map[string]*schema.Field) []string {
+	out := make([]string, 0, len(children))
+	for name := range children {
+		out = append(out, name)
+	}
+
+	return out
+}

--- a/pkg/cmd/schemagen/schemagen_test.go
+++ b/pkg/cmd/schemagen/schemagen_test.go
@@ -307,6 +307,95 @@ replaces:
 	assert.NotContains(t, stdout, "type: int", "a text-decoded type was read as its underlying number")
 }
 
+// A component that decodes itself accepts settings its mapstructure tags do not
+// name. The hostmetrics receiver is the one that forced this: `scrapers` is
+// declared `mapstructure:"-"` and read by the receiver's own Unmarshal, so on
+// every release generated from the Go sources the schema listed four settings
+// and the config wrote five, and the receiver's central setting was reported as
+// unknown. The four that were resolved are still worth having; presenting them
+// as all of them is what turns the gap into a false positive.
+func TestAConfigThatDecodesItselfIsLeftOpen(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	confmap := module(t, root, "go.opentelemetry.io/collector/confmap", map[string]string{
+		"confmap.go": "package confmap\n\ntype Conf struct{}\n",
+	})
+	receiver := module(t, root, "example.com/collector/receiver/hostmetricsreceiver", map[string]string{
+		"metadata.yaml": "type: hostmetrics\nstatus:\n  class: receiver\n" +
+			"  stability:\n    beta: [metrics]\n",
+		"config.go": "package hostmetricsreceiver\n\n" +
+			"import \"go.opentelemetry.io/collector/confmap\"\n\n" +
+			"type Config struct {\n" +
+			"\tScrapers map[string]any `mapstructure:\"-\"`\n" +
+			"\tRootPath string `mapstructure:\"root_path\"`\n}\n\n" +
+			"func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error { return nil }\n",
+	})
+
+	path := filepath.Join(root, "manifest.yaml")
+	writeFile(t, path, fmt.Sprintf(`
+dist:
+  name: custom
+  otelcol_version: 0.100.0
+receivers:
+  - gomod: example.com/collector/receiver/hostmetricsreceiver v0.0.0
+replaces:
+  - example.com/collector/receiver/hostmetricsreceiver => %s
+  - go.opentelemetry.io/collector/confmap => %s
+`, receiver, confmap))
+
+	code, stdout, stderr := run(t, "--builder", path, "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+	assert.Contains(t, stdout, "root_path:", "the settings that did resolve were dropped")
+	assert.Contains(t, stdout, "open: true", "a partly resolved component was closed over half its settings")
+}
+
+// Where upstream publishes a config schema it states the sections its Unmarshal
+// reads, so it settles the question the Go sources could only leave open. A
+// release that has one keeps the full check.
+func TestAPublishedSchemaClosesWhatItDescribes(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	confmap := module(t, root, "go.opentelemetry.io/collector/confmap", map[string]string{
+		"confmap.go": "package confmap\n\ntype Conf struct{}\n",
+	})
+	receiver := module(t, root, "example.com/collector/receiver/hostmetricsreceiver", map[string]string{
+		"metadata.yaml": "type: hostmetrics\nstatus:\n  class: receiver\n" +
+			"  stability:\n    beta: [metrics]\n",
+		"config.schema.yaml": "type: object\nproperties:\n" +
+			"  root_path:\n    type: string\n" +
+			"  scrapers:\n    type: object\n    properties:\n" +
+			"      cpu:\n        type: object\n        properties:\n" +
+			"          collection_interval:\n            type: string\n",
+		"config.go": "package hostmetricsreceiver\n\n" +
+			"import \"go.opentelemetry.io/collector/confmap\"\n\n" +
+			"type Config struct {\n" +
+			"\tScrapers map[string]any `mapstructure:\"-\"`\n" +
+			"\tRootPath string `mapstructure:\"root_path\"`\n}\n\n" +
+			"func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error { return nil }\n",
+	})
+
+	path := filepath.Join(root, "manifest.yaml")
+	writeFile(t, path, fmt.Sprintf(`
+dist:
+  name: custom
+  otelcol_version: 0.157.0
+receivers:
+  - gomod: example.com/collector/receiver/hostmetricsreceiver v0.0.0
+replaces:
+  - example.com/collector/receiver/hostmetricsreceiver => %s
+  - go.opentelemetry.io/collector/confmap => %s
+`, receiver, confmap))
+
+	code, stdout, stderr := run(t, "--builder", path, "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+	assert.Contains(t, stdout, "scrapers:", "the published schema was not read")
+	assert.NotContains(t, stdout, "open: true", "a fully described component was left open")
+}
+
 // A setting that decodes into a component.ID names an extension, and that is
 // the only thing that says so: a storage id and a directory path are both
 // strings by the time they reach the schema. Marking it here is what lets


### PR DESCRIPTION
Fixes #108.

## Which case it turned out to be

The issue asked to confirm first: regenerate `contrib/v0.100.0` and diff it, since a regenerated schema carrying `scrapers` would mean the registry just holds stale data.

It does not. `hostmetricsreceiver` at v0.100.0 declares

```go
type Config struct {
	scraperhelper.ControllerConfig `mapstructure:",squash"`
	Scrapers                       map[string]internal.Config `mapstructure:"-"`
	RootPath                       string                     `mapstructure:"root_path"`
}

func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error { ... }
```

`scrapers` is excluded from mapstructure and read by the receiver's own `Unmarshal`. The generator honoured the tag, which is correct, and then recorded the four settings it did resolve as the complete accepted set, which is not. Upstream did not begin publishing `config.schema.yaml` widely until v0.145.0 (11 components at v0.143.0, 299 at v0.145.0), so there is nothing to resolve `scrapers` from that far back — regenerating would produce the same file. This is the second case in the issue: the generator needs a rule about partial resolution.

## The rule

A `Config` that decodes itself from a confmap **and** holds a field mapstructure cannot fill accepts settings no tag names, so the mapping is left open. What was resolved is still recorded and still checked — `root_path` keeps its type, required and deprecated checks — and what was not is let through, rather than the component being closed over half of itself.

Both halves are needed. A config that decodes itself but names every setting stays closed (`mysqlreceiver`, whose `Unmarshal` only handles a deprecated key), and a skipped field with no confmap decoding behind it stays closed too. Across contrib at v0.130.0 it moves five components out of ~330: `hostmetrics` and `receivercreator` — the two that really do read sections by hand — plus `geoip`, and `datadog` and `transform`, whose skipped fields are internal state the generator cannot tell apart from a hidden setting. Openness also squashes outwards, since an embedded struct's settings are the outer mapping's settings.

## Openness where a published schema exists

`enrich` never took anything away, so a source-derived `open` would have survived into a current release and quietly stopped `unknown-field` checking `hostmetrics` on v0.157.0. A published schema states the sections its `Unmarshal` reads — v0.157.0 has `scrapers` fully expanded, `cpu` through `system` — so openness is now the one thing enrichment settles rather than only adds to: where the secondary lists a mapping's keys it decides whether that mapping is closed, and a secondary that lists none says nothing either way.

## Verified

Against the real v0.100.0 schema with `open: true` set on `hostmetrics` by hand, which is what this generates:

```console
$ otelcol-config-lint run --collector-version v0.100.0 --default none -E unknown-field \
    --schema-location <registry as published> hostmetrics.yaml
hostmetrics.yaml:4:5: warning: unknown setting "scrapers" for receivers.hostmetrics [unknown-field]
    hint: accepted settings: collection_interval, initial_delay, root_path, timeout

$ otelcol-config-lint run --collector-version v0.100.0 --default none -E unknown-field \
    --schema-location <same schema, open> hostmetrics.yaml
$ echo $?
0
```

Also run against the real upstream sources at v0.130.0: `hostmetrics` and `receivercreator` open, `mysqlreceiver` closed.

New tests cover the rule directly (`gosource_internal_test.go`) and end to end through the generator, in both directions — open without a published schema, closed with one.

## Follow-up

This changes what `schemagen` writes, not what the registry currently holds, so the false positive stays until `otelcol-config-schemas` regenerates the old releases against this. That is a pull request there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)