### PR TITLE
feat(schemagen): count the components a release leaves open, and diff a regeneration against itself

### DIFF
--- a/docs/rules/unknown-field.md
+++ b/docs/rules/unknown-field.md
@@ -41,8 +41,14 @@ passes.
 
 The same holds for a component resolved only [in
 part](../schemas.md#field-schemas): where the settings that were read are known
-not to be all of them, the ones that were read are still checked and the rest
-are let through, rather than the component being closed over half of itself.
+not to be all of them, the component is left open rather than closed over half
+of itself. That turns this rule off for the whole component — a misspelling of
+a setting the generator *did* resolve goes unreported too, since nothing
+distinguishes it from one of the settings that were never named. The other
+three readers of the schema still check what was resolved. How many components
+a release leaves this way is counted in the summary the registry is
+[regenerated](../schemas.md#regenerating-a-release-the-registry-already-has)
+with.
 
 `${env:...}` expansions are left alone, and `--ignore-missing-schemas` turns off
 reporting for components the schema does not describe at all, which is what a

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -116,9 +116,11 @@ by hand, present or not.
 
 The generated diff is several megabytes of YAML, so the pull request leads with
 what actually changed. `--summary` writes it: the components the release adds,
-drops and renames, and the ones that crossed the beta line, which is what
+drops and renames, the ones that crossed the beta line, which is what
 [`component-stability`](rules/component-stability.md) reports on and so what
-changes the findings an unchanged config gets.
+changes the findings an unchanged config gets, and how many are [left
+open](#field-schemas) — the components no unknown setting is reported for, which
+is the one part of a schema that is a gap rather than a statement.
 
 ```sh
 go run ./cmd/schemagen generate --builder acme=./builder.yaml --registry ./schemas \
@@ -130,11 +132,44 @@ go run ./cmd/schemagen generate --builder acme=./builder.yaml --registry ./schem
 
 4 added, 1 renamed, 2 across the beta line; 327 components in total.
 
+12 of them are left open: their settings are not fully described, so
+`unknown-field` does not check them.
+
 **Added**
 
 - receiver `faro`
 …
 ```
+
+## Regenerating a release the registry already has
+
+A schema is regenerated in place when the generator learns to describe
+something differently, which is a correction to every release already published
+rather than to the next one — the weekly run only ever looks forward, so it
+will not do this on its own. Dispatch the workflow with the versions to redo,
+oldest first; `base` stacks one batch on the last so a long backfill arrives as
+a few reviewable pull requests instead of one.
+
+The summary of such a run compares the release **against itself**, not against
+the release before it: what there is to review is what this run changed about
+it. So a backfill reads as the list of components that moved:
+
+```
+### contrib: `v0.153.0` regenerated
+
+1 left open; 284 components in total.
+
+1 of them is left open: its settings are not fully described, so
+`unknown-field` does not check it.
+
+**Left open**
+
+- receiver `hostmetrics`
+```
+
+Comparing against the previous release would answer the other question, and in
+a batch generating oldest first it would answer it against a file the same run
+had just rewritten, so the change being made would appear nowhere.
 
 ## Adding a release by hand
 
@@ -229,6 +264,12 @@ mapping is left open, because presenting half of a component's settings as all
 of them is what turns a coverage gap into a false positive. Upstream began
 publishing `config.schema.yaml` widely at v0.145.0 and it states these sections
 outright, so this is what the releases before it rest on.
+
+An open component is a check that does not run: `unknown-field` lets every
+setting through for it, a typo in one the generator *did* resolve included. That
+is the right trade against reporting a valid config as wrong, but it is silent,
+so `--summary` counts the components a release leaves open — see [keeping the
+registry current](#keeping-the-registry-current).
 
 This is what [`unknown-field`](rules/unknown-field.md),
 [`required-field`](rules/required-field.md),

--- a/pkg/cmd/schemagen/summary.go
+++ b/pkg/cmd/schemagen/summary.go
@@ -9,27 +9,39 @@ import (
 	"github.com/minuk-dev/otelcol-config-lint/pkg/schema"
 )
 
-// summarise records what one generated schema changes against the newest
-// release the registry already holds for that distribution.
+// summarise records what one generated schema changes against what the
+// registry served for that distribution up to now.
 //
-// It runs before the schema is written, so the comparison is against what the
-// registry served up to now even when a release is regenerated in place. A
-// distribution with nothing to compare against still gets an entry, saying how
-// large its first schema is.
+// Which file that is depends on whether the release is new. A new one is
+// compared against the release before it, since what a reviewer wants to know
+// is what upstream changed. A release the registry already holds is compared
+// against itself: it is being regenerated because the generator now describes
+// something differently -- a component it leaves open rather than closing over
+// half of it, say -- and that change is what there is to review. Comparing it
+// against the release before it would answer the other question, and in a
+// backfill run generating oldest first it would answer it against a file this
+// same run has just rewritten, so the change being made would appear nowhere.
+//
+// It runs before the schema is written, which is what leaves the old file
+// there to compare against. A distribution with nothing to compare against
+// still gets an entry, saying how large its first schema is.
 func (o *options) summarise(cat *schema.Schema) {
 	if o.summaryFile == "" || o.registryDir == "" {
 		return
 	}
 
-	previous := previousIn(filepath.Join(o.registryDir, cat.Distribution), cat.CollectorVersion)
+	dir := filepath.Join(o.registryDir, cat.Distribution)
+
+	previous := readVersion(dir, cat.CollectorVersion)
+	if previous == nil {
+		previous = previousIn(dir, cat.CollectorVersion)
+	}
 
 	o.diffs = append(o.diffs, schema.DiffSchemas(previous, cat))
 }
 
 // previousIn reads the newest release a distribution directory holds that is
-// older than version, or nil when it holds none. A file that cannot be read is
-// treated as absent: a summary is a convenience, and failing the run over it
-// would throw away the schemas that did generate.
+// older than version, or nil when it holds none.
 func previousIn(dir, version string) *schema.Schema {
 	var newest string
 
@@ -47,8 +59,16 @@ func previousIn(dir, version string) *schema.Schema {
 		return nil
 	}
 
+	return readVersion(dir, newest)
+}
+
+// readVersion reads one release out of a distribution directory, in whichever
+// form it is filed, or nil when the directory does not hold it. A file that
+// cannot be read is treated as absent: a summary is a convenience, and failing
+// the run over it would throw away the schemas that did generate.
+func readVersion(dir, version string) *schema.Schema {
 	for _, ext := range schema.Extensions() {
-		cat, err := schema.ReadFile(filepath.Join(dir, newest+ext))
+		cat, err := schema.ReadFile(filepath.Join(dir, version+ext))
 		if err == nil {
 			return cat
 		}

--- a/pkg/cmd/schemagen/summary_test.go
+++ b/pkg/cmd/schemagen/summary_test.go
@@ -71,6 +71,30 @@ func TestSummaryOfAFirstRelease(t *testing.T) {
 	assert.Contains(t, readFile(t, summary), "### custom: new at `v0.157.0`")
 }
 
+// A release the registry already holds is being generated again because the
+// generator changed, so the summary is what this run changes about that
+// release -- not what upstream changed a release earlier, which in a backfill
+// generating oldest first would be measured against a file the same run had
+// just rewritten.
+func TestSummaryOfARegeneratedReleaseComparesAgainstItself(t *testing.T) {
+	t.Parallel()
+
+	registry := t.TempDir()
+	seedRegistry(t, registry, "v0.150.0", "v0.157.0")
+
+	manifest := singleComponentManifest(t, t.TempDir())
+	summary := filepath.Join(t.TempDir(), "summary.md")
+
+	code, _, stderr := run(t, "--builder", "custom="+manifest,
+		"--registry", registry, "--summary", summary, "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+
+	written := readFile(t, summary)
+	assert.Contains(t, written, "### custom: `v0.157.0` regenerated")
+	assert.NotContains(t, written, "`v0.150.0`", "compared against the release before it")
+}
+
 func TestSummaryNeedsARegistry(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/schema/diff.go
+++ b/pkg/schema/diff.go
@@ -38,6 +38,20 @@ type Diff struct {
 	// direction. Below beta is what component-stability reports on, so these
 	// are the changes that alter what an unchanged config is told.
 	Restabilised []StabilityChange
+	// Open lists the components of the new release whose settings map is left
+	// open, so that unknown-field lets anything through for them.
+	//
+	// It is the one part of a schema that is a gap rather than a statement: a
+	// component the generator could only half resolve is left open instead of
+	// being closed over the half it did resolve, which trades a false positive
+	// for a check that quietly does not run. Counting it is what keeps that
+	// trade visible in the release it is made.
+	Open []Ref
+	// Opened and Closed are the components that changed side, among those both
+	// releases carry. A component that is new here is in neither: it is an
+	// addition, and its openness is already counted in Open.
+	Opened []Ref
+	Closed []Ref
 	// Total is how many components the new schema carries, which is the one
 	// number worth having when From is empty.
 	Total int
@@ -87,7 +101,18 @@ func DiffSchemas(previous, release *Schema) *Diff {
 		Removed:      nil,
 		Renamed:      nil,
 		Restabilised: nil,
+		Open:         nil,
+		Opened:       nil,
+		Closed:       nil,
 		Total:        release.Count(),
+	}
+
+	// The open components of a release stand on their own: they are what the
+	// schema does not describe, whether or not there is an earlier release to
+	// compare against, and the first schema of a distribution is exactly where
+	// the size of that gap is worth stating.
+	for _, kind := range config.Kinds() {
+		d.Open = append(d.Open, openIn(kind, release.Components[kind])...)
 	}
 
 	if previous == nil {
@@ -113,16 +138,23 @@ func DiffSchemas(previous, release *Schema) *Diff {
 		d.Added = append(d.Added, missingFrom(kind, old, current, skip)...)
 		d.Removed = append(d.Removed, missingFrom(kind, current, old, nil)...)
 		d.Restabilised = append(d.Restabilised, restabilisedIn(kind, old, current)...)
+
+		opened, closed := opennessChanges(kind, old, current)
+		d.Opened = append(d.Opened, opened...)
+		d.Closed = append(d.Closed, closed...)
 	}
 
 	return d
 }
 
 // Empty reports whether the two releases ship the same components, described
-// the same way.
+// the same way. A component that changed side on openness is described
+// differently, and what an unchanged config is told about it changes with it,
+// so it counts.
 func (d *Diff) Empty() bool {
 	return len(d.Added) == 0 && len(d.Removed) == 0 &&
-		len(d.Renamed) == 0 && len(d.Restabilised) == 0
+		len(d.Renamed) == 0 && len(d.Restabilised) == 0 &&
+		len(d.Opened) == 0 && len(d.Closed) == 0
 }
 
 // missingFrom lists the components of have that base does not, skipping the
@@ -138,9 +170,70 @@ func missingFrom(kind config.Kind, base, have map[string]*Component, skip map[st
 		out = append(out, Ref{Kind: kind, Type: typ})
 	}
 
-	sort.Slice(out, func(a, b int) bool { return out[a].Type < out[b].Type })
+	sortRefs(out)
 
 	return out
+}
+
+// openIn lists the components of a kind whose own settings map is open.
+//
+// Only that top map counts. A free-form map further down -- a headers block, a
+// set of resource attributes -- is open because the keys under it are the
+// config author's to name, which is the schema describing the component
+// correctly rather than a gap in what it knows.
+func openIn(kind config.Kind, byType map[string]*Component) []Ref {
+	var out []Ref
+
+	for typ, comp := range byType {
+		if isOpen(comp) {
+			out = append(out, Ref{Kind: kind, Type: typ})
+		}
+	}
+
+	sortRefs(out)
+
+	return out
+}
+
+// opennessChanges lists the components a release stopped describing in full,
+// and the ones it went back to describing in full, among those both releases
+// carry.
+func opennessChanges(kind config.Kind, old, current map[string]*Component) ([]Ref, []Ref) {
+	var opened, closed []Ref
+
+	for typ, comp := range current {
+		was, ok := old[typ]
+		if !ok {
+			continue // an addition, already reported as one
+		}
+
+		ref := Ref{Kind: kind, Type: typ}
+
+		switch before, after := isOpen(was), isOpen(comp); {
+		case !before && after:
+			opened = append(opened, ref)
+		case before && !after:
+			closed = append(closed, ref)
+		}
+	}
+
+	sortRefs(opened)
+	sortRefs(closed)
+
+	return opened, closed
+}
+
+// isOpen reports whether a component accepts settings its schema does not
+// name. A component with no field schema at all is not open: nothing about it
+// was resolved, so there is no half-description to warn about, and the rules
+// that read settings skip it outright.
+func isOpen(comp *Component) bool { return comp.Fields != nil && comp.Fields.Open }
+
+// sortRefs orders a list of components by type, so a report reads the same way
+// every run. Every list in one diff is of a single kind, which is why the kind
+// does not enter the ordering.
+func sortRefs(refs []Ref) {
+	sort.Slice(refs, func(a, b int) bool { return refs[a].Type < refs[b].Type })
 }
 
 // renamesIn finds the component types that gained a new name in this release.
@@ -262,11 +355,20 @@ func (d *Diff) Markdown() string {
 	if d.From == "" {
 		fmt.Fprintf(&b, "### %s: new at `%s`\n\n%d components.\n",
 			d.Distribution, d.To, d.Total)
+		b.WriteString(d.coverage())
 
 		return b.String()
 	}
 
-	fmt.Fprintf(&b, "### %s: `%s` → `%s`\n\n%s\n", d.Distribution, d.From, d.To, d.headline())
+	if d.From == d.To {
+		// The same release, generated again: the difference is what the
+		// generator now says about it, not what upstream changed.
+		fmt.Fprintf(&b, "### %s: `%s` regenerated\n\n%s\n", d.Distribution, d.To, d.headline())
+	} else {
+		fmt.Fprintf(&b, "### %s: `%s` → `%s`\n\n%s\n", d.Distribution, d.From, d.To, d.headline())
+	}
+
+	b.WriteString(d.coverage())
 
 	writeList(&b, "Added", len(d.Added), func(i int) string { return refLine(d.Added[i]) })
 	writeList(&b, "Removed", len(d.Removed), func(i int) string { return refLine(d.Removed[i]) })
@@ -280,8 +382,29 @@ func (d *Diff) Markdown() string {
 
 		return fmt.Sprintf("%s `%s` (%s): %s → %s", c.Kind, c.Type, c.Signal, c.From, c.To)
 	})
+	writeList(&b, "Left open", len(d.Opened), func(i int) string { return refLine(d.Opened[i]) })
+	writeList(&b, "Described in full again", len(d.Closed), func(i int) string { return refLine(d.Closed[i]) })
 
 	return b.String()
+}
+
+// coverage is the paragraph saying how much of the release the schema does not
+// describe. It is kept out of the headline because it is not a change between
+// the two releases: it is a standing gap, which is why it is also written for
+// a distribution's first schema, and why a release with none says nothing.
+func (d *Diff) coverage() string {
+	if len(d.Open) == 0 {
+		return ""
+	}
+
+	if len(d.Open) == 1 {
+		return "\n1 of them is left open: its settings are not fully described, " +
+			"so `unknown-field` does not check it.\n"
+	}
+
+	return fmt.Sprintf(
+		"\n%d of them are left open: their settings are not fully described, "+
+			"so `unknown-field` does not check them.\n", len(d.Open))
 }
 
 // headline is the one line a reviewer reads when nothing below needs attention.
@@ -298,6 +421,8 @@ func (d *Diff) headline() string {
 		{len(d.Removed), "removed"},
 		{len(d.Renamed), "renamed"},
 		{len(d.Restabilised), "across the beta line"},
+		{len(d.Opened), "left open"},
+		{len(d.Closed), "described in full again"},
 	}
 
 	var parts []string

--- a/pkg/schema/diff_test.go
+++ b/pkg/schema/diff_test.go
@@ -228,3 +228,106 @@ func componentNames(n int) []string {
 
 	return out
 }
+
+// A component the generator could only half resolve is left open, which turns
+// unknown-field off for it. That is a gap rather than a mistake, but it is
+// silent in the schema, so the summary counts it.
+func TestDiffCountsTheComponentsLeftOpen(t *testing.T) {
+	t.Parallel()
+
+	next := release("v0.158.0", map[string]*schema.Component{
+		"hostmetrics": {Type: "hostmetrics", Fields: &schema.Field{Type: "map", Open: true}},
+		"otlp":        {Type: "otlp", Fields: &schema.Field{Type: "map"}},
+		"nofields":    {Type: "nofields"},
+	})
+
+	d := schema.DiffSchemas(nil, next)
+
+	assert.Equal(t, []schema.Ref{{Kind: config.KindReceiver, Type: "hostmetrics"}}, d.Open)
+
+	rendered := d.Markdown()
+	assert.Contains(t, rendered, "3 components.")
+	assert.Contains(t, rendered, "1 of them is left open")
+}
+
+// A free-form map inside a component -- headers, resource attributes -- is the
+// schema describing it correctly, not a gap, so it is not counted.
+func TestDiffDoesNotCountAnOpenMapInsideAComponent(t *testing.T) {
+	t.Parallel()
+
+	d := schema.DiffSchemas(nil, release("v0.158.0", map[string]*schema.Component{
+		"otlp": {Type: "otlp", Fields: &schema.Field{Type: "map", Children: map[string]*schema.Field{
+			"headers": {Type: "map", Open: true},
+		}}},
+	}))
+
+	assert.Empty(t, d.Open)
+	assert.NotContains(t, d.Markdown(), "left open")
+}
+
+// Regenerating a release with a changed generator moves components across the
+// line, which is what says how far a fix like #110 reaches.
+func TestDiffReportsComponentsThatChangedOpenness(t *testing.T) {
+	t.Parallel()
+
+	from := release("v0.157.0", map[string]*schema.Component{
+		"hostmetrics": {Type: "hostmetrics", Fields: &schema.Field{Type: "map"}},
+		"settled":     {Type: "settled", Fields: &schema.Field{Type: "map", Open: true}},
+		"steady":      {Type: "steady", Fields: &schema.Field{Type: "map", Open: true}},
+	})
+	next := release("v0.158.0", map[string]*schema.Component{
+		"hostmetrics": {Type: "hostmetrics", Fields: &schema.Field{Type: "map", Open: true}},
+		"settled":     {Type: "settled", Fields: &schema.Field{Type: "map"}},
+		"steady":      {Type: "steady", Fields: &schema.Field{Type: "map", Open: true}},
+		"arrived":     {Type: "arrived", Fields: &schema.Field{Type: "map", Open: true}},
+	})
+
+	d := schema.DiffSchemas(from, next)
+
+	assert.Equal(t, []schema.Ref{{Kind: config.KindReceiver, Type: "hostmetrics"}}, d.Opened)
+	assert.Equal(t, []schema.Ref{{Kind: config.KindReceiver, Type: "settled"}}, d.Closed)
+	assert.False(t, d.Empty())
+
+	rendered := d.Markdown()
+	assert.Contains(t, rendered, "1 added, 1 left open, 1 described in full again")
+	assert.Contains(t, rendered, "3 of them are left open")
+	assert.Contains(t, rendered, "**Left open**\n\n- receiver `hostmetrics`")
+	assert.Contains(t, rendered, "**Described in full again**\n\n- receiver `settled`")
+}
+
+// A component that arrives open is an addition, not something this release
+// stopped describing.
+func TestDiffDoesNotReportANewOpenComponentAsOpened(t *testing.T) {
+	t.Parallel()
+
+	d := schema.DiffSchemas(
+		release("v0.157.0", map[string]*schema.Component{}),
+		release("v0.158.0", map[string]*schema.Component{
+			"arrived": {Type: "arrived", Fields: &schema.Field{Type: "map", Open: true}},
+		}),
+	)
+
+	assert.Empty(t, d.Opened)
+	assert.Len(t, d.Open, 1)
+	assert.Equal(t, []schema.Ref{{Kind: config.KindReceiver, Type: "arrived"}}, d.Added)
+}
+
+// Regenerating a release the registry already holds compares it against
+// itself, so the heading says so rather than claiming an upgrade from a
+// version to the same version.
+func TestMarkdownNamesARegeneratedRelease(t *testing.T) {
+	t.Parallel()
+
+	before := release("v0.153.0", map[string]*schema.Component{
+		"hostmetrics": {Type: "hostmetrics", Fields: &schema.Field{Type: "map"}},
+	})
+	after := release("v0.153.0", map[string]*schema.Component{
+		"hostmetrics": {Type: "hostmetrics", Fields: &schema.Field{Type: "map", Open: true}},
+	})
+
+	rendered := schema.DiffSchemas(before, after).Markdown()
+
+	assert.Contains(t, rendered, "### contrib: `v0.153.0` regenerated")
+	assert.NotContains(t, rendered, "→ `v0.153.0`")
+	assert.Contains(t, rendered, "1 left open")
+}


### PR DESCRIPTION
Issue #111 is that the fix in #110 has not reached anyone: every schema the
registry serves was generated before it, so 26 of the 31 releases still report
`hostmetrics.scrapers` as a setting the receiver does not accept. The fix is to
regenerate those releases, which happens in the registry — the `schemas`
workflow there already generates a dispatched version whether or not it is
present. This PR is the two things that had to change here first, both about the
summary that makes such a run reviewable.

## The trade #110 made is silent

`open: true` turns `unknown-field` off for the whole component. That is the
right way round — a check that does not run beats one that is wrong — but a
typo in `root_path` now goes unreported along with the false positive, and
nothing said how far that had spread.

So `--summary` counts the components a release leaves open, and lists the ones
that changed side. The count stands on its own (it is written for a
distribution's first schema too, and omitted entirely when it is zero); the
lists are the diff, and are what says how far #110 actually reaches — the
number issue #111 calls the real scope of #108.

Only a component's own settings map counts. A free-form map further down — a
`headers` block, a set of resource attributes — is open because the keys under
it are the config author's to name, which is the schema being right rather than
a gap in it.

## A regenerated release was compared against the wrong file

`--summary` compared against the release *before* the one being generated. That
answers what upstream changed, which is the question for a new release, not for
one being generated again because the generator changed.

In a backfill it is worse than merely off-topic: releases are generated oldest
first, so by the time `v0.153.0` is summarised, the `v0.152.0` it would compare
against has already been rewritten by the same run — both carry the fix, and the
change being made appears nowhere at all.

A release the registry already holds is now compared against itself, and the
heading says so rather than claiming an upgrade from a version to the same
version.

## Verified

Against the registry's real published `contrib/v0.153.0`: it carries **0** open
components today, which is #111's claim that no published schema has the fix.
Marking `hostmetrics` open the way post-#110 schemagen would renders as

```
### contrib: `v0.153.0` regenerated

1 left open; 284 components in total.

1 of them is left open: its settings are not fully described, so
`unknown-field` does not check it.

**Left open**

- receiver `hostmetrics`
```

`go test ./...` passes; `make lint` is at the untouched-tree baseline (50
`goconst`, from the local golangci-lint being newer than the pinned one).

## Not in here

The regeneration itself. It is a dispatch of the `schemas` workflow in
`otelcol-config-schemas`, in batches oldest-first with `base` stacking one on
the last — `docs/schemas.md` gains a section saying so, since the weekly run
only ever looks forward and will not do this on its own. #111 stays open until
those releases are republished.

Also left alone: `docs/rules/unknown-field.md` said a half-resolved component
still has its resolved settings checked for unknown keys. It does not — `open`
is per map, so a misspelling of a resolved setting is let through too. Corrected
rather than expanded on.

Refs #111, #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
