### PR TITLE
fix(schemagen): a published schema closes a hand-read section only where it describes one

### DIFF
--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -261,9 +261,17 @@ receiver declares `Scrapers` as `mapstructure:"-"` and reads the `scrapers`
 section by hand, and the receiver creator holds its `receivers` the same way.
 The settings that were resolved are still recorded and still checked; the
 mapping is left open, because presenting half of a component's settings as all
-of them is what turns a coverage gap into a false positive. Upstream began
-publishing `config.schema.yaml` widely at v0.145.0 and it states these sections
-outright, so this is what the releases before it rest on.
+of them is what turns a coverage gap into a false positive.
+
+A published `config.schema.yaml` can close such a mapping again, but only where
+it describes the hand-read section. Upstream derives those files from the same
+mapstructure tags, so a section read by hand is missing from both: hostmetrics
+has published one since v0.145.0 that lists `root_path` and
+`metadata_collection_interval`, and says nothing of `scrapers` until v0.154.0.
+A published schema settles openness only where it names a key the sources never
+resolved, which is the evidence that it describes more than the tags do; one
+that adds nothing has not looked into that section either, and the mapping
+stays open.
 
 An open component is a check that does not run: `unknown-field` lets every
 setting through for it, a typo in one the generator *did* resolve included. That

--- a/pkg/cmd/schemagen/fields.go
+++ b/pkg/cmd/schemagen/fields.go
@@ -417,6 +417,44 @@ func attachFields(cat *schema.Schema, set *schemaSet) int {
 	return n
 }
 
+// settleOpenness decides whether the secondary closes a mapping the primary
+// left open.
+//
+// A published schema states a component's sections outright, the ones the Go
+// sources can only decode by hand included, so where it describes a section no
+// tag names it is the better answer about whether that mapping is closed. But
+// only where it does. Upstream derives these files from the same mapstructure
+// tags, so a component that reads a section by hand is missing it from both:
+// hostmetrics has published a schema since v0.145.0 that lists root_path and
+// metadata_collection_interval and says nothing of scrapers until v0.154.0.
+// Closing on that puts the false positive back, and puts it back for exactly
+// the releases people are still running.
+//
+// So a secondary settles openness only where it says something the primary did
+// not already know. A key the sources never resolved is the evidence that this
+// schema describes more than the tags do; one that lists only keys they did
+// resolve has not looked into the hand-read section either, and the open
+// mapping stands.
+func settleOpenness(primary, secondary *schema.Field) {
+	if secondary.Open {
+		primary.Open = true
+
+		return
+	}
+
+	if !primary.Open || len(secondary.Children) == 0 {
+		return
+	}
+
+	for name := range secondary.Children {
+		if _, known := primary.Children[name]; !known {
+			primary.Open = false
+
+			return
+		}
+	}
+}
+
 // enrich adds to a field schema without ever taking away from it. The primary
 // states the shape; the secondary contributes what it knows and nothing else,
 // because a key dropped here becomes a false report against a valid config.
@@ -433,14 +471,7 @@ func enrich(primary, secondary *schema.Field) {
 		primary.ExtensionRef = secondary.ExtensionRef
 	}
 
-	// Openness is the one thing the secondary settles rather than only adds to.
-	// A published schema states a component's sections outright, the ones the
-	// Go sources can only decode by hand included, so where it lists a
-	// mapping's keys it is the better answer about whether that mapping is
-	// closed. A secondary that lists none says nothing either way.
-	if secondary.Open || len(secondary.Children) > 0 {
-		primary.Open = secondary.Open
-	}
+	settleOpenness(primary, secondary)
 
 	for name, child := range secondary.Children {
 		if primary.Children == nil {

--- a/pkg/cmd/schemagen/schemagen_test.go
+++ b/pkg/cmd/schemagen/schemagen_test.go
@@ -396,6 +396,53 @@ replaces:
 	assert.NotContains(t, stdout, "open: true", "a fully described component was left open")
 }
 
+// Upstream derives the published schema from the same mapstructure tags, so a
+// component that reads a section by hand is missing it from both. hostmetrics
+// published one from v0.145.0 that says nothing of "scrapers" until v0.154.0,
+// and a schema that describes no more than the sources did cannot be what
+// closes the component: doing so puts the false positive back for every
+// release in between.
+func TestAPublishedSchemaThatAddsNothingDoesNotClose(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	confmap := module(t, root, "go.opentelemetry.io/collector/confmap", map[string]string{
+		"confmap.go": "package confmap\n\ntype Conf struct{}\n",
+	})
+	receiver := module(t, root, "example.com/collector/receiver/hostmetricsreceiver", map[string]string{
+		"metadata.yaml": "type: hostmetrics\nstatus:\n  class: receiver\n" +
+			"  stability:\n    beta: [metrics]\n",
+		// Every property here is one the sources already resolved.
+		"config.schema.yaml": "type: object\nproperties:\n" +
+			"  root_path:\n    description: the host's root directory\n    type: string\n",
+		"config.go": "package hostmetricsreceiver\n\n" +
+			"import \"go.opentelemetry.io/collector/confmap\"\n\n" +
+			"type Config struct {\n" +
+			"\tScrapers map[string]any `mapstructure:\"-\"`\n" +
+			"\tRootPath string `mapstructure:\"root_path\"`\n}\n\n" +
+			"func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error { return nil }\n",
+	})
+
+	path := filepath.Join(root, "manifest.yaml")
+	writeFile(t, path, fmt.Sprintf(`
+dist:
+  name: custom
+  otelcol_version: 0.153.0
+receivers:
+  - gomod: example.com/collector/receiver/hostmetricsreceiver v0.0.0
+replaces:
+  - example.com/collector/receiver/hostmetricsreceiver => %s
+  - go.opentelemetry.io/collector/confmap => %s
+`, receiver, confmap))
+
+	code, stdout, stderr := run(t, "--builder", path, "--cache", t.TempDir())
+
+	require.Equal(t, schemagen.ExitOK, code, "run failed: %s", stderr)
+	assert.Contains(t, stdout, "the host's root directory", "the published schema was not read")
+	assert.Contains(t, stdout, "open: true",
+		"a published schema describing no more than the sources closed a hand-read section")
+}
+
 // A setting that decodes into a component.ID names an extension, and that is
 // the only thing that says so: a storage id and a directory path are both
 // strings by the time they reach the schema. Marking it here is what lets


### PR DESCRIPTION
Regenerating the registry to publish #110 — the point of #111 — showed that
#110 does not reach the releases #111 is about. `hostmetrics` comes back
**closed over the same five settings**, and `scrapers` is still reported as a
setting it does not accept.

## What #110 missed

Upstream derives `config.schema.yaml` from the same mapstructure tags the Go
pass reads, so a section a component decodes by hand is missing from *both*
accounts of it. hostmetrics has published one **since v0.145.0**:

```yaml
# receiver/hostmetricsreceiver/config.schema.yaml @ v0.153.0
properties:
  metadata_collection_interval: {...}
  root_path: {...}
allOf:
  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
```

No `scrapers`. It appears at v0.154.0 and not before. So #110's rule — a
published schema that lists a mapping's keys settles whether it is closed —
reads that file, sees keys, and closes the component the Go pass had correctly
left open.

The boundary, checked against the sources at each tag:

| releases | published schema | `scrapers` in it | after #110 |
| --- | --- | --- | --- |
| ≤ v0.144.0 | none | — | open ✔ |
| v0.145.0 – v0.153.0 | yes | **no** | **closed ✘** |
| ≥ v0.154.0 | yes | yes | closed ✔ |

The middle row is the one #111 is about, and the one anyone is still running.
(#111 guessed upstream started publishing at v0.154.0; it started at v0.145.0
and only *added `scrapers`* at v0.154.0.)

## The rule

A secondary settles openness only where it says something the sources did not
already know. A key they never resolved is the evidence that this schema
describes more than the tags do — at v0.154.0 that key is `scrapers`, the
component closes, and current releases keep the full `unknown-field` check. A
schema that lists only keys they did resolve has not looked into the hand-read
section either, so the open mapping stands.

## Measured

Regenerating `contrib` v0.153.0 from the real upstream manifest, this branch
against `main`:

```
main:        0 components left open
this branch: 12
  receiver  cisco_os, ciscoos, gitlab, host_metrics, hostmetrics,
            libhoney, receiver_creator
  processor filter, geoip, transform
  exporter  file
  connector count
```

`hostmetrics` is `open: true` again. That list is what #111 asked for — the
real scope of #108 — and it says hostmetrics was not alone. #114's summary is
what reports the count on each regenerated release.

`TestAPublishedSchemaClosesWhatItDescribes` (the v0.154.0 shape) still passes
unchanged; the new `TestAPublishedSchemaThatAddsNothingDoesNotClose` is the
v0.145.0–v0.153.0 shape. `go test ./...` passes; `make lint` is at the
untouched-tree baseline (50 `goconst`).

`docs/schemas.md` said the published schemas "state these sections outright".
They do not, for this range — corrected.

## Next

The registry backfill for v0.145.0–v0.153.0 needs this merged first: generated
without it, those schemas still carry the false positive. Regeneration is a
separate PR in `otelcol-config-schemas`.

Refs #111, #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
